### PR TITLE
Fix simulator VibesMP audio handoff

### DIFF
--- a/guides/Simulator.md
+++ b/guides/Simulator.md
@@ -8,7 +8,7 @@ display and input, while Picoware itself runs inside MicroPython.
 - Full Picoware UI with framebuffer and keyboard input
 - Scripted/viewer touch input for supported touch-board profiles
 - Real network access via host DNS/TCP/TLS (or `--network offline` for fixtures)
-- Audio playback for WAV/MP3 files and HTTP radio streams
+- Audio playback for WAV/MP3 files and HTTP MP3 radio streams
 - Simulated SD card at `simulator/sdcard` (auto-seeded on first run)
 - Headless mode for automated testing (`--headless`)
 
@@ -17,20 +17,20 @@ display and input, while Picoware itself runs inside MicroPython.
 ### macOS
 
 ```sh
-brew install micropython sdl2
+brew install micropython sdl2 ffmpeg
 ```
 
 ### Linux
 
 ```sh
 # Debian / Ubuntu
-sudo apt install micropython libsdl2-dev
+sudo apt install micropython libsdl2-dev ffmpeg
 
 # Fedora
-sudo dnf install micropython SDL2-devel
+sudo dnf install micropython SDL2-devel ffmpeg
 
 # Arch
-sudo pacman -S micropython sdl2
+sudo pacman -S micropython sdl2 ffmpeg
 ```
 
 ### Windows
@@ -86,6 +86,12 @@ micropython run.py --viewer --apps-source /path/to/apps
 
 # Run as a touch board
 micropython run.py --viewer --board waveshare-1.43-rp2350
+
+# Capture a screenshot at exit
+micropython run.py --headless --frames 120 --screenshot /tmp/picoware.bmp
+
+# Record simulator framebuffer frames
+micropython run.py --viewer --record /tmp/picoware.frames
 ```
 
 Useful board names include `picocalc-pico2w`, `waveshare-1.28-rp2350`,
@@ -124,6 +130,27 @@ battery 42
 controller. `battery N` sets the battery percentage reported by simulator board
 shims.
 
+`wait`, `sleep`, or `frames` in a script delays later queued input. This is useful
+when launching directly into an app and waiting for lazy imports or loading
+screens before sending keys.
+
+### Audio and radio
+
+The simulator has two native audio sidecars:
+
+- `audio-player`: local WAV/MP3 playback with seek/pause/resume support
+- `radio-player`: HTTP radio playback for VibesMP/web-radio testing
+
+Local MP3 playback is decoded by the simulator helper. HTTP radio playback is
+decoded by host `ffmpeg` into 44.1 kHz stereo PCM and then played through SDL
+with a callback ring buffer. Because of that, `ffmpeg` is a required host
+dependency for simulator web radio even though it is not needed on the Pico.
+
+Radio testing is meant to stay close to the device constraints: use plain
+`http://` MP3 streams when possible. AAC, HTTPS-heavy streams, ICY metadata, and
+recording features may work on desktop tools but are not treated as Pico 2W
+parity targets.
+
 ### Rebuilding
 
 Native binaries are built automatically on first use. To rebuild manually:
@@ -133,12 +160,19 @@ cd simulator
 
 ./build.sh --force    # rebuild all
 ./build.sh --clean    # remove binaries
+./build.sh --check    # report missing/stale binaries without rebuilding
 ./build.sh viewer     # rebuild only the viewer
+./build.sh audio      # rebuild local audio and radio helpers
+./build.sh audio-player
+./build.sh radio-player
+./build.sh jpeg
 ./build.sh gameboy    # rebuild only the Game Boy helper
 ```
 
 ## Notes
-- HTTP radio supports MP3 streams only.
+- VibesMP HTTP radio support is intended for MP3 streams only.
+- Simulator web radio requires host `ffmpeg`; if radio starts and immediately
+  stops, confirm `ffmpeg` is installed and visible in `PATH`.
 - GameBoy is playable when the native helper builds successfully.
 - Ghouls uses a deterministic simulator scene unless a native sidecar is added.
 - Bluetooth and USB are virtual simulator models; they do not attach to the

--- a/simulator/audio/sdl_radio_player.c
+++ b/simulator/audio/sdl_radio_player.c
@@ -3,12 +3,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define MINIMP3_IMPLEMENTATION
-#include "../../src/MicroPython/audio/minimp3/minimp3.h"
-
-#define INPUT_CAP (256 * 1024)
 #define READ_CHUNK 4096
+#define START_QUEUE_MS 500
 #define MAX_QUEUE_MS 1800
+#define RING_MS 3000
 
 typedef struct {
     int playing;
@@ -21,11 +19,70 @@ typedef struct {
     char error[128];
 } radio_state_t;
 
+typedef struct {
+    radio_state_t *state;
+    Uint8 *buf;
+    size_t cap;
+    size_t read_pos;
+    size_t write_pos;
+    size_t fill;
+} radio_audio_t;
+
+static size_t ring_space(const radio_audio_t *audio) {
+    return audio->cap > audio->fill ? audio->cap - audio->fill : 0;
+}
+
+static size_t ring_write(radio_audio_t *audio, const Uint8 *src, size_t len) {
+    size_t space = ring_space(audio);
+    if (len > space) len = space;
+    size_t first = len;
+    if (first > audio->cap - audio->write_pos) first = audio->cap - audio->write_pos;
+    memcpy(audio->buf + audio->write_pos, src, first);
+    if (len > first) memcpy(audio->buf, src + first, len - first);
+    audio->write_pos = (audio->write_pos + len) % audio->cap;
+    audio->fill += len;
+    return len;
+}
+
+static size_t ring_read(radio_audio_t *audio, Uint8 *dst, size_t len) {
+    if (len > audio->fill) len = audio->fill;
+    size_t first = len;
+    if (first > audio->cap - audio->read_pos) first = audio->cap - audio->read_pos;
+    memcpy(dst, audio->buf + audio->read_pos, first);
+    if (len > first) memcpy(dst + first, audio->buf, len - first);
+    audio->read_pos = (audio->read_pos + len) % audio->cap;
+    audio->fill -= len;
+    return len;
+}
+
+static void audio_cb(void *userdata, Uint8 *stream, int len) {
+    radio_audio_t *audio = (radio_audio_t *)userdata;
+    radio_state_t *st = audio->state;
+    memset(stream, 0, (size_t)len);
+    if (!st->playing || st->stop || !audio->buf || audio->fill == 0) {
+        return;
+    }
+    size_t got = ring_read(audio, stream, (size_t)len);
+    if (st->volume < 100) {
+        Sint16 *pcm = (Sint16 *)stream;
+        int samples = (int)(got / sizeof(Sint16));
+        for (int i = 0; i < samples; i++) {
+            pcm[i] = (Sint16)(((int)pcm[i] * st->volume) / 100);
+        }
+    }
+    st->position += (unsigned long long)(got / sizeof(Sint16));
+}
+
 static int file_exists(const char *path) {
     FILE *f = fopen(path, "rb");
     if (!f) return 0;
     fclose(f);
     return 1;
+}
+
+static int starts_with(const char *text, const char *prefix) {
+    size_t n = strlen(prefix);
+    return strncmp(text, prefix, n) == 0;
 }
 
 static char *shell_quote(const char *text) {
@@ -78,22 +135,21 @@ static int read_command(const char *path, char *buf, size_t buflen) {
     return n > 0;
 }
 
-static void apply_command(SDL_AudioDeviceID dev, radio_state_t *st, const char *cmd) {
+static void apply_command(SDL_AudioDeviceID dev, radio_state_t *st, radio_audio_t *audio, const char *cmd) {
     if (!cmd || !cmd[0]) return;
+    if (dev) SDL_LockAudioDevice(dev);
     if (strcmp(cmd, "stop") == 0) {
         st->stop = 1;
         st->playing = 0;
         strcpy(st->state, "stopped");
-        if (dev) SDL_ClearQueuedAudio(dev);
+        if (audio) audio->fill = 0;
     } else if (strcmp(cmd, "pause") == 0) {
         st->playing = 0;
         strcpy(st->state, "paused");
-        if (dev) SDL_PauseAudioDevice(dev, 1);
     } else if (strcmp(cmd, "resume") == 0) {
         if (!st->stop) {
             st->playing = 1;
             strcpy(st->state, "playing");
-            if (dev) SDL_PauseAudioDevice(dev, 0);
         }
     } else if (strncmp(cmd, "volume ", 7) == 0) {
         int vol = atoi(cmd + 7);
@@ -101,33 +157,28 @@ static void apply_command(SDL_AudioDeviceID dev, radio_state_t *st, const char *
         if (vol > 100) vol = 100;
         st->volume = vol;
     }
+    if (dev) SDL_UnlockAudioDevice(dev);
 }
 
-static void poll_command(SDL_AudioDeviceID dev, radio_state_t *st, const char *cmd_path) {
+static void poll_command(SDL_AudioDeviceID dev, radio_state_t *st, radio_audio_t *audio, const char *cmd_path) {
     char cmd[128] = "";
     if (file_exists(cmd_path) && read_command(cmd_path, cmd, sizeof(cmd))) {
-        apply_command(dev, st, cmd);
+        apply_command(dev, st, audio, cmd);
     }
 }
 
-static SDL_AudioDeviceID open_device(int hz, int channels) {
+static SDL_AudioDeviceID open_device(int hz, int channels, radio_audio_t *audio, int paused) {
     SDL_AudioSpec want;
     memset(&want, 0, sizeof(want));
     want.freq = hz;
     want.format = AUDIO_S16SYS;
     want.channels = (Uint8)channels;
     want.samples = 2048;
-    want.callback = NULL;
+    want.callback = audio_cb;
+    want.userdata = audio;
     SDL_AudioDeviceID dev = SDL_OpenAudioDevice(NULL, 0, &want, NULL, 0);
-    if (dev) SDL_PauseAudioDevice(dev, 0);
+    if (dev) SDL_PauseAudioDevice(dev, paused ? 1 : 0);
     return dev;
-}
-
-static void apply_volume(mp3d_sample_t *pcm, int count, int volume) {
-    if (volume >= 100) return;
-    for (int i = 0; i < count; i++) {
-        pcm[i] = (mp3d_sample_t)(((int)pcm[i] * volume) / 100);
-    }
 }
 
 int main(int argc, char **argv) {
@@ -163,9 +214,9 @@ int main(int argc, char **argv) {
         SDL_Quit();
         return 3;
     }
-    size_t cmd_len = strlen(quoted) + 128;
-    char *curl_cmd = (char *)malloc(cmd_len);
-    if (!curl_cmd) {
+    size_t cmd_len = strlen(quoted) + 256;
+    char *decode_cmd = (char *)malloc(cmd_len);
+    if (!decode_cmd) {
         free(quoted);
         strcpy(st.error, "out of memory");
         strcpy(st.state, "error");
@@ -173,102 +224,106 @@ int main(int argc, char **argv) {
         SDL_Quit();
         return 3;
     }
-    snprintf(curl_cmd, cmd_len, "curl -L --no-buffer --silent --show-error %s", quoted);
+    const char *reconnect_opts = (starts_with(url, "http://") || starts_with(url, "https://"))
+        ? "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 2 "
+        : "";
+    snprintf(
+        decode_cmd,
+        cmd_len,
+        "ffmpeg -hide_banner -nostdin -loglevel error %s"
+        "-i %s -vn -f s16le -acodec pcm_s16le -ar 44100 -ac 2 -",
+        reconnect_opts,
+        quoted
+    );
     free(quoted);
 
-    FILE *pipe = popen(curl_cmd, "r");
-    free(curl_cmd);
+    FILE *pipe = popen(decode_cmd, "r");
+    free(decode_cmd);
     if (!pipe) {
-        strcpy(st.error, "could not start curl");
+        strcpy(st.error, "could not start ffmpeg");
         strcpy(st.state, "error");
         write_status(status_path, &st);
         SDL_Quit();
         return 4;
     }
 
-    mp3dec_t dec;
-    mp3dec_init(&dec);
-    unsigned char *input = (unsigned char *)malloc(INPUT_CAP);
-    if (!input) {
-        strcpy(st.error, "input buffer alloc failed");
+    Uint32 bytes_per_ms = (Uint32)(st.sample_rate * st.channels * sizeof(Sint16) / 1000);
+    radio_audio_t audio;
+    memset(&audio, 0, sizeof(audio));
+    audio.state = &st;
+    audio.cap = (size_t)bytes_per_ms * RING_MS;
+    audio.buf = (Uint8 *)malloc(audio.cap);
+    if (!audio.buf) {
+        strcpy(st.error, "ring buffer alloc failed");
         strcpy(st.state, "error");
-        write_status(status_path, &st);
         pclose(pipe);
+        write_status(status_path, &st);
         SDL_Quit();
         return 5;
     }
-    size_t used = 0;
-    mp3d_sample_t pcm[MINIMP3_MAX_SAMPLES_PER_FRAME];
-    SDL_AudioDeviceID dev = 0;
+
+    SDL_AudioDeviceID dev = open_device(st.sample_rate, st.channels, &audio, 1);
+    if (!dev) {
+        snprintf(st.error, sizeof(st.error), "SDL_OpenAudioDevice: %s", SDL_GetError());
+        strcpy(st.state, "error");
+        free(audio.buf);
+        pclose(pipe);
+        write_status(status_path, &st);
+        SDL_Quit();
+        return 5;
+    }
+
+    int output_started = 0;
+    unsigned char input[READ_CHUNK];
     st.playing = 1;
-    strcpy(st.state, "startup_buffering");
+    strcpy(st.state, "buffering");
     write_status(status_path, &st);
 
     while (!st.stop) {
-        poll_command(dev, &st, cmd_path);
+        poll_command(dev, &st, &audio, cmd_path);
         if (st.stop) break;
 
-        if (dev && st.playing) {
-            Uint32 queued = SDL_GetQueuedAudioSize(dev);
-            Uint32 bytes_per_ms = (Uint32)(st.sample_rate * st.channels * sizeof(Sint16) / 1000);
-            if (bytes_per_ms && queued > bytes_per_ms * MAX_QUEUE_MS) {
-                write_status(status_path, &st);
-                SDL_Delay(25);
-                continue;
-            }
-        } else if (dev && !st.playing) {
+        SDL_LockAudioDevice(dev);
+        size_t buffered = audio.fill;
+        size_t space = ring_space(&audio);
+        SDL_UnlockAudioDevice(dev);
+
+        if (st.playing && bytes_per_ms && buffered > (size_t)bytes_per_ms * MAX_QUEUE_MS) {
+            write_status(status_path, &st);
+            SDL_Delay(20);
+            continue;
+        }
+        if (!st.playing) {
             write_status(status_path, &st);
             SDL_Delay(50);
             continue;
         }
-
-        if (used + READ_CHUNK > INPUT_CAP) {
-            size_t keep = used > 16384 ? 16384 : used;
-            memmove(input, input + used - keep, keep);
-            used = keep;
+        if (space < READ_CHUNK) {
+            write_status(status_path, &st);
+            SDL_Delay(10);
+            continue;
         }
 
-        size_t n = fread(input + used, 1, READ_CHUNK, pipe);
+        size_t n = fread(input, 1, READ_CHUNK, pipe);
         if (n == 0) {
             if (feof(pipe)) break;
             SDL_Delay(20);
             continue;
         }
-        used += n;
 
-        while (used > 0 && !st.stop) {
-            mp3dec_frame_info_t info;
-            memset(&info, 0, sizeof(info));
-            int samples = mp3dec_decode_frame(&dec, input, (int)used, pcm, &info);
-            if (info.frame_bytes == 0) break;
-            if (samples > 0 && info.hz > 0 && info.channels > 0) {
-                if (!dev) {
-                    st.sample_rate = info.hz;
-                    st.channels = info.channels;
-                    dev = open_device(st.sample_rate, st.channels);
-                    if (!dev) {
-                        snprintf(st.error, sizeof(st.error), "SDL_OpenAudioDevice: %s", SDL_GetError());
-                        strcpy(st.state, "error");
-                        st.playing = 0;
-                        st.stop = 1;
-                        break;
-                    }
-                    strcpy(st.state, "playing");
-                }
-                int total = samples * info.channels;
-                apply_volume(pcm, total, st.volume);
-                SDL_QueueAudio(dev, pcm, (Uint32)(total * sizeof(mp3d_sample_t)));
-                st.position += (unsigned long long)total;
+        SDL_LockAudioDevice(dev);
+        ring_write(&audio, input, n - (n % sizeof(Sint16)));
+        buffered = audio.fill;
+        SDL_UnlockAudioDevice(dev);
+
+        if (!output_started) {
+            if (bytes_per_ms && buffered >= (size_t)bytes_per_ms * START_QUEUE_MS) {
+                output_started = 1;
+                strcpy(st.state, "playing");
+                SDL_PauseAudioDevice(dev, 0);
             }
-            size_t consumed = (size_t)info.frame_bytes;
-            if (consumed >= used) {
-                used = 0;
-            } else {
-                memmove(input, input + consumed, used - consumed);
-                used -= consumed;
-            }
-            poll_command(dev, &st, cmd_path);
         }
+        poll_command(dev, &st, &audio, cmd_path);
         write_status(status_path, &st);
     }
 
@@ -276,15 +331,34 @@ int main(int argc, char **argv) {
     if (!st.error[0] && !st.stop) strcpy(st.state, "eof");
     write_status(status_path, &st);
     if (dev) {
-        while (!st.stop && SDL_GetQueuedAudioSize(dev) > 0) {
-            poll_command(dev, &st, cmd_path);
+        SDL_LockAudioDevice(dev);
+        size_t buffered = audio.fill;
+        SDL_UnlockAudioDevice(dev);
+        if (!output_started && buffered > 0) {
+            output_started = 1;
+            strcpy(st.state, "playing");
+            st.playing = 1;
+            SDL_PauseAudioDevice(dev, 0);
+        }
+        while (!st.stop) {
+            SDL_LockAudioDevice(dev);
+            buffered = audio.fill;
+            SDL_UnlockAudioDevice(dev);
+            if (!buffered) break;
+            poll_command(dev, &st, &audio, cmd_path);
             write_status(status_path, &st);
             SDL_Delay(50);
         }
+        st.playing = 0;
         SDL_CloseAudioDevice(dev);
     }
-    free(input);
-    pclose(pipe);
+    free(audio.buf);
+    int pipe_status = pclose(pipe);
+    if (!st.stop && !st.error[0] && st.position == 0) {
+        snprintf(st.error, sizeof(st.error), "ffmpeg produced no audio: %d", pipe_status);
+        strcpy(st.state, "error");
+        write_status(status_path, &st);
+    }
     SDL_Quit();
     return st.error[0] ? 6 : 0;
 }

--- a/simulator/build.sh
+++ b/simulator/build.sh
@@ -301,8 +301,7 @@ build_radio_player() {
         "radio-player" \
         "$sim_dir/audio/sdl_radio_player" \
         "sdl" \
-        "$sim_dir/audio/sdl_radio_player.c" \
-        "$root_dir"/src/MicroPython/audio/minimp3/*.h
+        "$sim_dir/audio/sdl_radio_player.c"
 }
 
 build_jpeg() {

--- a/simulator/hardware/audio.py
+++ b/simulator/hardware/audio.py
@@ -111,6 +111,8 @@ class Audio:
         self._player_status_file = ""
         self._player_status = {}
         self._player_active = False
+        self._player_proc = None
+        self._player_log = None
         self._paused = False
         self._radio_temp_path = ""
 
@@ -153,14 +155,76 @@ class Audio:
         if not self._player_cmd_file:
             return
         try:
+            for _ in range(20):
+                try:
+                    open(self._player_cmd_file, "r").close()
+                except OSError:
+                    break
+                time.sleep(0.01)
             with open(self._player_cmd_file, "w") as handle:
                 handle.write(str(command) + "\n")
         except OSError:
             pass
 
-    def _stop_player(self):
+    def _stop_player(self, wait=False):
         self._send_player_command("stop")
+        proc = self._player_proc
+        if proc:
+            try:
+                timeout = 0.3 if wait else 0.05
+                proc.wait(timeout=timeout)
+            except Exception:
+                try:
+                    proc.terminate()
+                except Exception:
+                    pass
+                try:
+                    proc.wait(timeout=0.2)
+                except Exception:
+                    try:
+                        proc.kill()
+                    except Exception:
+                        pass
+            self._player_proc = None
+        if self._player_log:
+            try:
+                self._player_log.close()
+            except Exception:
+                pass
+            self._player_log = None
         self._player_active = False
+
+    def _launch_player_process(self, binary, source, cmd_file, status_file, log_path):
+        try:
+            import subprocess
+
+            self._player_log = open(log_path, "ab")
+            self._player_proc = subprocess.Popen(
+                [binary, source, cmd_file, status_file],
+                stdout=self._player_log,
+                stderr=self._player_log,
+            )
+            return True
+        except ImportError:
+            try:
+                import os
+
+                cmd = (
+                    _quote(binary)
+                    + " "
+                    + _quote(source)
+                    + " "
+                    + _quote(cmd_file)
+                    + " "
+                    + _quote(status_file)
+                    + " >>"
+                    + _quote(log_path)
+                    + " 2>&1 &"
+                )
+                return os.system(cmd) == 0
+            except Exception as e:
+                print("[sim:audio] player launch failed:", e)
+                return False
 
     def _read_player_status(self):
         if not self._player_status_file:
@@ -212,7 +276,7 @@ class Audio:
             import sim_runtime
             import os
 
-            if sim_runtime.audio_mode != "real" or sim_runtime.headless:
+            if sim_runtime.audio_mode != "real" or (sim_runtime.headless and not sim_runtime.viewer):
                 return False
             if source.startswith("http://") or source.startswith("https://"):
                 return False
@@ -224,7 +288,7 @@ class Audio:
             binary = self._build_player()
             if not binary:
                 return False
-            self._stop_player()
+            self._stop_player(wait=True)
             cmd_file = sim_runtime.sd_root + "/sim_audio.cmd"
             status_file = sim_runtime.sd_root + "/sim_audio.status"
             for path in (cmd_file, status_file):
@@ -234,8 +298,8 @@ class Audio:
                     pass
             self._player_cmd_file = cmd_file
             self._player_status_file = status_file
-            cmd = _quote(binary) + " " + _quote(host_path) + " " + _quote(cmd_file) + " " + _quote(status_file) + " >/tmp/picoware-sim-audio.log 2>&1 &"
-            os.system(cmd)
+            if not self._launch_player_process(binary, host_path, cmd_file, status_file, "/tmp/picoware-sim-audio.log"):
+                return False
             self._player_active = True
             for _ in range(8):
                 time.sleep(0.05)
@@ -251,12 +315,12 @@ class Audio:
             import sim_runtime
             import os
 
-            if sim_runtime.audio_mode != "real" or sim_runtime.headless:
+            if sim_runtime.audio_mode != "real" or (sim_runtime.headless and not sim_runtime.viewer):
                 return False
             binary = self._build_radio_player()
             if not binary:
                 return False
-            self._stop_player()
+            self._stop_player(wait=True)
             cmd_file = sim_runtime.sd_root + "/sim_audio.cmd"
             status_file = sim_runtime.sd_root + "/sim_audio.status"
             for path in (cmd_file, status_file):
@@ -266,8 +330,8 @@ class Audio:
                     pass
             self._player_cmd_file = cmd_file
             self._player_status_file = status_file
-            cmd = _quote(binary) + " " + _quote(url) + " " + _quote(cmd_file) + " " + _quote(status_file) + " >/tmp/picoware-sim-radio.log 2>&1 &"
-            os.system(cmd)
+            if not self._launch_player_process(binary, url, cmd_file, status_file, "/tmp/picoware-sim-radio.log"):
+                return False
             self._player_active = True
             self._radio_state = "startup_buffering"
             for _ in range(12):
@@ -285,7 +349,7 @@ class Audio:
             import sim_runtime
             import os
 
-            if sim_runtime.audio_mode != "real" or sim_runtime.headless:
+            if sim_runtime.audio_mode != "real" or (sim_runtime.headless and not sim_runtime.viewer):
                 return ""
             temp = sim_runtime.sd_root + "/sim_radio_stream.mp3"
             try:

--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -803,8 +803,10 @@ def run_script_file(path):
             request_game(value)
             delay = max(delay, 180)
         elif command in ("wait", "sleep", "frames"):
-            # Queue-based script version. Timed waits pass through.
-            pass
+            try:
+                delay += int(value or "1")
+            except ValueError:
+                delay += 1
         else:
             raise ValueError("Unknown script command: " + command)
 


### PR DESCRIPTION
Fixes simulator-side VibesMP/audio behavior without including firmware audio-driver changes or the VibesMP app payload.

## What changed

- Keep owned `subprocess.Popen` handles for simulator audio helpers.
- Stop, terminate, and if needed kill the previous helper before starting a new MP3 or radio source.
- Allow real audio in viewer mode while still blocking real audio in true headless mode.
- Replace simulator radio helper MP3-frame decoding with host `ffmpeg` decoding to 44.1 kHz stereo PCM.
- Play radio PCM through an SDL callback ring buffer instead of `SDL_QueueAudio`.
- Add wait/frame delay handling for simulator script files.
- Update simulator docs for `ffmpeg`, audio/radio helper commands, screenshots, recording, and radio limitations.
- Add two simulator test tools:
  - `tools/vibesmp_audio_control_test.py`
  - `tools/vibesmp_bitrate_test.py`