### PR TITLE
simulator parity for recent board changes

### DIFF
--- a/simulator/hardware/flipper_battery.py
+++ b/simulator/hardware/flipper_battery.py
@@ -1,0 +1,15 @@
+def init():
+    return True
+
+
+def get_voltage_mv():
+    return 3300 + get_percentage() * 860 // 100
+
+
+def get_percentage():
+    try:
+        import sim_runtime
+
+        return sim_runtime.battery_percentage()
+    except Exception:
+        return 87

--- a/simulator/hardware/flipper_input.py
+++ b/simulator/hardware/flipper_input.py
@@ -1,0 +1,26 @@
+import picoware_keyboard
+
+
+def init():
+    return picoware_keyboard.init()
+
+
+def deinit():
+    return picoware_keyboard.deinit()
+
+
+def poll():
+    return picoware_keyboard.poll()
+
+
+def key_available():
+    return picoware_keyboard.key_available()
+
+
+def get_key():
+    return picoware_keyboard.get_key()
+
+
+def get_key_nonblocking():
+    key = picoware_keyboard.get_key_nonblocking()
+    return key if key else None

--- a/simulator/hardware/lcd.py
+++ b/simulator/hardware/lcd.py
@@ -26,6 +26,14 @@ class LCD:
     MODE_PSRAM = 1
 
     def __init__(self, scale_x=1.0, scale_y=1.0, scale_position=False):
+        try:
+            import picoware_boards
+
+            self.width, self.height = picoware_boards.get_current_display_size()
+            if self.width * self.height > 320 * 480:
+                self.width, self.height = 320, 320
+        except Exception:
+            self.width, self.height = 320, 320
         self._scale_x_factor = scale_x
         self._scale_y_factor = scale_y
         self.scale_position = scale_position

--- a/simulator/hardware/pancake_battery.py
+++ b/simulator/hardware/pancake_battery.py
@@ -1,0 +1,15 @@
+def init():
+    return True
+
+
+def get_voltage():
+    return 3.3 + get_percentage() * 0.9 / 100
+
+
+def get_percentage():
+    try:
+        import sim_runtime
+
+        return sim_runtime.battery_percentage()
+    except Exception:
+        return 87

--- a/simulator/hardware/picoware_boards.py
+++ b/simulator/hardware/picoware_boards.py
@@ -10,6 +10,39 @@ BOARD_CROWPANEL_10_1 = 8
 BOARD_CARDPUTER = 9
 BOARD_WAVESHARE_2_06 = 10
 BOARD_PANCAKE = 11
+BOARD_FLIPPER_ZERO = 12
+
+_BOARD_NAMES = (
+    "PicoCalc - Pico",
+    "PicoCalc - Pico W",
+    "PicoCalc - Pico 2",
+    "PicoCalc - Pico 2 W",
+    "Waveshare 1.28",
+    "Waveshare 1.43",
+    "Waveshare 3.49",
+    "PicoCalc - Pimoroni 2 W",
+    "CrowPanel 10.1",
+    "Cardputer",
+    "Waveshare 2.06",
+    "Pancake",
+    "Flipper Zero",
+)
+
+_DISPLAY_SIZES = (
+    (320, 320),
+    (320, 320),
+    (320, 320),
+    (320, 320),
+    (240, 240),
+    (466, 466),
+    (172, 640),
+    (320, 320),
+    (1024, 600),
+    (240, 135),
+    (410, 502),
+    (320, 480),
+    (128, 64),
+)
 
 try:
     import sim_runtime
@@ -39,31 +72,119 @@ elif _name in ("waveshare-2.06-esp32s3", "waveshare-2-06-esp32s3", "waveshare-20
     BOARD_ID = BOARD_WAVESHARE_2_06
 elif _name == "pancake":
     BOARD_ID = BOARD_PANCAKE
+elif _name in ("flipper-zero", "flipper"):
+    BOARD_ID = BOARD_FLIPPER_ZERO
 else:
     BOARD_ID = BOARD_PICOCALC_PICO_2W
 
 BOARD_HAS_PSRAM = 1 if BOARD_ID in (BOARD_PICOCALC_PICO_2, BOARD_PICOCALC_PICO_2W, BOARD_PICOCALC_PIMORONI_2W) else 0
-BOARD_HAS_SD = 1
+BOARD_HAS_SD = 0 if BOARD_ID in (BOARD_WAVESHARE_1_28_RP2350, BOARD_CROWPANEL_10_1) else 1
 BOARD_HAS_TOUCH = 1 if BOARD_ID in (BOARD_WAVESHARE_1_28_RP2350, BOARD_WAVESHARE_1_43_RP2350, BOARD_WAVESHARE_3_49_RP2350, BOARD_CROWPANEL_10_1, BOARD_WAVESHARE_2_06, BOARD_PANCAKE) else 0
-BOARD_HAS_WIFI = 1 if BOARD_ID in (BOARD_PICOCALC_PICOW, BOARD_PICOCALC_PICO_2W, BOARD_WAVESHARE_2_06, BOARD_PANCAKE) else 0
-BOARD_HAS_AUDIO = 0 if BOARD_ID in (BOARD_WAVESHARE_2_06, BOARD_PANCAKE) else 1
+BOARD_HAS_WIFI = 1 if BOARD_ID in (BOARD_PICOCALC_PICOW, BOARD_PICOCALC_PICO_2W, BOARD_PICOCALC_PIMORONI_2W, BOARD_CARDPUTER, BOARD_WAVESHARE_2_06, BOARD_PANCAKE) else 0
+BOARD_HAS_AUDIO = 1 if BOARD_ID in (BOARD_PICOCALC_PICO, BOARD_PICOCALC_PICOW, BOARD_PICOCALC_PICO_2, BOARD_PICOCALC_PICO_2W, BOARD_PICOCALC_PIMORONI_2W) else 0
+BOARD_HAS_RP2040 = 1 if BOARD_ID in (BOARD_PICOCALC_PICO, BOARD_PICOCALC_PICOW) else 0
+BOARD_HAS_RP2350 = 1 if BOARD_ID in (BOARD_PICOCALC_PICO_2, BOARD_PICOCALC_PICO_2W, BOARD_WAVESHARE_1_28_RP2350, BOARD_WAVESHARE_1_43_RP2350, BOARD_WAVESHARE_3_49_RP2350, BOARD_PICOCALC_PIMORONI_2W) else 0
+BOARD_HAS_ESP32 = 1 if BOARD_ID in (BOARD_CROWPANEL_10_1, BOARD_CARDPUTER, BOARD_WAVESHARE_2_06, BOARD_PANCAKE) else 0
+
+
+def _valid_board_id(board_id):
+    return 0 <= int(board_id) < len(_BOARD_NAMES)
 
 
 def get_device_name():
     """Return the human-readable device name."""
-    return "Simulator"
+    if BOARD_ID == BOARD_FLIPPER_ZERO:
+        return "Flipper Zero STM32WB55RG"
+    if BOARD_ID == BOARD_CROWPANEL_10_1:
+        return "CrowPanel 10.1 ESP32-P4"
+    if BOARD_ID == BOARD_PANCAKE:
+        return "ESP32-C5"
+    if BOARD_ID in (BOARD_CARDPUTER, BOARD_WAVESHARE_2_06):
+        return "ESP32-S3"
+    if BOARD_ID == BOARD_PICOCALC_PIMORONI_2W:
+        return "Pimoroni Pico Plus 2 W"
+    if BOARD_ID in (BOARD_PICOCALC_PICOW, BOARD_PICOCALC_PICO_2W):
+        return "Raspberry Pi Pico W" if BOARD_HAS_RP2040 else "Raspberry Pi Pico 2 W"
+    return "Raspberry Pi Pico" if BOARD_HAS_RP2040 else "Raspberry Pi Pico 2"
 
 
 def get_current_name():
     """Return the full simulator device name."""
-    return "Simulator"
+    return get_name(BOARD_ID)
+
+
+def get_name(board_id):
+    """Return the firmware board name for *board_id*."""
+    return _BOARD_NAMES[int(board_id)] if _valid_board_id(board_id) else "Unknown Board"
+
+
+def get_display_size(board_id):
+    """Return the native display size for *board_id*."""
+    return _DISPLAY_SIZES[int(board_id)] if _valid_board_id(board_id) else (0, 0)
+
+
+def get_current_display_size():
+    """Return the native display size for the selected simulator board."""
+    return get_display_size(BOARD_ID)
 
 
 def is_circular(board_id):
     """Return True if the board has a circular display."""
-    return False
+    return int(board_id) in (
+        BOARD_WAVESHARE_1_28_RP2350,
+        BOARD_WAVESHARE_1_43_RP2350,
+        BOARD_WAVESHARE_2_06,
+    )
 
 
 def has_psram(board_id=None):
     """Return True if the board has PSRAM."""
-    return BOARD_HAS_PSRAM == 1
+    selected = BOARD_ID if board_id is None else int(board_id)
+    return selected in (
+        BOARD_PICOCALC_PICO_2,
+        BOARD_PICOCALC_PICO_2W,
+        BOARD_PICOCALC_PIMORONI_2W,
+    )
+
+
+def has_sd_card(board_id):
+    """Return True if *board_id* has SD storage."""
+    return int(board_id) not in (
+        BOARD_WAVESHARE_1_28_RP2350,
+        BOARD_CROWPANEL_10_1,
+    )
+
+
+def has_touch(board_id):
+    """Return True if *board_id* has touch input."""
+    return int(board_id) in (
+        BOARD_WAVESHARE_1_28_RP2350,
+        BOARD_WAVESHARE_1_43_RP2350,
+        BOARD_WAVESHARE_3_49_RP2350,
+        BOARD_CROWPANEL_10_1,
+        BOARD_WAVESHARE_2_06,
+        BOARD_PANCAKE,
+    )
+
+
+def has_wifi(board_id):
+    """Return True if *board_id* has Wi-Fi."""
+    return int(board_id) in (
+        BOARD_PICOCALC_PICOW,
+        BOARD_PICOCALC_PICO_2W,
+        BOARD_PICOCALC_PIMORONI_2W,
+        BOARD_CARDPUTER,
+        BOARD_WAVESHARE_2_06,
+        BOARD_PANCAKE,
+    )
+
+
+def has_audio(board_id):
+    """Return True if *board_id* has audio support."""
+    return int(board_id) in (
+        BOARD_PICOCALC_PICO,
+        BOARD_PICOCALC_PICOW,
+        BOARD_PICOCALC_PICO_2,
+        BOARD_PICOCALC_PICO_2W,
+        BOARD_PICOCALC_PIMORONI_2W,
+    )

--- a/simulator/hardware/sd_mp.py
+++ b/simulator/hardware/sd_mp.py
@@ -48,6 +48,16 @@ def init():
     global _initialized
     _initialized = True
     sim_runtime.mkdir_p(sim_runtime.sd_root)
+    try:
+        import picoware_boards
+        import vfs_mp
+
+        if picoware_boards.BOARD_HAS_ESP32 == 1:
+            vfs_mp.mount("/sdcard")
+        elif picoware_boards.BOARD_ID == picoware_boards.BOARD_FLIPPER_ZERO:
+            vfs_mp.mount("/sd")
+    except Exception:
+        pass
     return True
 
 

--- a/simulator/hardware/touch.py
+++ b/simulator/hardware/touch.py
@@ -6,13 +6,60 @@ class Touch:
     def read(self):
         try:
             import sim_runtime
-
-            point = sim_runtime.touch_point()
-        except Exception:
+        except ImportError:
             point = (0, 0)
+        else:
+            sim_runtime.loop_polled()
+            point = sim_runtime.touch_point()
+            if point == (0, 0) and sim_runtime.has_key():
+                point = self._point_for_key(sim_runtime.pop_key())
+                if point != (0, 0):
+                    # Firmware touch input is debounced against wall-clock time.
+                    # Give an injected key enough separation to be accepted.
+                    import time
+
+                    time.sleep_ms(121)
         self.x = int(point[0])
         self.y = int(point[1])
         return point != (0, 0)
+
+    def _point_for_key(self, key):
+        """Translate scripted directional keys into board touch zones."""
+        import sim_runtime
+
+        name = str(sim_runtime.board).lower().replace("_", "-")
+        if name == "pancake":
+            points = {
+                0xB5: (160, 48),
+                0xB6: (160, 432),
+                0xB4: (20, 240),
+                0xB7: (300, 240),
+                0xB1: (32, 32),
+                13: (160, 240),
+            }
+        elif name in (
+            "waveshare-2.06",
+            "waveshare-2.06-esp32s3",
+            "waveshare-2-06-esp32s3",
+        ):
+            points = {
+                0xB5: (205, 60),
+                0xB6: (205, 442),
+                0xB4: (25, 251),
+                0xB7: (360, 251),
+                0xB1: (360, 442),
+                13: (205, 251),
+            }
+        else:
+            points = {
+                0xB5: (512, 60),
+                0xB6: (512, 540),
+                0xB4: (62, 300),
+                0xB7: (962, 300),
+                0xB1: (512, 300),
+                13: (512, 300),
+            }
+        return points.get(int(key), (0, 0))
 
     def reset(self):
         try:

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -26,11 +26,39 @@ ROOT = _dirname(THIS_DIR)
 HARDWARE_DIR = THIS_DIR + "/hardware"
 MICROPYTHON_DIR = ROOT + "/src/MicroPython"
 
+_BOARD_DISPLAY_SIZES = {
+    "picocalc-pico": (320, 320),
+    "picocalc-picow": (320, 320),
+    "picocalc-pico2": (320, 320),
+    "picocalc-pico2w": (320, 320),
+    "picocalc-pimoroni-2w": (320, 320),
+    "pimoroni-2w": (320, 320),
+    "waveshare-1.28-rp2350": (240, 240),
+    "waveshare-1.43-rp2350": (466, 466),
+    "waveshare-3.49-rp2350": (172, 640),
+    "crowpanel-10.1": (1024, 600),
+    "crowpanel": (1024, 600),
+    "cardputer": (240, 135),
+    "waveshare-2.06": (410, 502),
+    "waveshare-2.06-esp32s3": (410, 502),
+    "pancake": (320, 480),
+    "flipper-zero": (128, 64),
+    "flipper": (128, 64),
+}
+
 
 def _insert_path(path):
     """Insert a directory into sys.path if not present."""
     if path not in sys.path:
         sys.path.insert(0, path)
+
+
+def _simulator_display_size(board_name):
+    """Return a framebuffer size that fits the default Unix MicroPython heap."""
+    width, height = _BOARD_DISPLAY_SIZES.get(board_name, (320, 320))
+    if width * height > 320 * 480:
+        return 320, 320
+    return width, height
 
 
 def _parse_args(argv):
@@ -234,7 +262,8 @@ def _run_main():
     with open(MICROPYTHON_DIR + "/main.py", "r") as handle:
         code = handle.read()
     exec(code, namespace)
-    namespace["main"]()
+    if namespace["main"]() is False:
+        raise RuntimeError("Picoware main reported a fatal error")
 
 
 def _install_view_tracking():
@@ -421,6 +450,8 @@ def _run_coverage(opts):
             + _quote(opts["apps_source"])
             + (" --app " if kind == "app" else " --game ")
             + _quote(name)
+            + " --wait-view "
+            + _quote(("app_" if kind == "app" else "game_") + name)
             + " >"
             + _quote(log_path)
             + " 2>&1"
@@ -433,6 +464,8 @@ def _run_coverage(opts):
             rows.append((kind, name, "fail", "child run exited " + str(status), log_path))
             print("[coverage:fail]", kind, name, status)
     _write_coverage_report(report_dir + "/coverage-" + mode + ".json", mode, rows)
+    if any(row[2] == "fail" for row in rows):
+        raise SystemExit(1)
 
 
 def _build_native(target, check=False):
@@ -452,13 +485,13 @@ def _run_sim_check(opts):
         + " --check",
         "micropython "
         + _quote(THIS_DIR + "/run.py")
-        + " --headless --frames 30 --audio silent --network offline --sd "
+        + " --headless --frames 30 --wait-view desktop_view --audio silent --network offline --sd "
         + _quote(opts["sd"])
         + " --apps-source "
         + _quote(opts["apps_source"]),
         "micropython "
         + _quote(THIS_DIR + "/run.py")
-        + " --headless --app Calculator --frames 120 --audio silent --network offline --sd "
+        + " --headless --app Calculator --wait-view app_Calculator --frames 160 --audio silent --network offline --sd "
         + _quote(opts["sd"])
         + " --apps-source "
         + _quote(opts["apps_source"]),
@@ -474,12 +507,24 @@ def _run_sim_check(opts):
         + _quote(opts["sd"])
         + " --apps-source "
         + _quote(opts["apps_source"]),
+        "micropython "
+        + _quote(THIS_DIR + "/run.py")
+        + " --headless --board pancake --app keyboard-simple --frames 40 --wait-view app_keyboard-simple --audio silent --network offline --sd "
+        + _quote(opts["sd"])
+        + " --apps-source "
+        + _quote(opts["apps_source"]),
+        "micropython "
+        + _quote(THIS_DIR + "/run.py")
+        + " --headless --board flipper-zero --app Calculator --frames 40 --wait-view app_Calculator --audio silent --network offline --sd "
+        + _quote(opts["sd"])
+        + " --apps-source "
+        + _quote(opts["apps_source"]),
     )
     for cmd in commands:
         status = os.system(cmd)
         if status != 0:
             print("[sim-check:fail]", cmd, status)
-            raise SystemExit
+            raise SystemExit(1)
     _run_mjs_check()
     print("[sim-check:pass]")
 
@@ -605,7 +650,22 @@ def _start_viewer(opts):
     except OSError:
         pass
 
-    cmd = _quote(binary) + " " + _quote(frame) + " " + _quote(keys) + " " + str(opts["scale"]) + " >/tmp/picoware-sim-viewer.log 2>&1 &"
+    board_name = str(opts["board"]).lower().replace("_", "-")
+    width, height = _simulator_display_size(board_name)
+    cmd = (
+        _quote(binary)
+        + " "
+        + _quote(frame)
+        + " "
+        + _quote(keys)
+        + " "
+        + str(opts["scale"])
+        + " "
+        + str(width)
+        + " "
+        + str(height)
+        + " >/tmp/picoware-sim-viewer.log 2>&1 &"
+    )
     os.system(cmd)
     return frame, keys
 

--- a/simulator/viewer/sdl_fb_viewer.c
+++ b/simulator/viewer/sdl_fb_viewer.c
@@ -4,9 +4,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define FB_WIDTH 320
-#define FB_HEIGHT 320
+#define FB_WIDTH g_fb_width
+#define FB_HEIGHT g_fb_height
 #define FB_BYTES (FB_WIDTH * FB_HEIGHT * 2)
+
+static int g_fb_width = 320;
+static int g_fb_height = 320;
 
 static int map_key(SDL_Keycode key)
 {
@@ -370,7 +373,7 @@ int main(int argc, char **argv)
 {
     if (argc < 3)
     {
-        fprintf(stderr, "usage: %s FRAME_FILE INPUT_FILE [SCALE]\n", argv[0]);
+        fprintf(stderr, "usage: %s FRAME_FILE INPUT_FILE [SCALE] [WIDTH] [HEIGHT]\n", argv[0]);
         return 2;
     }
 
@@ -391,6 +394,16 @@ int main(int argc, char **argv)
     int scale = argc >= 4 ? atoi(argv[3]) : 2;
     if (scale < 1)
         scale = 1;
+    if (argc >= 6)
+    {
+        int width = atoi(argv[4]);
+        int height = atoi(argv[5]);
+        if (width > 0 && height > 0)
+        {
+            g_fb_width = width;
+            g_fb_height = height;
+        }
+    }
 
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) != 0)
     {

--- a/src/MicroPython/main.py
+++ b/src/MicroPython/main.py
@@ -38,12 +38,14 @@ def main():
                 vm.alert(f"Critical Error:\n{e}\nPlease restart.")
             except Exception:
                 pass
+        return False
     finally:
         del vm
         vm = None
         # Final cleanup
         collect()
         threshold(mem_free() // 4 + mem_alloc())
+    return True
 
 
 # run the main function

--- a/src/MicroPython/picoware/gui/keyboard.py
+++ b/src/MicroPython/picoware/gui/keyboard.py
@@ -537,6 +537,8 @@ class Keyboard:
     @micropython.native
     def _size_keys_to_screen(self) -> None:
         """Fit the key grid to the panel."""
+        minimum_key_width = self.KEY_WIDTH
+        minimum_key_height = self.KEY_HEIGHT
         widest_row = 0
         for row in range(self.NUM_ROWS):
             units = 0
@@ -555,8 +557,8 @@ class Keyboard:
         )
         key_height = min(usable_y // self.NUM_ROWS - self.KEY_SPACING, key_width)
 
-        self.KEY_WIDTH = max(key_width, Keyboard.KEY_WIDTH)
-        self.KEY_HEIGHT = max(key_height, Keyboard.KEY_HEIGHT)
+        self.KEY_WIDTH = max(key_width, minimum_key_width)
+        self.KEY_HEIGHT = max(key_height, minimum_key_height)
 
     @micropython.native
     def _key_row_geometry(self, row: int) -> tuple:

--- a/src/MicroPython/picoware/system/storage.py
+++ b/src/MicroPython/picoware/system/storage.py
@@ -305,7 +305,7 @@ class Storage:
             self._vfs_mounted = True
             return True
 
-        if BOARD_FLIPPER_ZERO:
+        if BOARD_ID == BOARD_FLIPPER_ZERO:
             result = self.mount()
             if result:
                 self._vfs_mounted = True
@@ -350,7 +350,7 @@ class Storage:
         if not self._vfs_mounted or BOARD_HAS_ESP32 == 1:
             return True
 
-        if BOARD_FLIPPER_ZERO:
+        if BOARD_ID == BOARD_FLIPPER_ZERO:
             self.unmount()
             self._vfs_mounted = False
             return True


### PR DESCRIPTION
Add missing Flipper Zero and board-family constants to the simulator board shim.
- Synchronize board names, capabilities, and display sizes with current firmware.
- Add simulated Flipper input/battery and Pancake battery modules.
- Correct the Flipper storage checks to compare `BOARD_ID` instead of treating the board constant as a boolean.
- Mount the appropriate simulated VFS paths for ESP32 and Flipper profiles.
- Support scripted directional input on touch-only boards.
- Fix dynamic on-screen keyboard sizing on touch displays.
- Add board-aware framebuffer dimensions to the SDL viewer.
- Fall back to the established 320×320 canvas for panels that exceed the default Unix MicroPython heap.
- Make simulator startup failures, unmet view assertions, and coverage failures return a nonzero exit status.
- Extend `--sim-check` with Pancake keyboard and Flipper application-launch coverage.

## Problems fixed

Before this change, current `dev` could not boot in the simulator because the board shim lacked newly required constants. Additional issues included:

- all non-ESP32 boards taking the Flipper storage path;
- Pancake scripted navigation stalling in touch input;
- touch keyboard sizing referencing removed class attributes;
- oversized panel framebuffers exhausting the simulator heap;
- simulator failures being printed while the command still exited successfully.