### PR TITLE
Fix simulator harness parity

### DIFF
--- a/simulator/hardware/http.py
+++ b/simulator/hardware/http.py
@@ -1,0 +1,90 @@
+"""Simulator shim for the native HTTP helper module."""
+
+_http = None
+_last_response = None
+_last_error = ""
+
+
+def _client():
+    global _http
+    if _http is None:
+        from picoware.system.http import HTTP
+
+        _http = HTTP()
+    return _http
+
+
+def _headers_from_text(headers):
+    if not headers:
+        return None
+    if isinstance(headers, dict):
+        return headers
+    out = {}
+    for line in str(headers).splitlines():
+        if ":" in line:
+            key, value = line.split(":", 1)
+            out[key.strip()] = value.strip()
+    return out or None
+
+
+def http_send_request(url, method="GET", headers=None, payload=None):
+    """Start a request and cache the response for http_get_http_response()."""
+    global _last_response, _last_error
+    try:
+        _last_response = _client().request(
+            str(method or "GET"),
+            str(url),
+            payload=payload,
+            headers=_headers_from_text(headers),
+        )
+        _last_error = ""
+        return True
+    except Exception as exc:
+        _last_response = None
+        _last_error = str(exc)
+        return False
+
+
+def http_file_download(url, destination_path):
+    """Download a URL to the simulated SD card."""
+    global _last_response, _last_error
+    try:
+        from picoware.system.storage import Storage
+
+        _last_response = _client().get(
+            str(url),
+            save_to_file=str(destination_path),
+            storage=Storage(),
+        )
+        _last_error = ""
+        return True
+    except Exception as exc:
+        _last_response = None
+        _last_error = str(exc)
+        return False
+
+
+def http_get_http_response(buffer=None, buffer_size=0):
+    """Return the cached response text.
+
+    The native helper copies into a caller-provided buffer. Python callers in
+    the simulator can use the returned string directly.
+    """
+    if _last_response is None:
+        return ""
+    text = getattr(_last_response, "text", "")
+    if buffer is not None:
+        data = str(text)[: int(buffer_size or len(str(text)))]
+        try:
+            buffer[: len(data)] = data
+        except Exception:
+            pass
+    return text
+
+
+def http_is_finished():
+    return True
+
+
+def http_last_error():
+    return _last_error

--- a/simulator/hardware/websocket.py
+++ b/simulator/hardware/websocket.py
@@ -1,0 +1,62 @@
+"""Simulator shim for the native websocket helper functions."""
+
+_websocket = None
+
+
+def http_websocket_start(url, port=0):
+    global _websocket
+    if _websocket is not None:
+        return False
+    try:
+        from picoware.system.websocket import WebSocketAsync
+
+        _websocket = WebSocketAsync(str(url))
+        return bool(_websocket.connect())
+    except Exception:
+        _websocket = None
+        return False
+
+
+def http_websocket_stop():
+    global _websocket
+    if _websocket is None:
+        return False
+    try:
+        _websocket.close()
+        return True
+    finally:
+        _websocket = None
+
+
+def http_websocket_send(message):
+    if _websocket is None:
+        return False
+    try:
+        return bool(_websocket.send(str(message)))
+    except Exception:
+        return False
+
+
+def http_websocket_is_connected():
+    if _websocket is None:
+        return False
+    try:
+        return bool(_websocket.is_connected)
+    except Exception:
+        return False
+
+
+def http_get_websocket_response(buffer=None, buffer_size=0):
+    if _websocket is None:
+        return False
+    value = _websocket.last_received
+    if value is None:
+        return False
+    text = str(value)
+    if buffer is not None:
+        data = text[: int(buffer_size or len(text))]
+        try:
+            buffer[: len(data)] = data
+        except Exception:
+            pass
+    return text

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -237,6 +237,72 @@ def _run_main():
     namespace["main"]()
 
 
+def _install_view_tracking():
+    """Report ViewManager transitions to the simulator harness."""
+    try:
+        import sim_runtime
+        from picoware.system.view_manager import ViewManager
+    except Exception:
+        return
+
+    if getattr(ViewManager, "_sim_view_tracking_installed", False):
+        return
+
+    def current_name(manager):
+        view = getattr(manager, "_current_view", None)
+        return getattr(view, "name", "")
+
+    def note(manager):
+        try:
+            name = current_name(manager)
+            if name != getattr(sim_runtime, "_current_view_name", ""):
+                sim_runtime.note_view(name)
+        except Exception:
+            pass
+
+    def note_name(name):
+        try:
+            if str(name or "") != getattr(sim_runtime, "_current_view_name", ""):
+                sim_runtime.note_view(name)
+        except Exception:
+            pass
+
+    original_set = ViewManager.set
+    original_switch_to = ViewManager.switch_to
+    original_back = ViewManager.back
+    original_remove = ViewManager.remove
+
+    def tracked_set(self, *args, **kwargs):
+        if args:
+            note_name(args[0])
+        result = original_set(self, *args, **kwargs)
+        note(self)
+        return result
+
+    def tracked_switch_to(self, *args, **kwargs):
+        if args:
+            note_name(args[0])
+        result = original_switch_to(self, *args, **kwargs)
+        note(self)
+        return result
+
+    def tracked_back(self, *args, **kwargs):
+        result = original_back(self, *args, **kwargs)
+        note(self)
+        return result
+
+    def tracked_remove(self, *args, **kwargs):
+        result = original_remove(self, *args, **kwargs)
+        note(self)
+        return result
+
+    ViewManager.set = tracked_set
+    ViewManager.switch_to = tracked_switch_to
+    ViewManager.back = tracked_back
+    ViewManager.remove = tracked_remove
+    ViewManager._sim_view_tracking_installed = True
+
+
 def _quote(path):
     """Shell-quote a path string."""
     return "'" + path.replace("'", "'\"'\"'") + "'"
@@ -572,6 +638,7 @@ def main():
     if opts["capabilities"]:
         sim_runtime.print_capabilities()
         return
+    _install_view_tracking()
     try:
         if opts["open"]:
             sim_runtime.request_open(opts["open"])


### PR DESCRIPTION
This PR updates the MicroPython simulator harness to better match current firmware behavior.

Changes
Adds simulator-only ViewManager transition tracking in simulator/run.py
Fixes --wait-view for built-in library views like Applications and loaded app views like app_Calculator
Adds top-level simulator shims for the newly built native helper modules:simulator/hardware/http.py
simulator/hardware/websocket.py

Why
Recent firmware commits added native http / websocket modules and exposed a simulator harness gap where --wait-view was not being updated for view transitions. This keeps simulator validation useful without changing firmware/system behavior.