### PR TITLE
Add Pico Bomber arcade game

### DIFF
--- a/builds/MicroPython/apps_unfrozen/games/Pico Bomber.py
+++ b/builds/MicroPython/apps_unfrozen/games/Pico Bomber.py
@@ -1,0 +1,5 @@
+"""Picoware launcher for Pico Bomber."""
+
+from pico_bomber import run, start, stop
+
+__all__ = ("start", "run", "stop")

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/__init__.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/__init__.py
@@ -1,0 +1,5 @@
+"""Pico Bomber package entry points."""
+
+from .app import run, start, stop
+
+__all__ = ("start", "run", "stop")

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -1,0 +1,136 @@
+"""Picoware lifecycle adapter for Pico Bomber."""
+
+from gc import collect
+from utime import ticks_add, ticks_diff, ticks_ms
+
+from picoware.system.buttons import (
+    BUTTON_BACK,
+    BUTTON_CENTER,
+    BUTTON_DOWN,
+    BUTTON_LEFT,
+    BUTTON_RIGHT,
+    BUTTON_SPACE,
+    BUTTON_UP,
+)
+
+from .leaderboard import Leaderboard
+from .model import (
+    MENU_LEADERBOARD,
+    STATE_GAME_OVER,
+    STATE_LEADERBOARD,
+    STATE_MODE_SELECT,
+    STATE_PLAYER_DYING,
+    STATE_PLAYING,
+    STATE_TITLE,
+    GameModel,
+)
+from .render import Renderer
+
+
+_game = None
+_renderer = None
+_leaderboard = None
+_next_frame = 0
+_score_saved = False
+FRAME_MS = 50
+GAME_CPU_FREQUENCY = 230000000
+
+
+def start(view_manager):
+    """Create a fresh Pico Bomber title screen."""
+    global _game, _renderer, _leaderboard, _next_frame, _score_saved
+
+    view_manager.freq(False, GAME_CPU_FREQUENCY)
+    _game = GameModel()
+    _renderer = Renderer(view_manager.draw)
+    _leaderboard = Leaderboard(view_manager.storage)
+    _game.leaderboard = _leaderboard.entries
+    _score_saved = False
+    _next_frame = ticks_ms()
+    _renderer.draw_frame(_game)
+    return True
+
+
+def run(view_manager):
+    """Handle one Picoware input/update/render cycle."""
+    global _next_frame, _score_saved
+
+    if _game is None or _renderer is None:
+        return
+
+    input_manager = view_manager.input_manager
+    button = input_manager.button
+    now = ticks_ms()
+    changed = False
+
+    if button == BUTTON_BACK:
+        input_manager.reset()
+        if _game.state == STATE_LEADERBOARD:
+            _game.open_mode_menu()
+            changed = True
+        elif _game.state == STATE_MODE_SELECT:
+            _game.state = STATE_TITLE
+            changed = True
+        else:
+            view_manager.back()
+            return
+    if button == BUTTON_UP:
+        if _game.state == STATE_MODE_SELECT:
+            changed = _game.select_mode(-1)
+        else:
+            changed = _game.move_player(0, -1, now)
+    elif button == BUTTON_DOWN:
+        if _game.state == STATE_MODE_SELECT:
+            changed = _game.select_mode(1)
+        else:
+            changed = _game.move_player(0, 1, now)
+    elif button == BUTTON_LEFT:
+        changed = _game.move_player(-1, 0, now)
+    elif button == BUTTON_RIGHT:
+        changed = _game.move_player(1, 0, now)
+    elif button in (BUTTON_CENTER, BUTTON_SPACE):
+        if _game.state in (STATE_TITLE, STATE_GAME_OVER):
+            _game.open_mode_menu()
+            changed = True
+        elif _game.state == STATE_LEADERBOARD:
+            _game.open_mode_menu()
+            changed = True
+        elif _game.state == STATE_MODE_SELECT:
+            if _game.menu_selection == MENU_LEADERBOARD:
+                _game.state = STATE_LEADERBOARD
+            else:
+                _game.new_game(now, _game.menu_selection)
+                _score_saved = False
+            changed = True
+        else:
+            changed = _game.place_bomb(now)
+
+    if button >= 0:
+        input_manager.reset()
+
+    if _game.update(now):
+        changed = True
+
+    if _game.state == STATE_GAME_OVER and not _score_saved:
+        _leaderboard.submit(_game.score, _game.stage, _game.mode)
+        _game.leaderboard = _leaderboard.entries
+        _score_saved = True
+        changed = True
+
+    animated = _game.state in (STATE_PLAYING, STATE_PLAYER_DYING)
+    if changed or (animated and ticks_diff(now, _next_frame) >= 0):
+        _renderer.draw_frame(_game)
+        _next_frame = ticks_add(now, FRAME_MS)
+
+
+def stop(view_manager):
+    """Release the game state when leaving the Picoware view."""
+    global _game, _renderer, _leaderboard, _next_frame, _score_saved
+
+    _game = None
+    _renderer = None
+    _leaderboard = None
+    _next_frame = 0
+    _score_saved = False
+    view_manager.freq()
+    collect()

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -32,15 +32,26 @@ _renderer = None
 _leaderboard = None
 _next_frame = 0
 _score_saved = False
+_frequency_changed = False
 FRAME_MS = 50
 GAME_CPU_FREQUENCY = 230000000
+
+
+def _thread_idle(view_manager):
+    """Return whether changing the global CPU clock is currently safe."""
+    thread_manager = getattr(view_manager, "thread_manager", None)
+    return thread_manager is None or thread_manager.thread is None
 
 
 def start(view_manager):
     """Create a fresh Pico Bomber title screen."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
+    global _frequency_changed
 
-    view_manager.freq(False, GAME_CPU_FREQUENCY)
+    _frequency_changed = False
+    if _thread_idle(view_manager):
+        view_manager.freq(False, GAME_CPU_FREQUENCY)
+        _frequency_changed = True
     _game = GameModel()
     _renderer = Renderer(view_manager.draw)
     _leaderboard = Leaderboard(view_manager.storage)
@@ -126,11 +137,14 @@ def run(view_manager):
 def stop(view_manager):
     """Release the game state when leaving the Picoware view."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
+    global _frequency_changed
 
     _game = None
     _renderer = None
     _leaderboard = None
     _next_frame = 0
     _score_saved = False
-    view_manager.freq()
+    if _frequency_changed and _thread_idle(view_manager):
+        view_manager.freq()
+    _frequency_changed = False
     collect()

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
@@ -1,0 +1,83 @@
+"""Small persistent leaderboard for Pico Bomber."""
+
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+
+LEADERBOARD_PATH = "/picoware/settings/pico_bomber_scores.json"
+MAX_SCORES = 5
+
+
+class Leaderboard:
+    """Load, rank, and save local score entries."""
+
+    def __init__(self, storage=None):
+        self.storage = storage
+        self.entries = []
+        self.load()
+
+    @staticmethod
+    def _valid_entry(entry):
+        return (
+            isinstance(entry, (list, tuple))
+            and len(entry) >= 3
+            and isinstance(entry[0], int)
+            and isinstance(entry[1], int)
+            and isinstance(entry[2], int)
+            and entry[0] >= 0
+            and entry[1] >= 1
+            and entry[2] in (0, 1)
+        )
+
+    @staticmethod
+    def _rank(entries):
+        ranked = []
+        for entry in entries:
+            item = [int(entry[0]), int(entry[1]), int(entry[2])]
+            inserted = False
+            for index in range(len(ranked)):
+                if item[0] > ranked[index][0]:
+                    ranked.insert(index, item)
+                    inserted = True
+                    break
+            if not inserted:
+                ranked.append(item)
+            if len(ranked) > MAX_SCORES:
+                ranked.pop()
+        return ranked
+
+    def load(self):
+        self.entries = []
+        if self.storage is None:
+            return self.entries
+        try:
+            if not self.storage.exists(LEADERBOARD_PATH):
+                return self.entries
+            loaded = json.loads(self.storage.read(LEADERBOARD_PATH, "r"))
+            if isinstance(loaded, list):
+                valid = []
+                for entry in loaded:
+                    if self._valid_entry(entry):
+                        valid.append(entry)
+                self.entries = self._rank(valid)
+        except Exception:
+            self.entries = []
+        return self.entries
+
+    def submit(self, score, stage, mode):
+        entry = [max(0, int(score)), max(1, int(stage)), int(mode)]
+        if not self._valid_entry(entry):
+            return False
+        previous = json.dumps(self.entries)
+        self.entries = self._rank(self.entries + [entry])
+        current = json.dumps(self.entries)
+        if current == previous:
+            return False
+        if self.storage is None:
+            return True
+        try:
+            return bool(self.storage.write(LEADERBOARD_PATH, current, "w"))
+        except Exception:
+            return False

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/model.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/model.py
@@ -1,0 +1,831 @@
+"""Game rules for Pico Bomber.
+
+The model intentionally has no Picoware display dependencies. Keeping the
+rules isolated makes the game cheaper to import, easier to test, and usable on
+every MicroPython board supported by Picoware.
+"""
+
+from random import randint
+
+try:
+    from utime import ticks_add, ticks_diff
+except ImportError:
+    def ticks_add(value, delta):
+        return value + delta
+
+    def ticks_diff(value, reference):
+        return value - reference
+
+
+GRID_WIDTH = 13
+GRID_HEIGHT = 13
+
+TILE_EMPTY = 0
+TILE_SOLID = 1
+TILE_BRICK = 2
+
+POWER_FLAME = 1
+POWER_BOMB = 2
+
+THEME_NATURE = 0
+THEME_INDUSTRIAL = 1
+THEME_WATER = 2
+THEME_NAMES = ("NATURE", "INDUSTRIAL", "WATER")
+
+MODE_GHOST_HUNT = 0
+MODE_BLAST_RIVALS = 1
+MODE_NAMES = ("GHOST HUNT", "BLAST RIVALS")
+MENU_LEADERBOARD = 2
+MENU_ITEM_COUNT = 3
+
+ENEMY_BLOB = 0
+ENEMY_CHASER = 1
+ENEMY_BOMBER = 2
+
+STATE_TITLE = 0
+STATE_PLAYING = 1
+STATE_STAGE_CLEAR = 2
+STATE_GAME_OVER = 3
+STATE_PLAYER_DYING = 4
+STATE_STAGE_INTRO = 5
+STATE_MODE_SELECT = 6
+STATE_LEADERBOARD = 7
+
+DEATH_PLAYER = 0
+DEATH_ENEMY_BLOB = 1
+DEATH_ENEMY_CHASER = 2
+DEATH_ENEMY_ELITE = 3
+DEATH_ENEMY_BOMBER = 4
+
+DECAL_BLOB = 0
+DECAL_CHASER = 1
+DECAL_ELITE = 2
+DECAL_SCORCH = 3
+DECAL_DEBRIS = 4
+DECAL_BOMBER = 5
+
+BOMB_FUSE_MS = 2100
+EXPLOSION_MS = 480
+PLAYER_INVULNERABLE_MS = 1400
+STAGE_CLEAR_MS = 1300
+DEATH_ANIMATION_MS = 720
+PLAYER_MOVE_ANIMATION_MS = 150
+ENEMY_MOVE_ANIMATION_MS = 190
+STAGE_INTRO_MS = 900
+POSITION_SCALE = 256
+MAX_DECALS = 12
+
+DIRECTIONS = ((0, -1), (0, 1), (-1, 0), (1, 0))
+SAFE_TILES = (
+    (1, 1),
+    (2, 1),
+    (3, 1),
+    (3, 2),
+    (1, 2),
+    (1, 3),
+    (2, 3),
+)
+
+
+class GameModel:
+    """Mutable state and rules for one Pico Bomber session."""
+
+    def __init__(self):
+        self.grid = []
+        self.player_x = 1
+        self.player_y = 1
+        self.lives = 3
+        self.score = 0
+        self.stage = 1
+        self.mode = MODE_GHOST_HUNT
+        self.menu_selection = MODE_GHOST_HUNT
+        self.theme = -1
+        self.flame_range = 2
+        self.bomb_limit = 1
+        self.bombs = []
+        self.explosions = []
+        self.enemies = []
+        self.powerups = []
+        self.decals = []
+        self.death_effects = []
+        self.leaderboard = []
+        self.state = STATE_TITLE
+        self.state_until = 0
+        self.invulnerable_until = 0
+        self.animation_time = 0
+        self.animation_last = 0
+        self.player_frame = 0
+        self.player_facing = 0
+        self.player_draw_x = POSITION_SCALE
+        self.player_draw_y = POSITION_SCALE
+
+    def open_mode_menu(self):
+        """Open the mode chooser with the current mode highlighted."""
+        self.menu_selection = self.mode
+        self.state = STATE_MODE_SELECT
+
+    def select_mode(self, direction):
+        """Move the mode chooser selection."""
+        if self.state != STATE_MODE_SELECT:
+            return False
+        count = MENU_ITEM_COUNT
+        self.menu_selection = (self.menu_selection + direction) % count
+        return True
+
+    def new_game(self, now, mode=None):
+        """Start a new run from stage one."""
+        if mode is not None:
+            self.mode = mode
+        else:
+            self.mode = self.menu_selection
+        self.lives = 3
+        self.score = 0
+        self.stage = 1
+        self.flame_range = 2
+        self.bomb_limit = 1
+        self._build_stage(now)
+
+    def _build_stage(self, now):
+        """Create a procedural arena with a guaranteed safe starting pocket."""
+        self.theme = self._choose_theme()
+        self.grid = []
+        for y in range(GRID_HEIGHT):
+            row = []
+            for x in range(GRID_WIDTH):
+                if (
+                    x == 0
+                    or y == 0
+                    or x == GRID_WIDTH - 1
+                    or y == GRID_HEIGHT - 1
+                    or (x % 2 == 0 and y % 2 == 0)
+                ):
+                    row.append(TILE_SOLID)
+                elif (x, y) in SAFE_TILES:
+                    row.append(TILE_EMPTY)
+                elif randint(0, 99) < 52:
+                    row.append(TILE_BRICK)
+                else:
+                    row.append(TILE_EMPTY)
+            self.grid.append(row)
+
+        self.player_x = 1
+        self.player_y = 1
+        self.player_draw_x = POSITION_SCALE
+        self.player_draw_y = POSITION_SCALE
+        self.bombs = []
+        self.explosions = []
+        self.powerups = []
+        self.decals = []
+        self.enemies = []
+        self.death_effects = []
+        self.invulnerable_until = ticks_add(now, PLAYER_INVULNERABLE_MS)
+        self.animation_time = now
+        self.animation_last = now
+        self.player_frame = 0
+        self.player_facing = 0
+        self.state = STATE_STAGE_INTRO
+        self.state_until = ticks_add(now, STAGE_INTRO_MS)
+
+        candidates = []
+        for y in range(GRID_HEIGHT - 2, 0, -1):
+            for x in range(GRID_WIDTH - 2, 0, -1):
+                if self.grid[y][x] != TILE_SOLID and x + y > 10:
+                    candidates.append((x, y))
+
+        enemy_count = min(2 + self.stage, 7)
+        while candidates and len(self.enemies) < enemy_count:
+            index = randint(0, len(candidates) - 1)
+            x, y = candidates.pop(index)
+            too_close = False
+            for enemy in self.enemies:
+                if abs(enemy[0] - x) + abs(enemy[1] - y) < 2:
+                    too_close = True
+                    break
+            if too_close:
+                continue
+            self.grid[y][x] = TILE_EMPTY
+            delay = randint(100, 350)
+            kind = (
+                ENEMY_BOMBER
+                if self.mode == MODE_BLAST_RIVALS
+                else randint(ENEMY_BLOB, ENEMY_CHASER)
+            )
+            elite_chance = min(35, 8 + self.stage * 3)
+            elite = 1 if self.stage >= 3 and randint(0, 99) < elite_chance else 0
+            self.enemies.append(
+                [
+                    x,
+                    y,
+                    ticks_add(now, delay),
+                    kind,
+                    randint(0, 3),
+                    0,
+                    x * POSITION_SCALE,
+                    y * POSITION_SCALE,
+                    elite,
+                    ticks_add(now, randint(1600, 3000)),
+                ]
+            )
+
+        # This is a fallback for an exceptionally crowded random map.
+        if not self.enemies:
+            self.grid[GRID_HEIGHT - 2][GRID_WIDTH - 2] = TILE_EMPTY
+            self.enemies.append(
+                [
+                    GRID_WIDTH - 2,
+                    GRID_HEIGHT - 2,
+                    ticks_add(now, 250),
+                    ENEMY_BOMBER
+                    if self.mode == MODE_BLAST_RIVALS
+                    else ENEMY_BLOB,
+                    0,
+                    0,
+                    (GRID_WIDTH - 2) * POSITION_SCALE,
+                    (GRID_HEIGHT - 2) * POSITION_SCALE,
+                    0,
+                    ticks_add(now, 2200),
+                ]
+            )
+
+    def _choose_theme(self):
+        theme = randint(0, len(THEME_NAMES) - 1)
+        if theme == self.theme:
+            theme = (theme + 1 + randint(0, len(THEME_NAMES) - 2)) % len(
+                THEME_NAMES
+            )
+        return theme
+
+    def bombs_available(self):
+        """Return how many additional bombs the player may place."""
+        player_bombs = 0
+        for bomb in self.bombs:
+            if len(bomb) < 5 or bomb[4] == 0:
+                player_bombs += 1
+        return max(0, self.bomb_limit - player_bombs)
+
+    def _has_bomb(self, x, y):
+        for bomb in self.bombs:
+            if bomb[0] == x and bomb[1] == y:
+                return True
+        return False
+
+    def _enemy_at(self, x, y, ignored=None):
+        for enemy in self.enemies:
+            if enemy is not ignored and enemy[0] == x and enemy[1] == y:
+                return True
+        return False
+
+    @staticmethod
+    def _draw_tile(value):
+        return (value + POSITION_SCALE // 2) // POSITION_SCALE
+
+    def _enemy_touches_player(self):
+        contact_distance = POSITION_SCALE * 3 // 5
+        for enemy in self.enemies:
+            if (
+                abs(enemy[6] - self.player_draw_x) <= contact_distance
+                and abs(enemy[7] - self.player_draw_y) <= contact_distance
+            ):
+                return True
+        return False
+
+    def _can_enter(self, x, y, block_enemies=False, ignored_enemy=None):
+        if x < 0 or y < 0 or x >= GRID_WIDTH or y >= GRID_HEIGHT:
+            return False
+        if self.grid[y][x] != TILE_EMPTY or self._has_bomb(x, y):
+            return False
+        if block_enemies and self._enemy_at(x, y, ignored_enemy):
+            return False
+        return True
+
+    def move_player(self, dx, dy, now):
+        """Attempt to move the player by one grid tile."""
+        if self.state != STATE_PLAYING:
+            return False
+        self.player_facing = self._facing_for_direction(dx, dy)
+        x = self.player_x + dx
+        y = self.player_y + dy
+        if not self._can_enter(x, y):
+            return False
+        self.player_x = x
+        self.player_y = y
+        self.player_frame = (self.player_frame + 1) % 4
+        self._collect_powerup()
+        if self._enemy_touches_player():
+            self._lose_life(now)
+        return True
+
+    @staticmethod
+    def _facing_for_direction(dx, dy):
+        if dy < 0:
+            return 3
+        if dx < 0:
+            return 1
+        if dx > 0:
+            return 2
+        return 0
+
+    def place_bomb(self, now):
+        """Place a bomb on the player's current tile if capacity allows."""
+        if (
+            self.state != STATE_PLAYING
+            or self.bombs_available() <= 0
+            or self._has_bomb(self.player_x, self.player_y)
+        ):
+            return False
+        self.bombs.append(
+            [
+                self.player_x,
+                self.player_y,
+                ticks_add(now, BOMB_FUSE_MS),
+                self.flame_range,
+                0,
+            ]
+        )
+        return True
+
+    def _collect_powerup(self):
+        for powerup in self.powerups:
+            if powerup[0] == self.player_x and powerup[1] == self.player_y:
+                if powerup[2] == POWER_FLAME:
+                    self.flame_range = min(6, self.flame_range + 1)
+                else:
+                    self.bomb_limit = min(5, self.bomb_limit + 1)
+                self.score += 25
+                self.powerups.remove(powerup)
+                return True
+        return False
+
+    def _add_explosion(self, x, y, expires, owner=0):
+        self._scorch_decals_at(x, y)
+        for flame in self.explosions:
+            if flame[0] == x and flame[1] == y:
+                flame[2] = expires
+                flame_owner = flame[3] if len(flame) >= 4 else 0
+                if flame_owner != owner:
+                    if len(flame) >= 4:
+                        flame[3] = 2
+                    else:
+                        flame.append(2)
+                return
+        self.explosions.append([x, y, expires, owner])
+
+    def _reveal_powerup(self, x, y):
+        if randint(0, 99) >= 24:
+            return
+        kind = POWER_FLAME if randint(0, 1) == 0 else POWER_BOMB
+        self.powerups.append([x, y, kind])
+
+    def _add_decal(self, draw_x, draw_y, kind):
+        tile_x = (draw_x + POSITION_SCALE // 2) // POSITION_SCALE
+        tile_y = (draw_y + POSITION_SCALE // 2) // POSITION_SCALE
+        if kind == DECAL_SCORCH:
+            for decal in self.decals:
+                decal_x = (decal[0] + POSITION_SCALE // 2) // POSITION_SCALE
+                decal_y = (decal[1] + POSITION_SCALE // 2) // POSITION_SCALE
+                if decal_x == tile_x and decal_y == tile_y:
+                    decal[2] = DECAL_SCORCH
+                    decal[3] = self.theme
+                    decal[4] = randint(0, 3)
+                    return
+        if len(self.decals) >= MAX_DECALS:
+            replace_index = -1
+            for index, decal in enumerate(self.decals):
+                if decal[2] in (DECAL_SCORCH, DECAL_DEBRIS):
+                    replace_index = index
+                    break
+            if replace_index >= 0:
+                self.decals.pop(replace_index)
+            elif kind in (DECAL_SCORCH, DECAL_DEBRIS):
+                return
+            else:
+                self.decals.pop(0)
+        self.decals.append(
+            [
+                draw_x,
+                draw_y,
+                kind,
+                self.theme,
+                randint(0, 3),
+            ]
+        )
+
+    def _scorch_decals_at(self, x, y):
+        for decal in self.decals:
+            decal_x = (decal[0] + POSITION_SCALE // 2) // POSITION_SCALE
+            decal_y = (decal[1] + POSITION_SCALE // 2) // POSITION_SCALE
+            if decal_x == x and decal_y == y:
+                decal[2] = DECAL_SCORCH
+                decal[3] = self.theme
+
+    def _detonate(self, bomb, now):
+        """Turn one bomb into blast tiles and arm bombs caught in the blast."""
+        if bomb not in self.bombs:
+            return
+        self.bombs.remove(bomb)
+        expires = ticks_add(now, EXPLOSION_MS)
+        owner = bomb[4] if len(bomb) >= 5 else 0
+        self._add_explosion(bomb[0], bomb[1], expires, owner)
+        self._add_decal(
+            bomb[0] * POSITION_SCALE,
+            bomb[1] * POSITION_SCALE,
+            DECAL_SCORCH,
+        )
+
+        for dx, dy in DIRECTIONS:
+            for distance in range(1, bomb[3] + 1):
+                x = bomb[0] + dx * distance
+                y = bomb[1] + dy * distance
+                tile = self.grid[y][x]
+                if tile == TILE_SOLID:
+                    break
+                self._add_explosion(x, y, expires, owner)
+
+                chained = None
+                for other in self.bombs:
+                    if other[0] == x and other[1] == y:
+                        chained = other
+                        break
+                if chained is not None:
+                    chained[2] = now
+
+                if tile == TILE_BRICK:
+                    self.grid[y][x] = TILE_EMPTY
+                    if owner == 0:
+                        self.score += 5
+                    self._add_decal(
+                        x * POSITION_SCALE,
+                        y * POSITION_SCALE,
+                        DECAL_DEBRIS,
+                    )
+                    self._reveal_powerup(x, y)
+                    break
+
+    def _is_flame(self, x, y):
+        for flame in self.explosions:
+            if flame[0] == x and flame[1] == y:
+                return True
+        return False
+
+    def _enemy_hit_by_flame(self, enemy):
+        enemy_x = self._draw_tile(enemy[6])
+        enemy_y = self._draw_tile(enemy[7])
+        for flame in self.explosions:
+            if flame[0] != enemy_x or flame[1] != enemy_y:
+                continue
+            owner = flame[3] if len(flame) >= 4 else 0
+            if enemy[3] == ENEMY_BOMBER and owner == 1:
+                continue
+            return True
+        return False
+
+    def _apply_explosion_damage(self, now):
+        killed = []
+        for enemy in self.enemies:
+            if self._enemy_hit_by_flame(enemy):
+                killed.append(enemy)
+        for enemy in killed:
+            self.enemies.remove(enemy)
+            if enemy[8]:
+                death_kind = DEATH_ENEMY_ELITE
+                decal_kind = DECAL_ELITE
+            elif enemy[3] == ENEMY_BOMBER:
+                death_kind = DEATH_ENEMY_BOMBER
+                decal_kind = DECAL_BOMBER
+            else:
+                death_kind = DEATH_ENEMY_BLOB + enemy[3]
+                decal_kind = DECAL_BLOB + enemy[3]
+            self._add_death_effect(
+                enemy[6],
+                enemy[7],
+                death_kind,
+                now,
+            )
+            self._add_decal(
+                enemy[6],
+                enemy[7],
+                decal_kind,
+            )
+            self.score += 250 if enemy[8] else 100
+
+        player_x = self._draw_tile(self.player_draw_x)
+        player_y = self._draw_tile(self.player_draw_y)
+        if self._is_flame(player_x, player_y):
+            self._lose_life(now)
+
+    def _add_death_effect(self, draw_x, draw_y, kind, now):
+        self.death_effects.append(
+            [
+                draw_x,
+                draw_y,
+                kind,
+                now,
+                ticks_add(now, DEATH_ANIMATION_MS),
+            ]
+        )
+
+    def _cleanup_death_effects(self, now):
+        changed = False
+        for effect in self.death_effects[:]:
+            if ticks_diff(now, effect[4]) >= 0:
+                self.death_effects.remove(effect)
+                changed = True
+        return changed
+
+    def _lose_life(self, now):
+        if (
+            self.state != STATE_PLAYING
+            or ticks_diff(now, self.invulnerable_until) < 0
+        ):
+            return False
+
+        self._add_death_effect(
+            self.player_draw_x,
+            self.player_draw_y,
+            DEATH_PLAYER,
+            now,
+        )
+        self.lives -= 1
+        self.bombs = []
+        self.state = STATE_PLAYER_DYING
+        self.state_until = ticks_add(now, DEATH_ANIMATION_MS)
+        return True
+
+    def _finish_player_death(self, now):
+        self.explosions = []
+        if self.lives <= 0:
+            self.state = STATE_GAME_OVER
+            self.state_until = 0
+            return
+
+        self.player_x = 1
+        self.player_y = 1
+        self.player_draw_x = POSITION_SCALE
+        self.player_draw_y = POSITION_SCALE
+        self.player_frame = 0
+        self.player_facing = 0
+        for x, y in SAFE_TILES:
+            self.grid[y][x] = TILE_EMPTY
+        self.invulnerable_until = ticks_add(now, PLAYER_INVULNERABLE_MS)
+
+        # Keep surviving enemies out of the respawn pocket.
+        for enemy in self.enemies:
+            if (enemy[0], enemy[1]) in SAFE_TILES:
+                enemy[0] = GRID_WIDTH - 2
+                enemy[1] = GRID_HEIGHT - 2
+                enemy[6] = enemy[0] * POSITION_SCALE
+                enemy[7] = enemy[1] * POSITION_SCALE
+                self.grid[enemy[1]][enemy[0]] = TILE_EMPTY
+        self.state = STATE_PLAYING
+        self.state_until = 0
+
+    def _bomb_reaches(self, bomb, x, y):
+        if bomb[0] != x and bomb[1] != y:
+            return False
+        distance = abs(bomb[0] - x) + abs(bomb[1] - y)
+        if distance > bomb[3]:
+            return False
+        dx = 0 if bomb[0] == x else (1 if x > bomb[0] else -1)
+        dy = 0 if bomb[1] == y else (1 if y > bomb[1] else -1)
+        check_x = bomb[0] + dx
+        check_y = bomb[1] + dy
+        while check_x != x or check_y != y:
+            if self.grid[check_y][check_x] != TILE_EMPTY:
+                return False
+            check_x += dx
+            check_y += dy
+        return self.grid[y][x] == TILE_EMPTY
+
+    def _tile_in_bomb_danger(self, x, y):
+        for bomb in self.bombs:
+            if self._bomb_reaches(bomb, x, y):
+                return True
+        return False
+
+    def _enemy_escape_score(self, x, y):
+        nearest = 999
+        for bomb in self.bombs:
+            distance = abs(bomb[0] - x) + abs(bomb[1] - y)
+            if distance < nearest:
+                nearest = distance
+        if not self._tile_in_bomb_danger(x, y):
+            return 1000 + nearest
+        return nearest
+
+    def _move_enemy(self, enemy, now):
+        candidates = []
+        for dx, dy in DIRECTIONS:
+            x = enemy[0] + dx
+            y = enemy[1] + dy
+            if self._can_enter(x, y, True, enemy):
+                candidates.append((x, y, dx, dy))
+
+        if candidates:
+            chosen = None
+            if (
+                enemy[3] == ENEMY_BOMBER
+                and self._tile_in_bomb_danger(enemy[0], enemy[1])
+            ):
+                best_score = -1
+                for x, y, dx, dy in candidates:
+                    score = self._enemy_escape_score(x, y)
+                    if score > best_score:
+                        chosen = (x, y, dx, dy)
+                        best_score = score
+            elif enemy[3] in (ENEMY_CHASER, ENEMY_BOMBER) or randint(0, 99) < 55:
+                best_distance = 999
+                for x, y, dx, dy in candidates:
+                    distance = abs(self.player_x - x) + abs(self.player_y - y)
+                    if distance < best_distance:
+                        chosen = (x, y, dx, dy)
+                        best_distance = distance
+            if chosen is None:
+                chosen = candidates[randint(0, len(candidates) - 1)]
+            enemy[0], enemy[1] = chosen[0], chosen[1]
+            enemy[4] = (enemy[4] + 1) % 4
+            enemy[5] = self._facing_for_direction(chosen[2], chosen[3])
+
+        interval = max(190, 520 - self.stage * 24)
+        if enemy[8]:
+            interval = max(150, interval * 3 // 4)
+        enemy[2] = ticks_add(now, interval + randint(0, 100))
+
+    def _enemy_try_bomb(self, enemy, now):
+        if (
+            self.mode != MODE_BLAST_RIVALS
+            or enemy[3] != ENEMY_BOMBER
+            or ticks_diff(now, enemy[9]) < 0
+            or enemy[6] != enemy[0] * POSITION_SCALE
+            or enemy[7] != enemy[1] * POSITION_SCALE
+        ):
+            return False
+
+        enemy_bombs = 0
+        for bomb in self.bombs:
+            if len(bomb) >= 5 and bomb[4] == 1:
+                enemy_bombs += 1
+        enemy_limit = min(4, 1 + self.stage // 2)
+        distance = abs(self.player_x - enemy[0]) + abs(self.player_y - enemy[1])
+        can_escape = False
+        for dx, dy in DIRECTIONS:
+            if self._can_enter(enemy[0] + dx, enemy[1] + dy, True, enemy):
+                can_escape = True
+                break
+
+        placed = False
+        if (
+            enemy_bombs < enemy_limit
+            and not self._has_bomb(enemy[0], enemy[1])
+            and can_escape
+            and (distance <= 6 or randint(0, 99) < 35)
+        ):
+            self.bombs.append(
+                [
+                    enemy[0],
+                    enemy[1],
+                    ticks_add(now, BOMB_FUSE_MS + 300),
+                    min(4, 2 + self.stage // 4),
+                    1,
+                ]
+            )
+            placed = True
+        enemy[9] = ticks_add(now, randint(2600, 4200))
+        return placed
+
+    @staticmethod
+    def _approach(value, target, step):
+        if value < target:
+            return min(target, value + step)
+        if value > target:
+            return max(target, value - step)
+        return value
+
+    def _advance_animation(self, now):
+        delta = ticks_diff(now, self.animation_last)
+        self.animation_last = now
+        if delta <= 0:
+            return False
+        delta = min(delta, ENEMY_MOVE_ANIMATION_MS)
+        player_delta = min(delta, PLAYER_MOVE_ANIMATION_MS)
+        player_step = max(
+            1,
+            (
+                POSITION_SCALE * player_delta
+                + PLAYER_MOVE_ANIMATION_MS
+                - 1
+            )
+            // PLAYER_MOVE_ANIMATION_MS,
+        )
+        enemy_step = max(
+            1,
+            (POSITION_SCALE * delta + ENEMY_MOVE_ANIMATION_MS - 1)
+            // ENEMY_MOVE_ANIMATION_MS,
+        )
+        changed = False
+
+        target_x = self.player_x * POSITION_SCALE
+        target_y = self.player_y * POSITION_SCALE
+        next_x = self._approach(self.player_draw_x, target_x, player_step)
+        next_y = self._approach(self.player_draw_y, target_y, player_step)
+        if next_x != self.player_draw_x or next_y != self.player_draw_y:
+            self.player_draw_x = next_x
+            self.player_draw_y = next_y
+            changed = True
+
+        for enemy in self.enemies:
+            target_x = enemy[0] * POSITION_SCALE
+            target_y = enemy[1] * POSITION_SCALE
+            next_x = self._approach(enemy[6], target_x, enemy_step)
+            next_y = self._approach(enemy[7], target_y, enemy_step)
+            if next_x != enemy[6] or next_y != enemy[7]:
+                enemy[6] = next_x
+                enemy[7] = next_y
+                changed = True
+        return changed
+
+    def _cleanup_explosions(self, now):
+        changed = False
+        for flame in self.explosions[:]:
+            if ticks_diff(now, flame[2]) >= 0:
+                self.explosions.remove(flame)
+                changed = True
+        return changed
+
+    def update(self, now):
+        """Advance timers, bombs, enemies, damage, and stage transitions."""
+        changed = False
+        self.animation_time = now
+        if self._advance_animation(now):
+            changed = True
+
+        if self._cleanup_death_effects(now):
+            changed = True
+
+        if self.state == STATE_STAGE_INTRO:
+            if ticks_diff(now, self.state_until) >= 0:
+                self.state = STATE_PLAYING
+                self.state_until = 0
+                return True
+            return changed
+
+        if self.state == STATE_PLAYER_DYING:
+            if self._cleanup_explosions(now):
+                changed = True
+            if ticks_diff(now, self.state_until) >= 0:
+                self._finish_player_death(now)
+                return True
+            return changed
+
+        if self.state == STATE_STAGE_CLEAR:
+            if ticks_diff(now, self.state_until) >= 0:
+                self.stage += 1
+                self.score += 250
+                self._build_stage(now)
+                return True
+            return False
+
+        if self.state != STATE_PLAYING:
+            return changed
+
+        if self._cleanup_explosions(now):
+            changed = True
+
+        while True:
+            due = None
+            for bomb in self.bombs:
+                if ticks_diff(now, bomb[2]) >= 0:
+                    due = bomb
+                    break
+            if due is None:
+                break
+            self._detonate(due, now)
+            changed = True
+
+        if self.explosions:
+            previous_lives = self.lives
+            previous_enemies = len(self.enemies)
+            self._apply_explosion_damage(now)
+            if previous_lives != self.lives or previous_enemies != len(self.enemies):
+                changed = True
+            if self.state != STATE_PLAYING:
+                return True
+
+        for enemy in self.enemies:
+            if ticks_diff(now, enemy[2]) >= 0:
+                self._move_enemy(enemy, now)
+                changed = True
+            if self._enemy_try_bomb(enemy, now):
+                changed = True
+
+        if self._enemy_touches_player():
+            if self._lose_life(now):
+                changed = True
+            if self.state != STATE_PLAYING:
+                return True
+
+        if not self.enemies and not self.death_effects:
+            self.state = STATE_STAGE_CLEAR
+            self.state_until = ticks_add(now, STAGE_CLEAR_MS)
+            changed = True
+
+        return changed

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
@@ -1,0 +1,1289 @@
+"""Low-allocation renderer for Pico Bomber."""
+
+from utime import ticks_diff
+
+from picoware.system.colors import (
+    TFT_BLACK,
+    TFT_CYAN,
+    TFT_DARKGREY,
+    TFT_GREEN,
+    TFT_LIGHTGREY,
+    TFT_ORANGE,
+    TFT_RED,
+    TFT_WHITE,
+    TFT_YELLOW,
+)
+
+from .model import (
+    DECAL_BLOB,
+    DECAL_BOMBER,
+    DECAL_CHASER,
+    DECAL_DEBRIS,
+    DECAL_ELITE,
+    DECAL_SCORCH,
+    DEATH_ANIMATION_MS,
+    DEATH_ENEMY_BLOB,
+    DEATH_ENEMY_BOMBER,
+    DEATH_ENEMY_CHASER,
+    DEATH_ENEMY_ELITE,
+    DEATH_PLAYER,
+    ENEMY_BOMBER,
+    GRID_HEIGHT,
+    GRID_WIDTH,
+    MODE_NAMES,
+    POSITION_SCALE,
+    POWER_BOMB,
+    STATE_GAME_OVER,
+    STATE_LEADERBOARD,
+    STATE_MODE_SELECT,
+    STATE_PLAYER_DYING,
+    STATE_STAGE_CLEAR,
+    STATE_STAGE_INTRO,
+    STATE_TITLE,
+    THEME_INDUSTRIAL,
+    THEME_NAMES,
+    THEME_NATURE,
+    THEME_WATER,
+    TILE_BRICK,
+    TILE_SOLID,
+)
+
+
+COLOR_ARENA = 0x0861
+COLOR_SOLID_LIGHT = 0x6B4D
+COLOR_PLAYER = 0x05FF
+COLOR_PLAYER_DARK = 0x0372
+COLOR_POWER = 0x7FE0
+COLOR_VISOR = 0x867D
+
+COLOR_GRASS = 0x1C84
+COLOR_GRASS_LIGHT = 0x2E66
+COLOR_MOSS = 0x3D86
+COLOR_NATURE_STONE = 0x52AA
+COLOR_WOOD = 0xA285
+COLOR_WOOD_DARK = 0x6183
+
+COLOR_FACTORY_FLOOR = 0x18C3
+COLOR_FACTORY_SEAM = 0x2945
+COLOR_STEEL = 0x630C
+COLOR_STEEL_LIGHT = 0x8C51
+COLOR_HAZARD = 0xD5A0
+
+COLOR_WATER = 0x0452
+COLOR_WATER_DARK = 0x02AB
+COLOR_WAVE = 0x4E7F
+COLOR_REEF = 0x39AA
+COLOR_CORAL = 0xF3E0
+COLOR_PURPLE = 0xA15C
+COLOR_INK = 0x30A7
+COLOR_COOLANT = 0x36DF
+COLOR_RUST = 0xA2C2
+COLOR_FOAM = 0xBFFF
+COLOR_GOLD = 0xF5E0
+
+PARTICLE_DIRECTIONS = (
+    (-1, -1),
+    (0, -1),
+    (1, -1),
+    (-1, 0),
+    (1, 0),
+    (-1, 1),
+    (0, 1),
+    (1, 1),
+)
+
+
+class Renderer:
+    """Draw a complete Pico Bomber frame using the native LCD primitives."""
+
+    def __init__(self, draw):
+        self.draw = draw
+        self.width = draw.size.x
+        self.height = draw.size.y
+        self.hud_height = 28 if self.height >= 160 else 14
+        available_w = max(1, self.width - 4)
+        available_h = max(1, self.height - self.hud_height - 4)
+        self.cell = max(
+            2,
+            min(available_w // GRID_WIDTH, available_h // GRID_HEIGHT),
+        )
+        self.board_w = self.cell * GRID_WIDTH
+        self.board_h = self.cell * GRID_HEIGHT
+        self.origin_x = (self.width - self.board_w) // 2
+        self.origin_y = self.hud_height + (
+            self.height - self.hud_height - self.board_h
+        ) // 2
+
+    def _center_text(self, text, y, color, font_size=1):
+        width = self.draw.len(text, font_size)
+        self.draw._text(max(0, (self.width - width) // 2), y, text, color, font_size)
+
+    def _tile_box(self, x, y):
+        return (
+            self.origin_x + x * self.cell,
+            self.origin_y + y * self.cell,
+        )
+
+    def _fixed_box(self, draw_x, draw_y):
+        return (
+            self.origin_x + draw_x * self.cell // POSITION_SCALE,
+            self.origin_y + draw_y * self.cell // POSITION_SCALE,
+        )
+
+    def _draw_title(self):
+        draw = self.draw
+        draw.fill_screen(COLOR_ARENA)
+        title_y = max(8, self.height // 7)
+        self._center_text("PICO BOMBER", title_y, TFT_YELLOW, 3)
+
+        cx = self.width // 2
+        cy = self.height // 2
+        radius = max(8, min(30, self.width // 12))
+        draw._fill_circle(cx, cy, radius, TFT_BLACK)
+        draw._circle(cx, cy, radius, TFT_LIGHTGREY)
+        draw._fill_circle(cx - radius // 3, cy - radius // 3, max(2, radius // 5), TFT_WHITE)
+        draw._line(cx + radius // 2, cy - radius // 2, cx + radius, cy - radius, TFT_ORANGE)
+        draw._fill_circle(cx + radius, cy - radius, max(2, radius // 7), TFT_YELLOW)
+
+        controls_y = min(self.height - 52, cy + radius + 24)
+        self._center_text("ARROWS  MOVE", controls_y, TFT_CYAN)
+        self._center_text("CENTER/SPACE  BOMB", controls_y + 16, TFT_WHITE)
+        self._center_text("PRESS CENTER", min(self.height - 16, controls_y + 38), TFT_GREEN)
+
+    def _draw_mode_menu(self, game):
+        draw = self.draw
+        draw.fill_screen(COLOR_ARENA)
+        title_y = 10 if self.height >= 160 else 4
+        self._center_text("CHOOSE MODE", title_y, TFT_YELLOW, 2)
+        self._center_text(
+            "UP/DOWN + CENTER",
+            title_y + (26 if self.height >= 160 else 18),
+            TFT_CYAN,
+            0,
+        )
+
+        compact = self.height < 200
+        gap = 6 if compact else 10
+        top = title_y + (44 if compact else 54)
+        card_h = (
+            max(24, (self.height - top - 4 - gap * 2) // 3)
+            if compact
+            else 64
+        )
+        box_w = min(self.width - 24, 270)
+        x = (self.width - box_w) // 2
+        items = MODE_NAMES + ("LEADERBOARD",)
+        descriptions = (
+            "HUNT CREATURES",
+            "BOMBERS FIGHT BACK",
+            "TOP 5 LOCAL SCORES",
+        )
+        colors = (COLOR_PURPLE, TFT_RED, TFT_GREEN)
+        for index in range(len(items)):
+            y = top + index * (card_h + gap)
+            selected = index == game.menu_selection
+            border = TFT_YELLOW if selected else TFT_DARKGREY
+            draw._fill_rectangle(
+                x,
+                y,
+                box_w,
+                card_h,
+                TFT_BLACK if selected else COLOR_FACTORY_FLOOR,
+            )
+            draw._rectangle(x, y, box_w, card_h, border)
+            marker = ">" if selected else " "
+            draw._text(
+                x + 10,
+                y + (7 if compact else 10),
+                marker + " " + items[index],
+                colors[index],
+                1,
+            )
+            if not compact:
+                draw._text(
+                    x + 28,
+                    y + 37,
+                    descriptions[index],
+                    TFT_WHITE,
+                    0,
+                )
+        if not compact:
+            self._center_text("BACK  TITLE", self.height - 16, TFT_LIGHTGREY, 0)
+
+    def _draw_leaderboard(self, game):
+        draw = self.draw
+        draw.fill_screen(COLOR_ARENA)
+        compact = self.height < 240
+        self._center_text(
+            "LEADERBOARD",
+            4 if compact else 10,
+            TFT_YELLOW,
+            1 if compact else 2,
+        )
+        self._center_text("LOCAL TOP 5", 20 if compact else 37, TFT_CYAN, 0)
+        box_w = min(self.width - (12 if compact else 24), 286)
+        x = (self.width - box_w) // 2
+        top = 34 if compact else 58
+        gap = 2 if compact else 4
+        row_h = (
+            max(12, (self.height - top - 20 - gap * 4) // 5)
+            if compact
+            else 36
+        )
+        entries = game.leaderboard
+        if not entries:
+            self._center_text(
+                "NO SCORES YET",
+                self.height // 2 - 8,
+                TFT_WHITE,
+                0 if compact else 1,
+            )
+            self._center_text("FINISH A RUN TO SAVE", self.height // 2 + 14, TFT_LIGHTGREY, 0)
+        else:
+            for index in range(min(5, len(entries))):
+                entry = entries[index]
+                y = top + index * (row_h + gap)
+                draw._fill_rectangle(x, y, box_w, row_h, TFT_BLACK)
+                draw._rectangle(
+                    x,
+                    y,
+                    box_w,
+                    row_h,
+                    TFT_YELLOW if index == 0 else TFT_DARKGREY,
+                )
+                mode = "GHOST" if entry[2] == 0 else "RIVALS"
+                if compact:
+                    text_y = y + max(2, (row_h - 8) // 2)
+                    draw._text(x + 5, text_y, "#%d" % (index + 1), TFT_YELLOW, 0)
+                    draw._text(x + 28, text_y, str(entry[0]), TFT_WHITE, 0)
+                    right = "%s S%d" % (
+                        "G" if entry[2] == 0 else "R",
+                        entry[1],
+                    )
+                    draw._text(
+                        x + box_w - draw.len(right, 0) - 5,
+                        text_y,
+                        right,
+                        TFT_CYAN,
+                        0,
+                    )
+                else:
+                    draw._text(x + 8, y + 8, "#%d" % (index + 1), TFT_YELLOW, 1)
+                    draw._text(
+                        x + 42,
+                        y + 8,
+                        "%06d" % entry[0],
+                        TFT_WHITE,
+                        1,
+                    )
+                    draw._text(x + 126, y + 5, mode, TFT_CYAN, 0)
+                    draw._text(
+                        x + 126,
+                        y + 19,
+                        "STAGE %d" % entry[1],
+                        TFT_GREEN,
+                        0,
+                    )
+        self._center_text(
+            "CENTER/BACK  MODES",
+            self.height - 16,
+            TFT_LIGHTGREY,
+            0,
+        )
+
+    def _draw_hud(self, game):
+        draw = self.draw
+        draw._fill_rectangle(0, 0, self.width, self.hud_height, TFT_BLACK)
+        if self.height < 160:
+            text = "S%d L%d B%d F%d %d" % (
+                game.stage,
+                game.lives,
+                game.bombs_available(),
+                game.flame_range,
+                game.score,
+            )
+            draw._text(2, 2, text, TFT_WHITE, 0)
+            return
+
+        draw._text(4, 4, "PICO BOMBER", TFT_YELLOW, 1)
+        status = "S:%d L:%d B:%d F:%d" % (
+            game.stage,
+            game.lives,
+            game.bombs_available(),
+            game.flame_range,
+        )
+        status_x = max(4, self.width - draw.len(status, 0) - 4)
+        draw._text(status_x, 3, status, TFT_CYAN, 0)
+        score_text = "%06d" % game.score
+        score_x = max(4, self.width - draw.len(score_text, 0) - 4)
+        draw._text(score_x, 15, score_text, TFT_WHITE, 0)
+        theme_color = (
+            TFT_GREEN
+            if game.theme == THEME_NATURE
+            else TFT_YELLOW
+            if game.theme == THEME_INDUSTRIAL
+            else TFT_CYAN
+        )
+        draw._text(4, 15, THEME_NAMES[game.theme], theme_color, 0)
+
+    def _draw_floor(self, px, py, x, y, theme, animation_time):
+        inset = 1 if self.cell >= 5 else 0
+        if theme == THEME_NATURE:
+            color = COLOR_GRASS
+        elif theme == THEME_INDUSTRIAL:
+            color = COLOR_FACTORY_FLOOR
+        else:
+            color = COLOR_WATER
+        self.draw._fill_rectangle(
+            px + inset,
+            py + inset,
+            self.cell - inset,
+            self.cell - inset,
+            color,
+        )
+
+        if self.cell < 8:
+            return
+        if theme == THEME_NATURE:
+            seed = (x * 7 + y * 11) % max(2, self.cell - 4)
+            self.draw._fill_rectangle(
+                px + 2 + seed,
+                py + 3 + (seed % 3),
+                2,
+                2,
+                COLOR_GRASS_LIGHT,
+            )
+            if (x * 5 + y * 3) % 17 == 0:
+                flower_x = px + self.cell - 5
+                flower_y = py + self.cell - 5
+                self.draw._fill_rectangle(
+                    flower_x,
+                    flower_y,
+                    2,
+                    2,
+                    TFT_YELLOW if (x + y) % 2 else TFT_WHITE,
+                )
+                self.draw._fill_rectangle(
+                    flower_x,
+                    flower_y + 2,
+                    1,
+                    2,
+                    COLOR_MOSS,
+                )
+        elif theme == THEME_INDUSTRIAL:
+            self.draw._rectangle(
+                px + 2,
+                py + 2,
+                self.cell - 5,
+                self.cell - 5,
+                COLOR_FACTORY_SEAM,
+            )
+            self.draw._fill_rectangle(px + 3, py + 3, 1, 1, TFT_LIGHTGREY)
+            if (x * 3 + y * 7) % 19 == 0:
+                pipe_y = py + self.cell - 5
+                self.draw._line(
+                    px + 3,
+                    pipe_y,
+                    px + self.cell - 4,
+                    pipe_y,
+                    COLOR_STEEL_LIGHT,
+                )
+                self.draw._fill_rectangle(
+                    px + self.cell - 5,
+                    pipe_y - 2,
+                    2,
+                    2,
+                    TFT_RED,
+                )
+        else:
+            wave_y = py + 4 + (
+                animation_time // 180 + x * 2 + y
+            ) % max(2, self.cell - 8)
+            self.draw._line(
+                px + 2,
+                wave_y,
+                px + max(3, self.cell // 2),
+                wave_y,
+                COLOR_WAVE,
+            )
+            self.draw._line(
+                px + self.cell // 2,
+                wave_y + 3,
+                px + self.cell - 3,
+                wave_y + 3,
+                COLOR_WATER_DARK,
+            )
+            if (x * 11 + y * 5) % 23 == 0:
+                bubble_x = px + self.cell - 5
+                bubble_y = py + 3
+                self.draw._circle(bubble_x, bubble_y, 2, COLOR_FOAM)
+
+    def _draw_solid(self, px, py, x, y, theme):
+        if theme == THEME_NATURE:
+            self.draw._fill_rectangle(
+                px,
+                py,
+                self.cell,
+                self.cell,
+                COLOR_NATURE_STONE,
+            )
+            if self.cell >= 7:
+                self.draw._rectangle(
+                    px + 2,
+                    py + 2,
+                    self.cell - 5,
+                    self.cell - 5,
+                    COLOR_SOLID_LIGHT,
+                )
+                self.draw._fill_rectangle(
+                    px + 1,
+                    py + 1,
+                    max(2, self.cell // 2),
+                    2,
+                    COLOR_MOSS,
+                )
+        elif theme == THEME_INDUSTRIAL:
+            self.draw._fill_rectangle(px, py, self.cell, self.cell, COLOR_STEEL)
+            if self.cell >= 7:
+                self.draw._rectangle(
+                    px + 2,
+                    py + 2,
+                    self.cell - 5,
+                    self.cell - 5,
+                    COLOR_STEEL_LIGHT,
+                )
+                rivet = max(1, self.cell // 10)
+                self.draw._fill_rectangle(px + 3, py + 3, rivet, rivet, TFT_WHITE)
+                self.draw._fill_rectangle(
+                    px + self.cell - 4 - rivet,
+                    py + self.cell - 4 - rivet,
+                    rivet,
+                    rivet,
+                    TFT_DARKGREY,
+                )
+        else:
+            self.draw._fill_rectangle(px, py, self.cell, self.cell, COLOR_WATER_DARK)
+            if self.cell >= 7:
+                self.draw._fill_rectangle(
+                    px + 2,
+                    py + 3,
+                    self.cell - 4,
+                    self.cell - 6,
+                    COLOR_REEF,
+                )
+                self.draw._line(
+                    px + 3,
+                    py + 4,
+                    px + self.cell - 4,
+                    py + 4,
+                    COLOR_WAVE,
+                )
+                if (x + y) % 3 == 0:
+                    self.draw._circle(
+                        px + self.cell - 5,
+                        py + self.cell // 2,
+                        2,
+                        TFT_CYAN,
+                    )
+
+    def _draw_brick(self, px, py, x, y, theme):
+        if theme == THEME_NATURE:
+            self.draw._fill_rectangle(px, py, self.cell, self.cell, COLOR_WOOD)
+            if self.cell >= 6:
+                self.draw._rectangle(
+                    px + 2,
+                    py + 2,
+                    self.cell - 5,
+                    self.cell - 5,
+                    COLOR_WOOD_DARK,
+                )
+                self.draw._line(
+                    px + 3,
+                    py + 3,
+                    px + self.cell - 4,
+                    py + self.cell - 4,
+                    COLOR_WOOD_DARK,
+                )
+                self.draw._line(
+                    px + self.cell - 4,
+                    py + 3,
+                    px + 3,
+                    py + self.cell - 4,
+                    COLOR_WOOD_DARK,
+                )
+        elif theme == THEME_INDUSTRIAL:
+            self.draw._fill_rectangle(px, py, self.cell, self.cell, COLOR_STEEL)
+            if self.cell >= 6:
+                band = max(2, self.cell // 7)
+                self.draw._fill_rectangle(
+                    px + 2,
+                    py + band + 1,
+                    self.cell - 4,
+                    self.cell - band * 2 - 2,
+                    COLOR_FACTORY_SEAM,
+                )
+                self.draw._fill_rectangle(px, py, self.cell, band, COLOR_HAZARD)
+                self.draw._fill_rectangle(
+                    px,
+                    py + self.cell - band,
+                    self.cell,
+                    band,
+                    COLOR_HAZARD,
+                )
+                stripe = max(3, self.cell // 4)
+                offset = 1
+                while offset < self.cell:
+                    self.draw._fill_rectangle(
+                        px + offset,
+                        py,
+                        min(2, self.cell - offset),
+                        band,
+                        TFT_BLACK,
+                    )
+                    lower_x = min(self.cell - 1, offset + stripe // 2)
+                    self.draw._fill_rectangle(
+                        px + lower_x,
+                        py + self.cell - band,
+                        min(2, self.cell - lower_x),
+                        band,
+                        TFT_BLACK,
+                    )
+                    offset += stripe
+                self.draw._rectangle(
+                    px + 1,
+                    py + 1,
+                    self.cell - 3,
+                    self.cell - 3,
+                    TFT_DARKGREY,
+                )
+        else:
+            self.draw._fill_rectangle(px, py, self.cell, self.cell, COLOR_WATER)
+            if self.cell >= 6:
+                center = px + self.cell // 2
+                base = py + self.cell - 3
+                self.draw._fill_rectangle(
+                    center - 2,
+                    py + 4,
+                    4,
+                    self.cell - 7,
+                    COLOR_CORAL,
+                )
+                self.draw._fill_rectangle(
+                    px + 4,
+                    py + self.cell // 2,
+                    self.cell - 8,
+                    4,
+                    COLOR_CORAL,
+                )
+                branch = 2 if (x + y) % 2 else -2
+                self.draw._line(
+                    center,
+                    py + self.cell // 2,
+                    center + branch,
+                    py + 3,
+                    TFT_ORANGE,
+                )
+                self.draw._line(
+                    px + 3,
+                    base,
+                    px + self.cell - 4,
+                    base,
+                    COLOR_REEF,
+                )
+
+    def _draw_powerup(self, powerup):
+        px, py = self._tile_box(powerup[0], powerup[1])
+        pad = max(2, self.cell // 5)
+        self.draw._fill_rectangle(
+            px + pad,
+            py + pad,
+            self.cell - pad * 2,
+            self.cell - pad * 2,
+            COLOR_POWER,
+        )
+        if self.cell >= 12:
+            label = "B" if powerup[2] == POWER_BOMB else "F"
+            tx = px + (self.cell - self.draw.len(label, 0)) // 2
+            ty = py + (self.cell - 8) // 2
+            self.draw._text(tx, ty, label, TFT_BLACK, 0)
+
+    def _draw_bomb(self, bomb, animation_time):
+        px, py = self._tile_box(bomb[0], bomb[1])
+        cx = px + self.cell // 2
+        cy = py + self.cell // 2 + 1
+        frame = (animation_time // 120) % 4
+        radius = max(1, self.cell // 3 + (1 if frame in (1, 2) else 0))
+        self.draw._fill_circle(cx, cy, radius, TFT_BLACK)
+        if self.cell >= 8:
+            enemy_bomb = len(bomb) >= 5 and bomb[4] == 1
+            self.draw._circle(
+                cx,
+                cy,
+                radius,
+                TFT_RED if enemy_bomb else TFT_DARKGREY,
+            )
+            self.draw._fill_circle(
+                cx - max(1, radius // 3),
+                cy - max(1, radius // 3),
+                max(1, radius // 4),
+                TFT_WHITE,
+            )
+            self.draw._line(cx + radius // 2, cy - radius, cx + radius, cy - radius - 3, TFT_ORANGE)
+            spark_x = cx + radius + (frame % 2)
+            spark_y = cy - radius - 3 - (frame // 2)
+            self.draw._fill_rectangle(
+                spark_x,
+                spark_y,
+                2,
+                2,
+                TFT_RED if enemy_bomb else TFT_YELLOW,
+            )
+
+    def _draw_flame(self, flame):
+        px, py = self._tile_box(flame[0], flame[1])
+        center = self.cell // 2
+        arm = max(1, self.cell // 4)
+        self.draw._fill_rectangle(px, py + center - arm, self.cell, arm * 2, TFT_ORANGE)
+        self.draw._fill_rectangle(px + center - arm, py, arm * 2, self.cell, TFT_ORANGE)
+        inner = max(1, arm // 2)
+        self.draw._fill_rectangle(
+            px + inner,
+            py + center - inner,
+            self.cell - inner * 2,
+            inner * 2,
+            TFT_YELLOW,
+        )
+        self.draw._fill_rectangle(
+            px + center - inner,
+            py + inner,
+            inner * 2,
+            self.cell - inner * 2,
+            TFT_YELLOW,
+        )
+
+    def _draw_player(self, game):
+        px, py = self._fixed_box(game.player_draw_x, game.player_draw_y)
+        frame = (game.animation_time // 110 + game.player_frame) % 4
+        color = COLOR_PLAYER
+        if (
+            ticks_diff(game.invulnerable_until, game.animation_time) > 0
+            and frame % 2
+        ):
+            color = TFT_WHITE
+
+        if self.cell < 12:
+            pad = max(1, self.cell // 6)
+            self.draw._fill_rectangle(
+                px + pad,
+                py + pad,
+                self.cell - pad * 2,
+                self.cell - pad * 2,
+                color,
+            )
+            return
+
+        bob = 1 if frame in (1, 3) else 0
+        pad = max(2, self.cell // 5)
+        body_w = self.cell - pad * 2
+        helmet_y = py + 2 + bob
+        helmet_h = max(7, self.cell // 2)
+
+        # Helmet and visor.
+        self.draw._fill_rectangle(
+            px + pad + 2,
+            helmet_y,
+            body_w - 4,
+            2,
+            color,
+        )
+        self.draw._fill_rectangle(
+            px + pad,
+            helmet_y + 2,
+            body_w,
+            helmet_h - 2,
+            color,
+        )
+        visor_x = px + pad + 2
+        visor_y = helmet_y + 4
+        visor_w = max(4, body_w - 4)
+        self.draw._fill_rectangle(visor_x, visor_y, visor_w, 4, COLOR_VISOR)
+
+        # Directional visor detail makes facing readable.
+        if game.player_facing == 1:
+            self.draw._fill_rectangle(visor_x + 1, visor_y + 1, 2, 2, TFT_WHITE)
+        elif game.player_facing == 2:
+            self.draw._fill_rectangle(
+                visor_x + visor_w - 3,
+                visor_y + 1,
+                2,
+                2,
+                TFT_WHITE,
+            )
+        elif game.player_facing == 3:
+            self.draw._line(
+                visor_x + 2,
+                visor_y + 1,
+                visor_x + visor_w - 3,
+                visor_y + 1,
+                TFT_WHITE,
+            )
+        else:
+            self.draw._fill_rectangle(visor_x + 2, visor_y + 1, 2, 2, TFT_WHITE)
+            self.draw._fill_rectangle(
+                visor_x + visor_w - 4,
+                visor_y + 1,
+                2,
+                2,
+                TFT_WHITE,
+            )
+
+        # Suit, arms, and alternating legs provide the four-step cycle.
+        torso_y = helmet_y + helmet_h
+        torso_w = max(4, body_w - 4)
+        self.draw._fill_rectangle(
+            px + pad + 2,
+            torso_y,
+            torso_w,
+            max(3, self.cell // 5),
+            COLOR_PLAYER_DARK,
+        )
+        self.draw._fill_rectangle(px + pad, torso_y + 1, 2, 4, color)
+        self.draw._fill_rectangle(px + self.cell - pad - 2, torso_y + 1, 2, 4, color)
+
+        leg_y = min(py + self.cell - 5, torso_y + max(3, self.cell // 5))
+        leg_w = max(2, torso_w // 3)
+        left_step = 2 if frame == 1 else 0
+        right_step = 2 if frame == 3 else 0
+        self.draw._fill_rectangle(
+            px + pad + 2,
+            leg_y + left_step,
+            leg_w,
+            max(2, 4 - left_step),
+            color,
+        )
+        self.draw._fill_rectangle(
+            px + self.cell - pad - 2 - leg_w,
+            leg_y + right_step,
+            leg_w,
+            max(2, 4 - right_step),
+            color,
+        )
+
+    def _enemy_colors(self, kind, theme, elite):
+        if elite:
+            return COLOR_GOLD, TFT_WHITE
+        if kind == ENEMY_BOMBER:
+            accent = (
+                COLOR_MOSS
+                if theme == THEME_NATURE
+                else COLOR_STEEL_LIGHT
+                if theme == THEME_INDUSTRIAL
+                else TFT_CYAN
+            )
+            return TFT_RED, accent
+        if kind == 0:
+            if theme == THEME_NATURE:
+                return COLOR_PURPLE, COLOR_GRASS_LIGHT
+            if theme == THEME_INDUSTRIAL:
+                return COLOR_COOLANT, TFT_CYAN
+            return COLOR_INK, COLOR_WAVE
+        if theme == THEME_NATURE:
+            return TFT_YELLOW, TFT_ORANGE
+        if theme == THEME_INDUSTRIAL:
+            return COLOR_RUST, TFT_LIGHTGREY
+        return COLOR_FOAM, TFT_CYAN
+
+    def _draw_blob_enemy(self, px, py, frame, theme, elite):
+        color, accent = self._enemy_colors(0, theme, elite)
+        pad = max(2, self.cell // 6)
+        squat = 2 if frame in (1, 3) else 0
+        side = 0 if squat == 0 else 1
+        x = px + pad - side
+        y = py + pad + squat
+        width = self.cell - pad * 2 + side * 2
+        height = self.cell - pad * 2 - squat
+        self.draw._fill_rectangle(x + 2, y, width - 4, 2, color)
+        self.draw._fill_rectangle(x, y + 2, width, height - 4, color)
+        self.draw._fill_rectangle(x + 2, y + height - 2, width - 4, 2, color)
+        if self.cell >= 12:
+            eye_y = y + 4
+            blink = frame == 2
+            eye_h = 1 if blink else 3
+            self.draw._fill_rectangle(x + 3, eye_y, 3, eye_h, TFT_WHITE)
+            self.draw._fill_rectangle(x + width - 6, eye_y, 3, eye_h, TFT_WHITE)
+            if theme == THEME_INDUSTRIAL and not elite:
+                self.draw._line(
+                    x + 2,
+                    y + height // 2,
+                    x + width - 3,
+                    y + height // 2,
+                    accent,
+                )
+            elif theme == THEME_WATER and not elite:
+                self.draw._circle(x + width // 2, y + height - 5, 2, accent)
+            foot_y = y + height - 2
+            if frame in (0, 2):
+                self.draw._fill_rectangle(x, foot_y, 4, 2, color)
+                self.draw._fill_rectangle(x + width - 4, foot_y, 4, 2, color)
+            else:
+                self.draw._fill_rectangle(x + 3, foot_y, 4, 2, color)
+                self.draw._fill_rectangle(x + width - 7, foot_y, 4, 2, color)
+            if elite:
+                self._draw_elite_mark(px, py)
+
+    def _draw_chaser_enemy(self, px, py, frame, facing, theme, elite):
+        color, accent = self._enemy_colors(1, theme, elite)
+        bob = (0, 1, 0, -1)[frame]
+        cx = px + self.cell // 2
+        cy = py + self.cell // 2 - 1 + bob
+        radius = max(3, self.cell // 3)
+        self.draw._fill_circle(cx, cy, radius, color)
+        self.draw._fill_rectangle(
+            cx - radius,
+            cy,
+            radius * 2 + 1,
+            radius,
+            color,
+        )
+        eye_y = cy - 2
+        eye_x = cx
+        if facing == 1:
+            eye_x -= 2
+        elif facing == 2:
+            eye_x += 2
+        elif facing == 3:
+            eye_y -= 1
+        self.draw._fill_rectangle(eye_x - 2, eye_y - 1, 4, 4, TFT_WHITE)
+        self.draw._fill_rectangle(eye_x, eye_y, 2, 2, TFT_BLACK)
+        if theme == THEME_INDUSTRIAL and not elite:
+            self.draw._line(
+                cx - radius + 2,
+                cy + 2,
+                cx + radius - 2,
+                cy + 2,
+                accent,
+            )
+        elif theme == THEME_WATER and not elite:
+            self.draw._fill_rectangle(
+                cx - radius - 2,
+                cy - 1,
+                2,
+                2,
+                accent,
+            )
+            self.draw._fill_rectangle(
+                cx + radius + 1,
+                cy - 1,
+                2,
+                2,
+                accent,
+            )
+
+        foot_y = cy + radius - 1
+        shift = 2 if frame in (1, 3) else 0
+        self.draw._fill_rectangle(cx - radius, foot_y, 4 + shift, 3, color)
+        self.draw._fill_rectangle(
+            cx + radius - 4 - shift,
+            foot_y,
+            4 + shift,
+            3,
+            color,
+        )
+        if elite:
+            self._draw_elite_mark(px, py)
+
+    def _draw_rival_enemy(self, px, py, frame, facing, theme, elite):
+        color, accent = self._enemy_colors(ENEMY_BOMBER, theme, elite)
+        bob = 1 if frame in (1, 3) else 0
+        pad = max(2, self.cell // 5)
+        helmet_y = py + 3 + bob
+        width = self.cell - pad * 2
+        helmet_h = max(7, self.cell // 2)
+        self.draw._fill_rectangle(
+            px + pad + 2,
+            helmet_y,
+            width - 4,
+            2,
+            color,
+        )
+        self.draw._fill_rectangle(
+            px + pad,
+            helmet_y + 2,
+            width,
+            helmet_h - 2,
+            color,
+        )
+        visor_x = px + pad + 2
+        visor_y = helmet_y + 4
+        visor_w = max(4, width - 4)
+        self.draw._fill_rectangle(visor_x, visor_y, visor_w, 4, TFT_BLACK)
+        glint_x = (
+            visor_x + 1
+            if facing == 1
+            else visor_x + visor_w - 3
+            if facing == 2
+            else visor_x + visor_w // 2 - 1
+        )
+        self.draw._fill_rectangle(glint_x, visor_y + 1, 2, 2, TFT_CYAN)
+
+        torso_y = helmet_y + helmet_h
+        self.draw._fill_rectangle(
+            px + pad + 2,
+            torso_y,
+            max(4, width - 4),
+            4,
+            COLOR_RUST if not elite else COLOR_GOLD,
+        )
+        self.draw._fill_rectangle(px + pad - 1, torso_y, 3, 5, color)
+        self.draw._fill_rectangle(px + self.cell - pad - 2, torso_y, 3, 5, color)
+        self.draw._fill_rectangle(
+            px + self.cell - pad - 1,
+            helmet_y + helmet_h - 3,
+            3,
+            5,
+            TFT_BLACK,
+        )
+        self.draw._fill_rectangle(
+            px + self.cell - pad,
+            helmet_y + helmet_h - 2,
+            1,
+            1,
+            accent,
+        )
+
+        leg_y = min(py + self.cell - 4, torso_y + 4)
+        left_step = 2 if frame == 1 else 0
+        right_step = 2 if frame == 3 else 0
+        self.draw._fill_rectangle(
+            px + pad + 2,
+            leg_y + left_step,
+            3,
+            max(2, 4 - left_step),
+            color,
+        )
+        self.draw._fill_rectangle(
+            px + self.cell - pad - 5,
+            leg_y + right_step,
+            3,
+            max(2, 4 - right_step),
+            color,
+        )
+        if elite:
+            self._draw_elite_mark(px, py)
+
+    def _draw_elite_mark(self, px, py):
+        cx = px + self.cell // 2
+        top = py + 1
+        self.draw._line(cx - 4, top + 3, cx - 2, top, COLOR_GOLD)
+        self.draw._line(cx - 2, top, cx, top + 3, COLOR_GOLD)
+        self.draw._line(cx, top + 3, cx + 2, top, COLOR_GOLD)
+        self.draw._line(cx + 2, top, cx + 4, top + 3, COLOR_GOLD)
+        self.draw._line(cx - 4, top + 3, cx + 4, top + 3, TFT_WHITE)
+
+    def _draw_enemy(self, enemy, animation_time, theme):
+        px, py = self._fixed_box(enemy[6], enemy[7])
+        frame = (animation_time // 120 + enemy[4] + enemy[0] + enemy[1]) % 4
+        elite = enemy[8]
+        if self.cell < 12:
+            pad = max(1, self.cell // 6)
+            color, accent = self._enemy_colors(enemy[3], theme, elite)
+            self.draw._fill_rectangle(
+                px + pad,
+                py + pad,
+                self.cell - pad * 2,
+                self.cell - pad * 2,
+                color,
+            )
+            if elite:
+                self.draw._rectangle(
+                    px + pad,
+                    py + pad,
+                    self.cell - pad * 2,
+                    self.cell - pad * 2,
+                    accent,
+                )
+        elif enemy[3] == ENEMY_BOMBER:
+            self._draw_rival_enemy(
+                px,
+                py,
+                frame,
+                enemy[5],
+                theme,
+                elite,
+            )
+        elif enemy[3] == 0:
+            self._draw_blob_enemy(px, py, frame, theme, elite)
+        else:
+            self._draw_chaser_enemy(px, py, frame, enemy[5], theme, elite)
+
+    def _draw_decal(self, decal):
+        px, py = self._fixed_box(decal[0], decal[1])
+        kind = decal[2]
+        theme = decal[3]
+        variant = decal[4]
+        cx = px + self.cell // 2
+        cy = py + self.cell // 2
+        radius = max(2, self.cell // 4)
+
+        if kind == DECAL_SCORCH:
+            color = (
+                COLOR_WOOD_DARK
+                if theme == THEME_NATURE
+                else TFT_BLACK
+                if theme == THEME_INDUSTRIAL
+                else COLOR_WATER_DARK
+            )
+            self.draw._fill_circle(cx, cy, radius + variant % 2, color)
+            self.draw._line(
+                cx - radius,
+                cy + variant % 3 - 1,
+                cx + radius,
+                cy - variant % 2,
+                TFT_DARKGREY if theme != THEME_WATER else COLOR_WAVE,
+            )
+            return
+
+        if kind == DECAL_DEBRIS:
+            color = (
+                COLOR_WOOD
+                if theme == THEME_NATURE
+                else COLOR_STEEL_LIGHT
+                if theme == THEME_INDUSTRIAL
+                else COLOR_CORAL
+            )
+            accent = (
+                COLOR_WOOD_DARK
+                if theme == THEME_NATURE
+                else COLOR_RUST
+                if theme == THEME_INDUSTRIAL
+                else COLOR_REEF
+            )
+            self.draw._fill_rectangle(px + 3, cy - 1, 4, 2, color)
+            self.draw._fill_rectangle(cx + 2, py + 4, 3, 3, accent)
+            self.draw._line(
+                cx - 2,
+                cy + 2,
+                cx + 4,
+                cy + 4,
+                color,
+            )
+            return
+
+        if kind == DECAL_ELITE:
+            self.draw._fill_circle(cx, cy, radius + 2, COLOR_GOLD)
+            self.draw._fill_circle(cx, cy, max(1, radius - 1), TFT_BLACK)
+            self.draw._line(cx - radius, cy, cx + radius, cy, TFT_WHITE)
+            self.draw._line(cx, cy - radius, cx, cy + radius, TFT_WHITE)
+            return
+
+        if kind == DECAL_BLOB:
+            color = (
+                COLOR_PURPLE
+                if theme == THEME_NATURE
+                else COLOR_COOLANT
+                if theme == THEME_INDUSTRIAL
+                else COLOR_INK
+            )
+            accent = (
+                COLOR_GRASS_LIGHT
+                if theme == THEME_NATURE
+                else TFT_CYAN
+                if theme == THEME_INDUSTRIAL
+                else COLOR_WAVE
+            )
+            self.draw._fill_circle(cx, cy, radius + variant % 2, color)
+            self.draw._fill_circle(cx - radius, cy + 2, max(1, radius // 2), color)
+            self.draw._fill_circle(cx + radius, cy - 1, max(1, radius // 2), color)
+            self.draw._fill_rectangle(cx - 1, cy - 1, 2, 2, accent)
+            return
+
+        if kind == DECAL_BOMBER:
+            self.draw._fill_circle(cx, cy, radius + 1, COLOR_RUST)
+            self.draw._fill_circle(cx, cy, max(1, radius - 2), TFT_BLACK)
+            self.draw._line(
+                cx - radius - 1,
+                cy - radius,
+                cx + radius + 1,
+                cy + radius,
+                TFT_RED,
+            )
+            self.draw._line(
+                cx + radius + 1,
+                cy - radius,
+                cx - radius - 1,
+                cy + radius,
+                TFT_RED,
+            )
+            return
+
+        color = (
+            TFT_ORANGE
+            if theme == THEME_NATURE
+            else COLOR_RUST
+            if theme == THEME_INDUSTRIAL
+            else COLOR_FOAM
+        )
+        accent = (
+            COLOR_MOSS
+            if theme == THEME_NATURE
+            else TFT_LIGHTGREY
+            if theme == THEME_INDUSTRIAL
+            else TFT_CYAN
+        )
+        self.draw._circle(cx, cy, radius + 1, color)
+        self.draw._circle(cx, cy, max(1, radius - 2), accent)
+        self.draw._fill_rectangle(cx - radius - 2, cy - 1, 3, 2, color)
+        self.draw._fill_rectangle(cx + radius, cy + 1, 3, 2, color)
+
+    def _draw_death(self, effect, animation_time, theme):
+        px, py = self._fixed_box(effect[0], effect[1])
+        elapsed = max(0, ticks_diff(animation_time, effect[3]))
+        frame = min(4, elapsed * 5 // DEATH_ANIMATION_MS)
+        cx = px + self.cell // 2
+        cy = py + self.cell // 2
+
+        if effect[2] == DEATH_PLAYER:
+            color = COLOR_PLAYER
+        elif effect[2] == DEATH_ENEMY_BLOB:
+            color = self._enemy_colors(0, theme, False)[0]
+        elif effect[2] == DEATH_ENEMY_ELITE:
+            color = COLOR_GOLD
+        elif effect[2] == DEATH_ENEMY_BOMBER:
+            color = TFT_RED
+        else:
+            color = self._enemy_colors(1, theme, False)[0]
+
+        radius = max(2, self.cell // 3)
+        if frame == 0:
+            self.draw._fill_circle(cx, cy, radius, TFT_WHITE)
+        else:
+            core_radius = max(1, radius - frame * 2)
+            self.draw._fill_circle(cx, cy, core_radius, color)
+
+        step = max(2, self.cell // 6)
+        distance = step * (frame + 1)
+        particle_size = 4 if frame == 0 else 3 if frame <= 3 else 2
+        seed = (
+            effect[0] // POSITION_SCALE * 3
+            + effect[1] // POSITION_SCALE * 5
+            + effect[2]
+        )
+        for index in range(len(PARTICLE_DIRECTIONS)):
+            dx, dy = PARTICLE_DIRECTIONS[index]
+            jitter = (seed + index * 7) % 3 - 1
+            particle_x = cx + dx * distance
+            particle_y = cy + dy * distance
+            if dx == 0:
+                particle_x += jitter
+            if dy == 0:
+                particle_y += jitter
+            particle_color = (
+                TFT_WHITE
+                if frame <= 1 and index % 3 == 0
+                else TFT_YELLOW
+                if index % 2
+                else color
+            )
+            if 0 < frame < 4 and index % 2 == 0:
+                self.draw._line(
+                    cx + dx * max(1, distance - step),
+                    cy + dy * max(1, distance - step),
+                    particle_x,
+                    particle_y,
+                    particle_color,
+                )
+            self.draw._fill_rectangle(
+                particle_x - particle_size // 2,
+                particle_y - particle_size // 2,
+                particle_size,
+                particle_size,
+                particle_color,
+            )
+
+    def _draw_overlay(self, title, subtitle, title_color):
+        box_w = min(self.width - 16, 250)
+        box_h = 70
+        x = (self.width - box_w) // 2
+        y = (self.height - box_h) // 2
+        self.draw._fill_rectangle(x, y, box_w, box_h, TFT_BLACK)
+        self.draw._rectangle(x, y, box_w, box_h, title_color)
+        self._center_text(title, y + 12, title_color, 2)
+        self._center_text(subtitle, y + 44, TFT_WHITE, 0)
+
+    def draw_frame(self, game):
+        """Render the current model state and present the framebuffer."""
+        if game.state == STATE_TITLE:
+            self._draw_title()
+            self.draw.swap()
+            return
+        if game.state == STATE_MODE_SELECT:
+            self._draw_mode_menu(game)
+            self.draw.swap()
+            return
+        if game.state == STATE_LEADERBOARD:
+            self._draw_leaderboard(game)
+            self.draw.swap()
+            return
+
+        background = (
+            COLOR_GRASS
+            if game.theme == THEME_NATURE
+            else COLOR_FACTORY_FLOOR
+            if game.theme == THEME_INDUSTRIAL
+            else COLOR_WATER_DARK
+        )
+        self.draw.fill_screen(background)
+        self._draw_hud(game)
+
+        for y in range(GRID_HEIGHT):
+            for x in range(GRID_WIDTH):
+                px, py = self._tile_box(x, y)
+                tile = game.grid[y][x]
+                if tile == TILE_SOLID:
+                    self._draw_solid(px, py, x, y, game.theme)
+                elif tile == TILE_BRICK:
+                    self._draw_brick(px, py, x, y, game.theme)
+                else:
+                    self._draw_floor(
+                        px,
+                        py,
+                        x,
+                        y,
+                        game.theme,
+                        game.animation_time,
+                    )
+
+        for decal in game.decals:
+            self._draw_decal(decal)
+        for powerup in game.powerups:
+            self._draw_powerup(powerup)
+        for bomb in game.bombs:
+            self._draw_bomb(bomb, game.animation_time)
+        for enemy in game.enemies:
+            self._draw_enemy(enemy, game.animation_time, game.theme)
+        if game.state not in (STATE_PLAYER_DYING, STATE_GAME_OVER):
+            self._draw_player(game)
+        for flame in game.explosions:
+            self._draw_flame(flame)
+        for effect in game.death_effects:
+            self._draw_death(effect, game.animation_time, game.theme)
+
+        if game.state == STATE_STAGE_INTRO:
+            theme_color = (
+                TFT_GREEN
+                if game.theme == THEME_NATURE
+                else TFT_YELLOW
+                if game.theme == THEME_INDUSTRIAL
+                else TFT_CYAN
+            )
+            self._draw_overlay(
+                THEME_NAMES[game.theme],
+                "STAGE %d - %s" % (game.stage, MODE_NAMES[game.mode]),
+                theme_color,
+            )
+        elif game.state == STATE_STAGE_CLEAR:
+            self._draw_overlay("STAGE CLEAR", "+250 BONUS", TFT_GREEN)
+        elif game.state == STATE_GAME_OVER:
+            self._draw_overlay("GAME OVER", "CENTER FOR MODES", TFT_RED)
+
+        self.draw.swap()


### PR DESCRIPTION
## Summary

- add Pico Bomber as a modular MicroPython game with a Picoware launcher
- provide Ghost Hunt and Blast Rivals modes with animated enemies, bombs, explosions, particles, and death effects
- add randomized Nature, Industrial, and Water stages with themed props and persistent battle decals
- add smooth tile movement, visible blast damage, elite enemies, rival bombers, and local top-five leaderboard persistence
- run the game at 230 MHz while active and restore the board default frequency when exiting

## Validation

- exercised in the Picoware simulator
- deployed and played on PicoCalc hardware
- verified the source-only branch contains no tests or compiled MPY artifacts