### PR TITLE
Add player names and stabilize Pico Bomber startup

### DIFF
--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -37,6 +37,7 @@ _leaderboard = None
 _next_frame = 0
 _score_saved = False
 _frequency_changed = False
+_frequency_pending = False
 _mode_start_pending = False
 FRAME_MS = 50
 GAME_CPU_FREQUENCY = 230000000
@@ -45,7 +46,27 @@ GAME_CPU_FREQUENCY = 230000000
 def _thread_idle(view_manager):
     """Return whether changing the global CPU clock is currently safe."""
     thread_manager = getattr(view_manager, "thread_manager", None)
-    return thread_manager is None or thread_manager.thread is None
+    if thread_manager is None:
+        return True
+    public_idle = getattr(thread_manager, "is_idle", None)
+    if public_idle is not None:
+        return bool(public_idle)
+    return (
+        getattr(thread_manager, "thread", None) is None
+        and not getattr(thread_manager, "_tasks", ())
+    )
+
+
+def _try_game_frequency(view_manager):
+    """Apply the game clock once inherited background work has drained."""
+    global _frequency_changed, _frequency_pending
+
+    if not _frequency_pending or not _thread_idle(view_manager):
+        return False
+    view_manager.freq(False, GAME_CPU_FREQUENCY)
+    _frequency_changed = True
+    _frequency_pending = False
+    return True
 
 
 def _log_mode_start_error(view_manager, phase, error):
@@ -78,15 +99,17 @@ def _submit_name(name):
 
 def _handle_name_input(input_manager, button):
     """Edit a short arcade name using the physical keyboard."""
-    if button == BUTTON_BACK:
-        _submit_name(DEFAULT_NAME)
-        return True
+    if button < 0:
+        return False
     if button in (BUTTON_CENTER, BUTTON_ENTER):
         _submit_name(_game.player_name)
         return True
-    if button in (BUTTON_BACKSPACE, BUTTON_DELETE):
+    if button in (BUTTON_BACK, BUTTON_BACKSPACE, BUTTON_DELETE):
         if _game.player_name:
             _game.player_name = _game.player_name[:-1]
+            return True
+        if button == BUTTON_BACK:
+            _submit_name(DEFAULT_NAME)
             return True
         return False
     if len(_game.player_name) >= MAX_NAME_LENGTH:
@@ -106,13 +129,12 @@ def _handle_name_input(input_manager, button):
 def start(view_manager):
     """Create a fresh Pico Bomber title screen."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
-    global _frequency_changed, _mode_start_pending
+    global _frequency_changed, _frequency_pending, _mode_start_pending
 
     _frequency_changed = False
+    _frequency_pending = True
     _mode_start_pending = False
-    if _thread_idle(view_manager):
-        view_manager.freq(False, GAME_CPU_FREQUENCY)
-        _frequency_changed = True
+    _try_game_frequency(view_manager)
     _game = GameModel()
     _renderer = Renderer(view_manager.draw)
     _leaderboard = Leaderboard(view_manager.storage)
@@ -130,15 +152,17 @@ def run(view_manager):
     if _game is None or _renderer is None:
         return
 
+    _try_game_frequency(view_manager)
     input_manager = view_manager.input_manager
     button = view_manager.button
     now = ticks_ms()
     changed = False
 
     if _game.state == STATE_NAME_ENTRY:
+        if button < 0:
+            return
         changed = _handle_name_input(input_manager, button)
-        if button >= 0:
-            input_manager.reset()
+        input_manager.reset()
         if changed:
             _renderer.draw_frame(_game)
         return
@@ -228,15 +252,16 @@ def run(view_manager):
 def stop(view_manager):
     """Release the game state when leaving the Picoware view."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
-    global _frequency_changed, _mode_start_pending
+    global _frequency_changed, _frequency_pending, _mode_start_pending
 
     _game = None
     _renderer = None
     _leaderboard = None
     _next_frame = 0
     _score_saved = False
+    _frequency_pending = False
     _mode_start_pending = False
-    if _frequency_changed and _thread_idle(view_manager):
+    if _frequency_changed:
         view_manager.freq()
     _frequency_changed = False
     collect()

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -5,20 +5,24 @@ from utime import ticks_add, ticks_diff, ticks_ms
 
 from picoware.system.buttons import (
     BUTTON_BACK,
+    BUTTON_BACKSPACE,
     BUTTON_CENTER,
+    BUTTON_DELETE,
     BUTTON_DOWN,
+    BUTTON_ENTER,
     BUTTON_LEFT,
     BUTTON_RIGHT,
     BUTTON_SPACE,
     BUTTON_UP,
 )
 
-from .leaderboard import Leaderboard
+from .leaderboard import DEFAULT_NAME, MAX_NAME_LENGTH, Leaderboard
 from .model import (
     MENU_LEADERBOARD,
     STATE_GAME_OVER,
     STATE_LEADERBOARD,
     STATE_MODE_SELECT,
+    STATE_NAME_ENTRY,
     STATE_PLAYER_DYING,
     STATE_PLAYING,
     STATE_TITLE,
@@ -33,6 +37,7 @@ _leaderboard = None
 _next_frame = 0
 _score_saved = False
 _frequency_changed = False
+_mode_start_pending = False
 FRAME_MS = 50
 GAME_CPU_FREQUENCY = 230000000
 
@@ -43,12 +48,68 @@ def _thread_idle(view_manager):
     return thread_manager is None or thread_manager.thread is None
 
 
+def _log_mode_start_error(view_manager, phase, error):
+    """Record the failing cold-start phase without replacing the exception."""
+    try:
+        view_manager.log(
+            "[Pico Bomber] mode-start %s: %r" % (phase, error),
+            2,
+        )
+    except Exception:
+        pass
+
+
+def _submit_name(name):
+    """Save the finished score and return to the game-over screen."""
+    global _score_saved
+
+    clean_name = Leaderboard.clean_name(name)
+    _leaderboard.submit(
+        _game.score,
+        _game.stage,
+        _game.mode,
+        clean_name,
+    )
+    _game.player_name = clean_name
+    _game.leaderboard = _leaderboard.entries
+    _game.state = STATE_GAME_OVER
+    _score_saved = True
+
+
+def _handle_name_input(input_manager, button):
+    """Edit a short arcade name using the physical keyboard."""
+    if button == BUTTON_BACK:
+        _submit_name(DEFAULT_NAME)
+        return True
+    if button in (BUTTON_CENTER, BUTTON_ENTER):
+        _submit_name(_game.player_name)
+        return True
+    if button in (BUTTON_BACKSPACE, BUTTON_DELETE):
+        if _game.player_name:
+            _game.player_name = _game.player_name[:-1]
+            return True
+        return False
+    if len(_game.player_name) >= MAX_NAME_LENGTH:
+        return False
+
+    char = input_manager.button_to_char(button).upper()
+    if len(char) == 1 and (
+        "A" <= char <= "Z"
+        or "0" <= char <= "9"
+        or char in (" ", "-", "_")
+    ):
+        _game.player_name += char
+        return True
+    return False
+
+
 def start(view_manager):
     """Create a fresh Pico Bomber title screen."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
-    global _frequency_changed
+    global _frequency_changed, _mode_start_pending
 
     _frequency_changed = False
+    _mode_start_pending = False
     if _thread_idle(view_manager):
         view_manager.freq(False, GAME_CPU_FREQUENCY)
         _frequency_changed = True
@@ -64,15 +125,23 @@ def start(view_manager):
 
 def run(view_manager):
     """Handle one Picoware input/update/render cycle."""
-    global _next_frame, _score_saved
+    global _next_frame, _score_saved, _mode_start_pending
 
     if _game is None or _renderer is None:
         return
 
     input_manager = view_manager.input_manager
-    button = input_manager.button
+    button = view_manager.button
     now = ticks_ms()
     changed = False
+
+    if _game.state == STATE_NAME_ENTRY:
+        changed = _handle_name_input(input_manager, button)
+        if button >= 0:
+            input_manager.reset()
+        if changed:
+            _renderer.draw_frame(_game)
+        return
 
     if button == BUTTON_BACK:
         input_manager.reset()
@@ -110,7 +179,13 @@ def run(view_manager):
             if _game.menu_selection == MENU_LEADERBOARD:
                 _game.state = STATE_LEADERBOARD
             else:
-                _game.new_game(now, _game.menu_selection)
+                _mode_start_pending = True
+                try:
+                    _game.new_game(now, _game.menu_selection)
+                except Exception as error:
+                    _log_mode_start_error(view_manager, "stage-build", error)
+                    _mode_start_pending = False
+                    raise
                 _score_saved = False
             changed = True
         else:
@@ -119,31 +194,48 @@ def run(view_manager):
     if button >= 0:
         input_manager.reset()
 
-    if _game.update(now):
+    try:
+        updated = _game.update(now)
+    except Exception as error:
+        if _mode_start_pending:
+            _log_mode_start_error(view_manager, "first-update", error)
+            _mode_start_pending = False
+        raise
+    if updated:
         changed = True
 
     if _game.state == STATE_GAME_OVER and not _score_saved:
-        _leaderboard.submit(_game.score, _game.stage, _game.mode)
-        _game.leaderboard = _leaderboard.entries
-        _score_saved = True
+        if _leaderboard.qualifies(_game.score):
+            _game.player_name = ""
+            _game.state = STATE_NAME_ENTRY
+        else:
+            _score_saved = True
         changed = True
 
     animated = _game.state in (STATE_PLAYING, STATE_PLAYER_DYING)
     if changed or (animated and ticks_diff(now, _next_frame) >= 0):
-        _renderer.draw_frame(_game)
+        try:
+            _renderer.draw_frame(_game)
+        except Exception as error:
+            if _mode_start_pending:
+                _log_mode_start_error(view_manager, "first-render", error)
+                _mode_start_pending = False
+            raise
+        _mode_start_pending = False
         _next_frame = ticks_add(now, FRAME_MS)
 
 
 def stop(view_manager):
     """Release the game state when leaving the Picoware view."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
-    global _frequency_changed
+    global _frequency_changed, _mode_start_pending
 
     _game = None
     _renderer = None
     _leaderboard = None
     _next_frame = 0
     _score_saved = False
+    _mode_start_pending = False
     if _frequency_changed and _thread_idle(view_manager):
         view_manager.freq()
     _frequency_changed = False

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
@@ -8,6 +8,8 @@ except ImportError:
 
 LEADERBOARD_PATH = "/picoware/settings/pico_bomber_scores.json"
 MAX_SCORES = 5
+MAX_NAME_LENGTH = 10
+DEFAULT_NAME = "PLAYER"
 
 
 class Leaderboard:
@@ -32,10 +34,33 @@ class Leaderboard:
         )
 
     @staticmethod
+    def clean_name(name):
+        """Return a short arcade-safe leaderboard name."""
+        if not isinstance(name, str):
+            return DEFAULT_NAME
+        cleaned = ""
+        for char in name.strip().upper():
+            if (
+                "A" <= char <= "Z"
+                or "0" <= char <= "9"
+                or char in (" ", "-", "_")
+            ):
+                cleaned += char
+                if len(cleaned) >= MAX_NAME_LENGTH:
+                    break
+        return cleaned or DEFAULT_NAME
+
+    @staticmethod
     def _rank(entries):
         ranked = []
         for entry in entries:
-            item = [int(entry[0]), int(entry[1]), int(entry[2])]
+            name = entry[3] if len(entry) >= 4 else DEFAULT_NAME
+            item = [
+                int(entry[0]),
+                int(entry[1]),
+                int(entry[2]),
+                Leaderboard.clean_name(name),
+            ]
             inserted = False
             for index in range(len(ranked)):
                 if item[0] > ranked[index][0]:
@@ -66,8 +91,18 @@ class Leaderboard:
             self.entries = []
         return self.entries
 
-    def submit(self, score, stage, mode):
-        entry = [max(0, int(score)), max(1, int(stage)), int(mode)]
+    def qualifies(self, score):
+        """Return whether a score would enter the local top five."""
+        score = max(0, int(score))
+        return len(self.entries) < MAX_SCORES or score > self.entries[-1][0]
+
+    def submit(self, score, stage, mode, name=DEFAULT_NAME):
+        entry = [
+            max(0, int(score)),
+            max(1, int(stage)),
+            int(mode),
+            self.clean_name(name),
+        ]
         if not self._valid_entry(entry):
             return False
         previous = json.dumps(self.entries)

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
@@ -20,6 +20,18 @@ class Leaderboard:
         self.entries = []
         self.load()
 
+    def _ensure_mounted(self):
+        """Make raw SD access available after the app loader unmounts it."""
+        if self.storage is None:
+            return False
+        mount = getattr(self.storage, "mount", None)
+        if mount is None:
+            return True
+        try:
+            return bool(mount())
+        except Exception:
+            return False
+
     @staticmethod
     def _valid_entry(entry):
         return (
@@ -75,7 +87,7 @@ class Leaderboard:
 
     def load(self):
         self.entries = []
-        if self.storage is None:
+        if not self._ensure_mounted():
             return self.entries
         try:
             if not self.storage.exists(LEADERBOARD_PATH):
@@ -112,6 +124,8 @@ class Leaderboard:
             return False
         if self.storage is None:
             return True
+        if not self._ensure_mounted():
+            return False
         try:
             return bool(self.storage.write(LEADERBOARD_PATH, current, "w"))
         except Exception:

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/model.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/model.py
@@ -50,6 +50,7 @@ STATE_PLAYER_DYING = 4
 STATE_STAGE_INTRO = 5
 STATE_MODE_SELECT = 6
 STATE_LEADERBOARD = 7
+STATE_NAME_ENTRY = 8
 
 DEATH_PLAYER = 0
 DEATH_ENEMY_BLOB = 1
@@ -109,6 +110,7 @@ class GameModel:
         self.decals = []
         self.death_effects = []
         self.leaderboard = []
+        self.player_name = ""
         self.state = STATE_TITLE
         self.state_until = 0
         self.invulnerable_until = 0
@@ -141,6 +143,7 @@ class GameModel:
         self.lives = 3
         self.score = 0
         self.stage = 1
+        self.player_name = ""
         self.flame_range = 2
         self.bomb_limit = 1
         self._build_stage(now)

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
@@ -36,6 +36,7 @@ from .model import (
     STATE_GAME_OVER,
     STATE_LEADERBOARD,
     STATE_MODE_SELECT,
+    STATE_NAME_ENTRY,
     STATE_PLAYER_DYING,
     STATE_STAGE_CLEAR,
     STATE_STAGE_INTRO,
@@ -252,33 +253,32 @@ class Renderer:
                     TFT_YELLOW if index == 0 else TFT_DARKGREY,
                 )
                 mode = "GHOST" if entry[2] == 0 else "RIVALS"
+                name = entry[3] if len(entry) >= 4 else "PLAYER"
                 if compact:
                     text_y = y + max(2, (row_h - 8) // 2)
-                    draw._text(x + 5, text_y, "#%d" % (index + 1), TFT_YELLOW, 0)
-                    draw._text(x + 28, text_y, str(entry[0]), TFT_WHITE, 0)
-                    right = "%s S%d" % (
-                        "G" if entry[2] == 0 else "R",
-                        entry[1],
-                    )
+                    left = "#%d %s" % (index + 1, name[:5])
+                    draw._text(x + 5, text_y, left, TFT_YELLOW, 0)
+                    score = str(entry[0])
                     draw._text(
-                        x + box_w - draw.len(right, 0) - 5,
+                        x + box_w - draw.len(score, 0) - 5,
                         text_y,
-                        right,
-                        TFT_CYAN,
+                        score,
+                        TFT_WHITE,
                         0,
                     )
                 else:
                     draw._text(x + 8, y + 8, "#%d" % (index + 1), TFT_YELLOW, 1)
+                    draw._text(x + 42, y + 4, name, TFT_CYAN, 0)
                     draw._text(
                         x + 42,
-                        y + 8,
+                        y + 17,
                         "%06d" % entry[0],
                         TFT_WHITE,
-                        1,
+                        0,
                     )
-                    draw._text(x + 126, y + 5, mode, TFT_CYAN, 0)
+                    draw._text(x + 150, y + 5, mode, TFT_CYAN, 0)
                     draw._text(
-                        x + 126,
+                        x + 150,
                         y + 19,
                         "STAGE %d" % entry[1],
                         TFT_GREEN,
@@ -288,6 +288,57 @@ class Renderer:
             "CENTER/BACK  MODES",
             self.height - 16,
             TFT_LIGHTGREY,
+            0,
+        )
+
+    def _draw_name_entry(self, game):
+        draw = self.draw
+        draw.fill_screen(COLOR_ARENA)
+        compact = self.height < 200
+        self._center_text(
+            "NEW HIGH SCORE",
+            8 if compact else 22,
+            TFT_YELLOW,
+            1 if compact else 2,
+        )
+        self._center_text(
+            "%06d  STAGE %d" % (game.score, game.stage),
+            30 if compact else 62,
+            TFT_CYAN,
+            0 if compact else 1,
+        )
+        self._center_text(
+            "ENTER YOUR NAME",
+            48 if compact else 96,
+            TFT_WHITE,
+            0 if compact else 1,
+        )
+
+        box_w = min(self.width - 24, 260)
+        box_h = 32 if compact else 54
+        x = (self.width - box_w) // 2
+        y = 65 if compact else 128
+        draw._fill_rectangle(x, y, box_w, box_h, TFT_BLACK)
+        draw._rectangle(x, y, box_w, box_h, TFT_YELLOW)
+        name = game.player_name
+        display_name = name + ("_" if len(name) < 10 else "")
+        if not display_name:
+            display_name = "_"
+        text_size = 1 if compact else 2
+        text_x = max(x + 6, x + (box_w - draw.len(display_name, text_size)) // 2)
+        text_y = y + (8 if compact else 14)
+        draw._text(text_x, text_y, display_name, TFT_GREEN, text_size)
+
+        self._center_text(
+            "TYPE A-Z / 0-9  BACKSPACE",
+            min(self.height - 34, y + box_h + 18),
+            TFT_LIGHTGREY,
+            0,
+        )
+        self._center_text(
+            "ENTER SAVE   BACK DEFAULT",
+            min(self.height - 16, y + box_h + 36),
+            TFT_CYAN,
             0,
         )
 
@@ -1222,6 +1273,10 @@ class Renderer:
             return
         if game.state == STATE_LEADERBOARD:
             self._draw_leaderboard(game)
+            self.draw.swap()
+            return
+        if game.state == STATE_NAME_ENTRY:
+            self._draw_name_entry(game)
             self.draw.swap()
             return
 

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
@@ -330,13 +330,13 @@ class Renderer:
         draw._text(text_x, text_y, display_name, TFT_GREEN, text_size)
 
         self._center_text(
-            "TYPE A-Z / 0-9  BACKSPACE",
+            "TYPE A-Z / 0-9  BACK ERASE",
             min(self.height - 34, y + box_h + 18),
             TFT_LIGHTGREY,
             0,
         )
         self._center_text(
-            "ENTER SAVE   BACK DEFAULT",
+            "ENTER SAVE  EMPTY = PLAYER",
             min(self.height - 16, y + box_h + 36),
             TFT_CYAN,
             0,


### PR DESCRIPTION
## Summary

- prompt qualifying players for a 10-character arcade name before saving their score
- support physical keyboard typing, uppercase normalization, Backspace/Delete editing, and Enter save
- make Back erase an existing name and save the default PLAYER name only when the field is empty
- display player names alongside score, mode, and stage on the local top-five leaderboard
- migrate existing three-field leaderboard entries in memory with the default PLAYER name
- skip character conversion and rendering entirely on idle name-entry frames, preventing the observed input stall
- remount raw SD storage before leaderboard reads and writes after the app loader releases its VFS mount
- defer the 230 MHz game clock until active and queued background work drains, then restore the board default on exit
- retain phase-specific cold-start diagnostics while re-raising the original exception

## Validation

- focused migration, ranking, name-editing, persistence, clock-lifecycle, and diagnostic checks passed
- 5,000 idle name-entry cycles performed zero character conversions, resets, or redraws
- Back erase, empty-name PLAYER fallback, uppercase-before-reset, storage mount ordering, and frequency deferral probes passed
- complete headless Pico Bomber launch and mode-selection flow passed
- Picoware simulator self-check and simulator build check passed
- MicroPython bytecode compilation completed in `/tmp`
- source-only diff contains no tests or compiled MPY artifacts