### PR TITLE
Wikireader: hot fixes, memory optimizations, anti-freeze UI...

### DIFF
--- a/builds/MicroPython/apps_unfrozen/wikireader.py
+++ b/builds/MicroPython/apps_unfrozen/wikireader.py
@@ -21,6 +21,7 @@ from picoware.system.buttons import (
     BUTTON_R,
     BUTTON_T,
     BUTTON_D,
+    BUTTON_0,
 )
 import _thread
 
@@ -1135,7 +1136,7 @@ class CustomArticleViewer:
 
         total_pages = max(1, (self.num_lines + self.visible_lines - 1) // self.visible_lines)
         current_page = (self.top_line // self.visible_lines) + 1
-        footer_text = f"Pg {current_page}/{total_pages} | S:Sz F:Fav D:Save T:ToC R:Rld"
+        footer_text = f"Pg {current_page}/{total_pages} | 0:Top S:Sz F:Fav D:Save T:ToC R:Rld"
         self.draw.text(Vector(5, footer_y + 4), footer_text, self.bg_color, 0)
 
         self.draw.swap()
@@ -1637,6 +1638,7 @@ def run_view_article(view_manager):
     global language_menu_origin_state, article_textbox, current_article_title, current_article_page_id
     if not article_textbox:
         return
+
     inp = view_manager.input_manager
     button = inp.button
 
@@ -1659,6 +1661,11 @@ def run_view_article(view_manager):
     elif button == BUTTON_BACK:
         inp.reset()
         change_state(view_manager, article_origin_state)
+    elif button == BUTTON_0:
+        inp.reset()
+        if article_textbox:
+            article_textbox.jump_to_line(0)
+            article_textbox.draw_viewer(current_article_title)
     elif button == BUTTON_S:
         article_textbox.cycle_font_size()
         article_textbox.draw_viewer(current_article_title)


### PR DESCRIPTION
Refactor: Massive RAM optimizations, anti-freeze UI, and graceful aborts

WikiReader Memory & Fragmentation Fixes:
- Replaced `struct.pack` in the word-wrapper with zero-allocation manual bitwise packing, preventing thousands of temporary string allocations.
- Drastically reduced `bytearray` allocation chunks from 200 lines to 10 lines (60 bytes) so they fit effortlessly into highly fragmented heaps.
- Removed the "Large" font size option to cap word-wrap line multiplication, preventing Out-Of-Memory crashes on incredibly long articles.
- Optimized Table of Contents generation by removing the `seen_p_idx` dictionary and bypassing expensive `.strip()` operations on non-heading paragraphs.
- Injected targeted `gc.collect()` sweeps directly into the chunking and parsing loops.

WikiReader UI & Responsiveness:
- Fixed synchronous blocking (app freeze) during massive offline article loading. The loading spinner now unconditionally animates every 150ms instead of waiting for percentage changes.
- Implemented graceful cancellation: Pressing `BACK` during the heavy file extraction or word-wrapping loops immediately aborts the process, drops the fragmented bytearrays, and returns to the menu safely.
- Added the "S:Sz" shortcut to the article viewer footer.