### PR TITLE
Fix MicroPython background task lifecycle races

### DIFF
--- a/guides/Libraries.md
+++ b/guides/Libraries.md
@@ -473,21 +473,23 @@ All color constants are RGB565 format and defined as `micropython.const` integer
     - Slots: `args`, `error`, `function`, `_id`, `name`, `result`, `should_stop`, `start_time`, `timeout`.
 - `ThreadManager` class: Manages a queue of `ThreadTask` objects, running them sequentially.
     - `__init__()`: Initializes the task queue.
+    - `is_idle`: Property — True when no task is queued or active.
+    - `pending_count`: Property — number of queued tasks, excluding the active task.
     - `task`: Property — the currently active `ThreadTask`.
     - `thread`: Property — the underlying `Thread` object.
-    - `add_task(task)`: Add a `ThreadTask` to the queue.
-    - `remove_task(task_id)`: Remove a task from the queue by ID.
+    - `add_task(task)`: Add a `ThreadTask` to the queue and return its task ID.
+    - `remove_task(task_id)`: Cooperatively stop and remove a queued task by ID. Returns True when removed.
     - `run()`: Process the task queue — starts the next queued task if no task is running. Returns a log string.
 
 #### picoware-system-time
 - `Time` class: Manages the device RTC and optional NTP time synchronization.
     - `__init__(thread_manager=None)`: Creates a `machine.RTC()` instance. Accepts an optional `ThreadManager` for async NTP fetch.
     - `date`: Property — current date as a `"M/D/Y"` formatted string.
-    - `is_fetching`: Property — True if an NTP sync is currently in progress.
+    - `is_fetching`: Property — True if an NTP sync is queued or currently in progress.
     - `is_set`: Property — True if the time has been set (manually or via NTP).
     - `rtc`: Property — the underlying `machine.RTC` object.
     - `time`: Property — current time as an `"H:MM:SS"` formatted string.
-    - `fetch(offset=0)`: Synchronize the RTC with NTP (`pool.ntp.org`). `offset` is the UTC offset in hours. Uses `ThreadManager` if available. Returns True if started/successful.
+    - `fetch(offset=0)`: Synchronize the RTC with NTP (`pool.ntp.org`). `offset` is the UTC offset in hours. Uses `ThreadManager` if available. Returns True if started/successful. Failed requests use a 30-second retry cooldown.
     - `set(year, month, day, hour, minute, second)`: Manually set the RTC time.
 
 #### picoware-system-uart
@@ -1469,4 +1471,4 @@ All color constants are RGB565 format and defined as `micropython.const` integer
   - `initializeAsTree(pos, height)`: Initialize as tree
   - `initializeAsHouse(pos, width, height, rot)`: Initialize as house
   - `initializeAsPillar(pos, height, radius)`: Initialize as pillar
-  - `getTransformedTriangles(output_triangles, count, camera_pos)`: Get transformed triangles 
+  - `getTransformedTriangles(output_triangles, count, camera_pos)`: Get transformed triangles

--- a/src/MicroPython/picoware/applications/games.py
+++ b/src/MicroPython/picoware/applications/games.py
@@ -1,6 +1,68 @@
 _games = None
 _games_index = 0
 _app_loader = None
+_pending_game = None
+
+
+def _thread_idle(view_manager):
+    """Return whether an SD import can run without a background worker."""
+    thread_manager = getattr(view_manager, "thread_manager", None)
+    return thread_manager is None or thread_manager.is_idle
+
+
+def _launch_game(view_manager, game_index, selected_game):
+    """Load and switch to a selected game after background work drains."""
+    from picoware.system.view import View
+
+    if game_index == 0:
+        from picoware.applications import ghouls
+
+        ghouls_view_name = "game_ghouls"
+        if view_manager.get_view(ghouls_view_name) is None:
+            ghouls_view = View(
+                ghouls_view_name,
+                ghouls.run,
+                ghouls.start,
+                ghouls.stop,
+            )
+            view_manager.add(ghouls_view)
+        view_manager.switch_to(ghouls_view_name)
+        return
+
+    if not selected_game or not _app_loader:
+        return
+
+    game_module = _app_loader.load_app(selected_game, "games")
+    if game_module is None:
+        view_manager.alert('Failed to load game "{}".'.format(selected_game))
+        return
+
+    game_view_name = "game_{}".format(selected_game)
+    from utime import ticks_ms
+
+    start_time = ticks_ms()
+    if view_manager.get_view(game_view_name) is None:
+        game_view = View(
+            game_view_name,
+            game_module.run,
+            game_module.start,
+            game_module.stop,
+        )
+        view_manager.log(
+            "[Games]: Created view for app {} after {} ms".format(
+                selected_game,
+                ticks_ms() - start_time,
+            ),
+        )
+        view_manager.add(game_view)
+
+    view_manager.switch_to(game_view_name)
+    view_manager.log(
+        '[Games]: Switched to view for app "{}" after {} ms'.format(
+            selected_game,
+            ticks_ms() - start_time,
+        ),
+    )
 
 
 def start(view_manager) -> bool:
@@ -20,6 +82,9 @@ def start(view_manager) -> bool:
 
     global _games
     global _app_loader
+    global _pending_game
+
+    _pending_game = None
 
     if _app_loader:
         del _app_loader
@@ -55,7 +120,6 @@ def start(view_manager) -> bool:
 
 def run(view_manager) -> None:
     """Run the games app."""
-    from picoware.system.view import View
     from picoware.system.buttons import (
         BUTTON_BACK,
         BUTTON_UP,
@@ -66,11 +130,24 @@ def run(view_manager) -> None:
     )
 
     global _games_index
+    global _pending_game
 
     if not _games:
         return
 
     button: int = view_manager.button
+
+    if _pending_game is not None:
+        if button == BUTTON_BACK:
+            _pending_game = None
+            _games_index = 0
+            view_manager.back()
+            return
+        if _thread_idle(view_manager):
+            pending = _pending_game
+            _pending_game = None
+            _launch_game(view_manager, pending[0], pending[1])
+        return
 
     if button in (BUTTON_UP, BUTTON_LEFT):
         _games.scroll_up()
@@ -81,54 +158,15 @@ def run(view_manager) -> None:
         view_manager.back()
     elif button == BUTTON_CENTER:
         _games_index = _games.selected_index
-
-        if _games_index == 0:
-            # Start Ghouls
-            from picoware.applications import ghouls
-
-            ghouls_view_name = "game_ghouls"
-            if view_manager.get_view(ghouls_view_name) is None:
-                ghouls_view = View(
-                    ghouls_view_name,
-                    ghouls.run,
-                    ghouls.start,
-                    ghouls.stop,
-                )
-                view_manager.add(ghouls_view)
-            view_manager.switch_to(ghouls_view_name)
-            return
-
-        # Get the selected game name
         selected_game = _games.current_item
-
-        if selected_game and _app_loader:
-            # Try to load the game
-            game_module = _app_loader.load_app(selected_game, "games")
-            if game_module is None:
-                view_manager.alert(f'Failed to load game "{selected_game}".')
-                return
-            # Create a view for the game and switch to it
-            game_view_name = f"game_{selected_game}"
-            from utime import ticks_ms
-
-            start_time = ticks_ms()
-
-            # Check if view already exists
-            if view_manager.get_view(game_view_name) is None:
-                game_view = View(
-                    game_view_name,
-                    game_module.run,
-                    game_module.start,
-                    game_module.stop,
-                )
-                view_manager.log(
-                    f"[Games]: Created view for app {selected_game} after {ticks_ms() - start_time} ms",
-                )
-                view_manager.add(game_view)
-
-            view_manager.switch_to(game_view_name)
+        if _thread_idle(view_manager):
+            _launch_game(view_manager, _games_index, selected_game)
+        else:
+            _pending_game = (_games_index, selected_game)
             view_manager.log(
-                f'[Games]: Switched to view for app "{selected_game}" after {ticks_ms() - start_time} ms',
+                '[Games]: Waiting for background work before loading "{}".'.format(
+                    selected_game,
+                ),
             )
 
 
@@ -136,7 +174,8 @@ def stop(view_manager) -> None:
     """Stop the games app"""
     from gc import collect
 
-    global _games, _app_loader
+    global _games, _app_loader, _pending_game
+    _pending_game = None
     if _games is not None:
         del _games
         _games = None

--- a/src/MicroPython/picoware/system/agent/context/app_creator.py
+++ b/src/MicroPython/picoware/system/agent/context/app_creator.py
@@ -528,21 +528,23 @@ All color constants are RGB565 format and defined as `micropython.const` integer
     - Slots: `args`, `error`, `function`, `_id`, `name`, `result`, `should_stop`, `start_time`, `timeout`.
 - `ThreadManager` class: Manages a queue of `ThreadTask` objects, running them sequentially.
     - `__init__()`: Initializes the task queue.
+    - `is_idle`: Property - True when no task is queued or active.
+    - `pending_count`: Property - number of queued tasks, excluding the active task.
     - `task`: Property - the currently active `ThreadTask`.
     - `thread`: Property - the underlying `Thread` object.
-    - `add_task(task)`: Add a `ThreadTask` to the queue.
-    - `remove_task(task_id)`: Remove a task from the queue by ID.
+    - `add_task(task)`: Add a `ThreadTask` to the queue and return its task ID.
+    - `remove_task(task_id)`: Cooperatively stop and remove a queued task by ID. Returns True when removed.
     - `run()`: Process the task queue - starts the next queued task if no task is running. Returns a log string.
 
 #### picoware-system-time
 - `Time` class: Manages the device RTC and optional NTP time synchronization.
     - `__init__(thread_manager=None)`: Creates a `machine.RTC()` instance. Accepts an optional `ThreadManager` for async NTP fetch.
     - `date`: Property - current date as a `"M/D/Y"` formatted string.
-    - `is_fetching`: Property - True if an NTP sync is currently in progress.
+    - `is_fetching`: Property - True if an NTP sync is queued or currently in progress.
     - `is_set`: Property - True if the time has been set (manually or via NTP).
     - `rtc`: Property - the underlying `machine.RTC` object.
     - `time`: Property - current time as an `"H:MM:SS"` formatted string.
-    - `fetch(offset=0)`: Synchronize the RTC with NTP (`pool.ntp.org`). `offset` is the UTC offset in hours. Uses `ThreadManager` if available. Returns True if started/successful.
+    - `fetch(offset=0)`: Synchronize the RTC with NTP (`pool.ntp.org`). `offset` is the UTC offset in hours. Uses `ThreadManager` if available. Returns True if started/successful. Failed requests use a 30-second retry cooldown.
     - `set(year, month, day, hour, minute, second)`: Manually set the RTC time.
 
 #### picoware-system-uart

--- a/src/MicroPython/picoware/system/http.py
+++ b/src/MicroPython/picoware/system/http.py
@@ -1100,7 +1100,7 @@ class HTTP:
                         storage,
                         send_file,
                     ),
-                    timeout=timeout,
+                    timeout=int(timeout * 1000),
                     stack_size=(
                         _stack_size
                         if self._chunk_size < _stack_size

--- a/src/MicroPython/picoware/system/thread.py
+++ b/src/MicroPython/picoware/system/thread.py
@@ -178,14 +178,31 @@ class ThreadManager:
         """Get the currently active thread."""
         return self._active_thread
 
-    def add_task(self, task: ThreadTask) -> None:
-        """Add a task to the manager."""
-        self._tasks.append(task)
+    @property
+    def is_idle(self) -> bool:
+        """Return whether no task is queued or active."""
+        return self._active_thread is None and not self._tasks
 
-    def remove_task(self, task_id: int) -> None:
-        """Remove a task from the manager."""
-        if task_id in self._tasks:
-            self._tasks.remove(task_id)
+    @property
+    def pending_count(self) -> int:
+        """Return the number of queued tasks, excluding the active task."""
+        return len(self._tasks)
+
+    def add_task(self, task: ThreadTask) -> int:
+        """Add a task to the manager."""
+        task.id = self._id
+        self._id += 1
+        self._tasks.append(task)
+        return task.id
+
+    def remove_task(self, task_id: int) -> bool:
+        """Stop and remove a queued task by ID."""
+        for index, task in enumerate(self._tasks):
+            if task.id == task_id:
+                task.stop()
+                self._tasks.pop(index)
+                return True
+        return False
 
     def run(self) -> str:
         """Run tasks one-by-one, waiting for each to complete before starting the next."""
@@ -196,14 +213,17 @@ class ThreadManager:
                 if self._active_task is not None:
                     self._outgoing = f"[ThreadManager] Task {self._active_task.id} ({self._active_task.name}) finished after {ticks_ms() - self._active_task.start_time} ms.\n"
                     # Task finished, capture error if any
-                    self._active_task.error = self._active_thread.error
+                    thread_error = self._active_thread.error
+                    if thread_error is not None:
+                        self._active_task.error = thread_error
                     collect()  
                 self._active_thread = None
                 self._active_task = None
             elif self._active_task is not None and self._active_task.should_stop:
                 # Stop was requested, stop the thread
                 self._active_thread.stop()
-                self._active_task.error = Exception("Thread task was stopped.")
+                if self._active_task.error is None:
+                    self._active_task.error = Exception("Thread task was stopped.")
             elif (
                 self._active_task is not None
                 and self._active_task.timeout > 0
@@ -211,6 +231,7 @@ class ThreadManager:
                 > self._active_task.timeout
             ):
                 # Task timed out, stop it
+                self._active_task.stop()
                 self._active_thread.stop()
                 self._active_task.error = Exception("Thread task timed out.")
             return self._outgoing
@@ -224,8 +245,6 @@ class ThreadManager:
             thread = Thread(task.function, task.args, task.stack_size)
             if thread.run():
                 task.start_time = ticks_ms()
-                task.id = self._id
-                self._id += 1
                 self._outgoing = (
                     f"[ThreadManager] Task {task.id} ({task.name}) started."
                 )

--- a/src/MicroPython/picoware/system/time.py
+++ b/src/MicroPython/picoware/system/time.py
@@ -1,3 +1,18 @@
+from time import gmtime
+import ustruct as struct
+from utime import ticks_add, ticks_diff, ticks_ms
+
+from picoware.system.thread import ThreadTask
+
+try:
+    import usocket as socket
+except ImportError:
+    socket = None
+
+
+NTP_RETRY_MS = 30000
+
+
 class Time:
     """Handles time-related functions."""
 
@@ -6,6 +21,8 @@ class Time:
         "_is_set",
         "_thread_manager",
         "_current_task",
+        "_pending",
+        "_retry_after",
         "_running",
         "_lock",
     )
@@ -24,6 +41,8 @@ class Time:
         self._is_set = False
         self._thread_manager = thread_manager
         self._current_task = None
+        self._pending = False
+        self._retry_after = 0
         self._running = False
 
     def __del__(self):
@@ -34,7 +53,23 @@ class Time:
         if self._current_task:
             self._current_task.stop()
             self._current_task = None
+        self._pending = False
+        self._retry_after = 0
+        self._running = False
         self._lock = None
+
+    def _recover_orphaned_fetch(self):
+        """Clear a queued fetch that no longer exists in ThreadManager."""
+        if (
+            self._pending
+            and not self._running
+            and self._current_task is not None
+            and self._thread_manager is not None
+            and getattr(self._thread_manager, "is_idle", False)
+        ):
+            self._pending = False
+            self._current_task = None
+            self._retry_after = ticks_add(ticks_ms(), NTP_RETRY_MS)
 
     @property
     def date(self) -> str:
@@ -47,11 +82,12 @@ class Time:
 
     @property
     def is_fetching(self) -> bool:
-        """Return whether the time is currently being fetched."""
+        """Return whether a time fetch is queued or currently running."""
         if self._lock is None:
             return False
         with self._lock:
-            return self._running
+            self._recover_orphaned_fetch()
+            return self._pending or self._running
 
     @property
     def is_set(self) -> bool:
@@ -91,79 +127,95 @@ class Time:
         """
         if self._lock is None:
             return False
-        
+        if socket is None:
+            return False
+
         try:
             with self._lock:
-                if self._running:
+                self._recover_orphaned_fetch()
+                if self._pending or self._running:
                     return False
                 if self._is_set:
                     return True
+                if (
+                    self._retry_after
+                    and ticks_diff(ticks_ms(), self._retry_after) < 0
+                ):
+                    return False
+                self._pending = True
 
             def fetch_ntp_time() -> None:
                 """Fetch the current time from an NTP server and set the RTC accordingly."""
-                from time import gmtime
-                import usocket as socket
-                import ustruct as struct
-
                 with self._lock:
                     self._is_set = False
+                    self._pending = False
                     self._running = True
-                NTP_QUERY = bytearray(48)
-                NTP_QUERY[0] = 0x1B
-                host = "pool.ntp.org"
-                timeout = 1
-                addr = socket.getaddrinfo(host, 123)[0][-1]
-                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
                 try:
-                    s.settimeout(timeout)
-                    s.sendto(NTP_QUERY, addr)
-                    msg = s.recv(48)
-                finally:
-                    s.close()
-                val = struct.unpack("!I", msg[40:44])[0]
+                    NTP_QUERY = bytearray(48)
+                    NTP_QUERY[0] = 0x1B
+                    host = "pool.ntp.org"
+                    timeout = 1
+                    addr = socket.getaddrinfo(host, 123)[0][-1]
+                    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    try:
+                        s.settimeout(timeout)
+                        s.sendto(NTP_QUERY, addr)
+                        msg = s.recv(48)
+                    finally:
+                        s.close()
+                    val = struct.unpack("!I", msg[40:44])[0]
 
-                # 2024-01-01 00:00:00 converted to an NTP timestamp
-                MIN_NTP_TIMESTAMP = 3913056000
-                if val < MIN_NTP_TIMESTAMP:
-                    val += 0x100000000
+                    # 2024-01-01 00:00:00 converted to an NTP timestamp
+                    MIN_NTP_TIMESTAMP = 3913056000
+                    if val < MIN_NTP_TIMESTAMP:
+                        val += 0x100000000
 
-                # Convert timestamp from NTP format to our internal format
-                EPOCH_YEAR = gmtime(0)[0]
-                if EPOCH_YEAR == 2000:
-                    # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
-                    NTP_DELTA = 3155673600
-                elif EPOCH_YEAR == 1970:
-                    # (date(1970, 1, 1) - date(1900, 1, 1)).days * 24*60*60
-                    NTP_DELTA = 2208988800
-                else:
-                    print("Unsupported epoch: {}".format(EPOCH_YEAR))
-                    with self._lock:
-                        self._running = False
-                        self._is_set = False
-                    return
-
-                t = val - NTP_DELTA + int(offset * 3600)  # Apply timezone offset
-                tm = gmtime(t)
-                with self._lock:
-                    self._rtc.datetime(
-                        (
-                            tm[0],  # year
-                            tm[1],  # month
-                            tm[2],  # day of the month
-                            tm[6] + 1,  # weekday
-                            tm[3],  # hour
-                            tm[4],  # minute
-                            tm[5],  # second
-                            0,  # subseconds
+                    # Convert timestamp from NTP format to our internal format
+                    EPOCH_YEAR = gmtime(0)[0]
+                    if EPOCH_YEAR == 2000:
+                        # (date(2000, 1, 1) - date(1900, 1, 1)).days * 24*60*60
+                        NTP_DELTA = 3155673600
+                    elif EPOCH_YEAR == 1970:
+                        # (date(1970, 1, 1) - date(1900, 1, 1)).days * 24*60*60
+                        NTP_DELTA = 2208988800
+                    else:
+                        raise ValueError(
+                            "Unsupported epoch: {}".format(EPOCH_YEAR)
                         )
-                    )
-                    self._is_set = True
-                    self._running = False
+
+                    t = val - NTP_DELTA + int(offset * 3600)  # Apply timezone offset
+                    tm = gmtime(t)
+                    with self._lock:
+                        self._rtc.datetime(
+                            (
+                                tm[0],  # year
+                                tm[1],  # month
+                                tm[2],  # day of the month
+                                tm[6] + 1,  # weekday
+                                tm[3],  # hour
+                                tm[4],  # minute
+                                tm[5],  # second
+                                0,  # subseconds
+                            )
+                        )
+                        self._is_set = True
+                        self._retry_after = 0
+                except Exception:
+                    with self._lock:
+                        self._is_set = False
+                        self._retry_after = ticks_add(
+                            ticks_ms(),
+                            NTP_RETRY_MS,
+                        )
+                    raise
+                finally:
+                    with self._lock:
+                        self._pending = False
+                        self._running = False
+                        self._current_task = None
 
             if not self._thread_manager:
                 return fetch_ntp_time()
-
-            from picoware.system.thread import ThreadTask
 
             task = ThreadTask("Time", function=fetch_ntp_time)
             self._current_task = task
@@ -172,8 +224,11 @@ class Time:
         except Exception as e:
             print(f"Failed to fetch time: {e}")
             with self._lock:
+                self._pending = False
                 self._running = False
+                self._current_task = None
                 self._is_set = False
+                self._retry_after = ticks_add(ticks_ms(), NTP_RETRY_MS)
             return False
 
     def set(self, year, month, day, hour, minute, second) -> None:
@@ -195,3 +250,4 @@ class Time:
                 )
             )
             self._is_set = True
+            self._retry_after = 0

--- a/src/MicroPython/picoware/system/view.py
+++ b/src/MicroPython/picoware/system/view.py
@@ -16,15 +16,26 @@ class View:
         self._stop = stop
         self.active = False
 
-    def __alert(self, exception, view_manager) -> None:
+    def __alert(self, action, exception, view_manager) -> None:
         """Display an alert message."""
         import sys
         import io
 
-        buf = io.StringIO()
-        sys.print_exception(exception, buf)
-        traceback_str = buf.getvalue()
-        view_manager.alert(f"{traceback_str}", False) 
+        prefix = "Error {} view '{}':".format(action, self.name)
+        try:
+            buf = io.StringIO()
+            sys.print_exception(exception, buf)
+            message = "{}\n{}".format(prefix, buf.getvalue())
+        except Exception:
+            print(prefix)
+            sys.print_exception(exception)
+            message = "{}\n{}".format(prefix, exception)
+
+        print(message)
+        try:
+            view_manager.alert(message, False)
+        except Exception as alert_error:
+            print("Unable to display view exception alert:", alert_error)
 
     def start(self, view_manager) -> bool:
         """Called when the view is created."""
@@ -34,7 +45,7 @@ class View:
                     self.active = True
                     return True
             except Exception as e:
-                self.__alert(f"Error starting view: {e}", view_manager)
+                self.__alert("starting", e, view_manager)
                 self.active = False
                 return False
         return False
@@ -45,7 +56,7 @@ class View:
             try:
                 self._stop(view_manager)
             except Exception as e:
-                self.__alert(f"Error stopping view: {e}", view_manager)
+                self.__alert("stopping", e, view_manager)
         self.active = False
 
     def run(self, view_manager):
@@ -54,6 +65,6 @@ class View:
             try:
                 self._run(view_manager)
             except Exception as e:
-                self.__alert(f"Error running view: {e}", view_manager)
+                self.__alert("running", e, view_manager)
                 self.active = False
                 view_manager.back()


### PR DESCRIPTION
## Summary

- mark NTP synchronization pending when queued, reject duplicate fetches, and add a retry cooldown after failures
- expose queue-aware ThreadManager idle/pending state, assign task IDs on enqueue, and fix queued-task removal, timeout, and error handling
- defer SD game imports until background workers are idle, while allowing a pending launch to be cancelled with Back
- convert asynchronous HTTP task timeouts from seconds to milliseconds
- preserve complete tracebacks from view start, run, and stop failures
- document the updated ThreadManager and Time APIs

## Validation

- Picoware simulator self-check and simulator build check passed
- targeted Time, ThreadManager, deferred-game-launch, HTTP-timeout, and traceback probes passed
- MicroPython bytecode compilation completed in `/tmp`
- 51/51 app and game coverage passed
- source-only diff contains no tests or compiled MPY artifacts