### PR TITLE
Harden Pico Bomber runtime and score storage

### DIFF
--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -4,6 +4,9 @@ from gc import collect
 from utime import ticks_add, ticks_diff, ticks_ms
 
 from picoware.system.buttons import (
+    BUTTON_0,
+    BUTTON_9,
+    BUTTON_A,
     BUTTON_BACK,
     BUTTON_BACKSPACE,
     BUTTON_CENTER,
@@ -11,9 +14,12 @@ from picoware.system.buttons import (
     BUTTON_DOWN,
     BUTTON_ENTER,
     BUTTON_LEFT,
+    BUTTON_MINUS,
     BUTTON_RIGHT,
     BUTTON_SPACE,
+    BUTTON_UNDERSCORE,
     BUTTON_UP,
+    BUTTON_Z,
 )
 
 from .leaderboard import DEFAULT_NAME, MAX_NAME_LENGTH, Leaderboard
@@ -97,7 +103,7 @@ def _submit_name(name):
     _score_saved = True
 
 
-def _handle_name_input(input_manager, button):
+def _handle_name_input(_input_manager, button):
     """Edit a short arcade name using the physical keyboard."""
     if button < 0:
         return False
@@ -115,12 +121,20 @@ def _handle_name_input(input_manager, button):
     if len(_game.player_name) >= MAX_NAME_LENGTH:
         return False
 
-    char = input_manager.button_to_char(button).upper()
-    if len(char) == 1 and (
-        "A" <= char <= "Z"
-        or "0" <= char <= "9"
-        or char in (" ", "-", "_")
-    ):
+    if BUTTON_A <= button <= BUTTON_Z:
+        char = chr(65 + button - BUTTON_A)
+    elif BUTTON_0 <= button <= BUTTON_9:
+        char = chr(48 + button - BUTTON_0)
+    elif button == BUTTON_SPACE:
+        char = " "
+    elif button == BUTTON_MINUS:
+        char = "-"
+    elif button == BUTTON_UNDERSCORE:
+        char = "_"
+    else:
+        return False
+
+    if char:
         _game.player_name += char
         return True
     return False
@@ -206,6 +220,9 @@ def run(view_manager):
                 _mode_start_pending = True
                 try:
                     _game.new_game(now, _game.menu_selection)
+                    # Release the stage builder's temporary candidate tuples
+                    # before the first full arena frame.
+                    collect()
                 except Exception as error:
                     _log_mode_start_error(view_manager, "stage-build", error)
                     _mode_start_pending = False

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
@@ -6,7 +6,7 @@ except ImportError:
     import json
 
 
-LEADERBOARD_PATH = "picoware/pbscores.dat"
+LEADERBOARD_PATH = "picoware/settings/pico_bomber.json"
 MAX_SCORES = 5
 MAX_NAME_LENGTH = 10
 MAX_SCORE_FILE_SIZE = 512

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/leaderboard.py
@@ -6,29 +6,37 @@ except ImportError:
     import json
 
 
-LEADERBOARD_PATH = "/picoware/settings/pico_bomber_scores.json"
+LEADERBOARD_PATH = "picoware/pbscores.dat"
 MAX_SCORES = 5
 MAX_NAME_LENGTH = 10
+MAX_SCORE_FILE_SIZE = 512
 DEFAULT_NAME = "PLAYER"
 
 
 class Leaderboard:
     """Load, rank, and save local score entries."""
 
+    __slots__ = ("storage", "entries", "_mounted")
+
     def __init__(self, storage=None):
         self.storage = storage
         self.entries = []
+        self._mounted = False
         self.load()
 
     def _ensure_mounted(self):
         """Make raw SD access available after the app loader unmounts it."""
         if self.storage is None:
             return False
+        if self._mounted:
+            return True
         mount = getattr(self.storage, "mount", None)
         if mount is None:
+            self._mounted = True
             return True
         try:
-            return bool(mount())
+            self._mounted = bool(mount())
+            return self._mounted
         except Exception:
             return False
 
@@ -92,7 +100,20 @@ class Leaderboard:
         try:
             if not self.storage.exists(LEADERBOARD_PATH):
                 return self.entries
-            loaded = json.loads(self.storage.read(LEADERBOARD_PATH, "r"))
+            size = getattr(self.storage, "size", None)
+            if size is None:
+                raw = self.storage.read(LEADERBOARD_PATH, "r")
+            else:
+                file_size = int(size(LEADERBOARD_PATH))
+                if file_size < 2 or file_size > MAX_SCORE_FILE_SIZE:
+                    return self.entries
+                raw = self.storage.read(
+                    LEADERBOARD_PATH,
+                    "r",
+                    0,
+                    file_size,
+                )
+            loaded = json.loads(raw)
             if isinstance(loaded, list):
                 valid = []
                 for entry in loaded:
@@ -127,6 +148,11 @@ class Leaderboard:
         if not self._ensure_mounted():
             return False
         try:
-            return bool(self.storage.write(LEADERBOARD_PATH, current, "w"))
+            if not self.storage.write(LEADERBOARD_PATH, current, "w"):
+                return False
+            if not self.storage.exists(LEADERBOARD_PATH):
+                return False
+            size = getattr(self.storage, "size", None)
+            return size is None or int(size(LEADERBOARD_PATH)) == len(current)
         except Exception:
             return False

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
@@ -385,13 +385,16 @@ class Renderer:
             color = COLOR_FACTORY_FLOOR
         else:
             color = COLOR_WATER
-        self.draw._fill_rectangle(
-            px + inset,
-            py + inset,
-            self.cell - inset,
-            self.cell - inset,
-            color,
-        )
+        # Nature and industrial floors already match the full-frame
+        # background. Only water needs a different base tile color.
+        if theme == THEME_WATER:
+            self.draw._fill_rectangle(
+                px + inset,
+                py + inset,
+                self.cell - inset,
+                self.cell - inset,
+                color,
+            )
 
         if self.cell < 8:
             return
@@ -581,25 +584,21 @@ class Renderer:
                     band,
                     COLOR_HAZARD,
                 )
-                stripe = max(3, self.cell // 4)
-                offset = 1
-                while offset < self.cell:
-                    self.draw._fill_rectangle(
-                        px + offset,
-                        py,
-                        min(2, self.cell - offset),
-                        band,
-                        TFT_BLACK,
-                    )
-                    lower_x = min(self.cell - 1, offset + stripe // 2)
-                    self.draw._fill_rectangle(
-                        px + lower_x,
-                        py + self.cell - band,
-                        min(2, self.cell - lower_x),
-                        band,
-                        TFT_BLACK,
-                    )
-                    offset += stripe
+                stripe = max(2, self.cell // 5)
+                self.draw._fill_rectangle(
+                    px + 3,
+                    py,
+                    stripe,
+                    band,
+                    TFT_BLACK,
+                )
+                self.draw._fill_rectangle(
+                    px + self.cell - stripe - 3,
+                    py + self.cell - band,
+                    stripe,
+                    band,
+                    TFT_BLACK,
+                )
                 self.draw._rectangle(
                     px + 1,
                     py + 1,
@@ -1290,9 +1289,10 @@ class Renderer:
         self.draw.fill_screen(background)
         self._draw_hud(game)
 
+        py = self.origin_y
         for y in range(GRID_HEIGHT):
+            px = self.origin_x
             for x in range(GRID_WIDTH):
-                px, py = self._tile_box(x, y)
                 tile = game.grid[y][x]
                 if tile == TILE_SOLID:
                     self._draw_solid(px, py, x, y, game.theme)
@@ -1307,6 +1307,8 @@ class Renderer:
                         game.theme,
                         game.animation_time,
                     )
+                px += self.cell
+            py += self.cell
 
         for decal in game.decals:
             self._draw_decal(decal)


### PR DESCRIPTION
## Summary

- harden Pico Bomber score persistence with bounded reads and post-write verification
- keep score data in `picoware/pbscores.dat` rather than the damaged settings path seen during device testing
- reduce repeated renderer allocations and temporary stage-build pressure
- preserve the existing `dev` clock lifecycle unchanged

## Why this PR was narrowed

The earlier revision also contained the five new level themes and accidentally replaced the existing pending 230 MHz clock guard with an immediate transition during `start()`.

Those are separate concerns. The themes now have their own PR, and the clock work has its own hardware-focused PR documenting the tested 240/220 MHz behavior. This runtime PR deliberately makes no CPU-frequency changes.

## Validation

- Python syntax compilation
- `mpy-cross` for all three changed modules
- headless Pico Bomber launch with title assertion
- `git diff --check`
- source-only three-file scope

