### PR TITLE
Add opt-in PicoCalc navigation key repeat

### DIFF
--- a/src/MicroPython/PicoCalc/picoware_keyboard/keyboard.c
+++ b/src/MicroPython/PicoCalc/picoware_keyboard/keyboard.c
@@ -36,6 +36,76 @@ static volatile char rx_buffer[KBD_BUFFER_SIZE];
 static volatile uint16_t rx_head = 0;
 static volatile uint16_t rx_tail = 0;
 static repeating_timer_t key_timer;
+static uint8_t repeating_key_code = 0;
+static uint32_t next_repeat_ms = 0;
+static bool hardware_hold_seen = false;
+static bool key_repeat_enabled = false;
+
+#define KEYBOARD_INITIAL_REPEAT_DELAY_MS (100)
+#define KEYBOARD_REPEAT_INTERVAL_MS (50)
+
+static bool keyboard_key_repeats(uint8_t key_code)
+{
+    switch (key_code)
+    {
+    case KEY_BACKSPACE:
+    case KEY_UP:
+    case KEY_DOWN:
+    case KEY_LEFT:
+    case KEY_RIGHT:
+    case KEY_INSERT:
+    case KEY_HOME:
+    case KEY_DEL:
+    case KEY_END:
+    case KEY_PAGE_UP:
+    case KEY_PAGE_DOWN:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static void keyboard_buffer_key(uint8_t key_code)
+{
+    uint8_t ch = key_code;
+    if (ch >= 'a' && ch <= 'z') // Ctrl and Shift handling
+    {
+        if (key_control)
+        {
+            ch &= 0x1F; // convert to control character
+        }
+        if (key_shift)
+        {
+            ch &= ~0x20;
+        }
+    }
+    else if (key_control && ch == KEY_UP)
+    {
+        ch = KEY_CTRL_UP;
+    }
+    else if (key_control && ch == KEY_DOWN)
+    {
+        ch = KEY_CTRL_DOWN;
+    }
+    else if (ch == KEY_ENTER) // enter key is returned as LF
+    {
+        ch = KEY_RETURN; // convert LF to CR
+    }
+
+    uint16_t next_head = (rx_head + 1) & (KBD_BUFFER_SIZE - 1);
+    if (next_head == rx_tail)
+    {
+        return; // Buffer full: preserve unread key events.
+    }
+    rx_buffer[rx_head] = ch;
+    rx_head = next_head;
+
+    // Notify that characters are available
+    if (keyboard_key_available_callback)
+    {
+        keyboard_key_available_callback();
+    }
+}
 
 //
 //  Keyboard Driver
@@ -50,10 +120,11 @@ void keyboard_poll()
     uint16_t key = sb_read_keyboard();
     uint8_t key_state = (key >> 8) & 0xFF;
     uint8_t key_code = key & 0xFF;
+    uint32_t now_ms = (uint32_t)(time_us_64() / 1000);
 
     if (key_state != 0)
     {
-        if (key_state == KEY_STATE_PRESSED)
+        if (key_state == KEY_STATE_PRESSED || key_state == KEY_STATE_HOLD)
         {
             if (key_code == KEY_MOD_CTRL)
             {
@@ -77,41 +148,36 @@ void keyboard_poll()
             }
             else
             {
-                // If a key is released, we return the key code
-                // This allows us to handle the key release in the main loop
-                uint8_t ch = key_code;
-                if (ch >= 'a' && ch <= 'z') // Ctrl and Shift handling
+                bool repeats = keyboard_key_repeats(key_code);
+                if (
+                    key_repeat_enabled &&
+                    key_state == KEY_STATE_PRESSED &&
+                    repeats
+                )
                 {
-                    if (key_control)
-                    {
-                        ch &= 0x1F; // convert to control character
-                    }
-                    if (key_shift)
-                    {
-                        ch &= ~0x20;
-                    }
+                    repeating_key_code = key_code;
+                    next_repeat_ms =
+                        now_ms + KEYBOARD_INITIAL_REPEAT_DELAY_MS;
+                    hardware_hold_seen = false;
                 }
-                else if (key_control && ch == KEY_UP)
+                else if (
+                    key_repeat_enabled &&
+                    key_state == KEY_STATE_HOLD &&
+                    repeats
+                )
                 {
-                    ch = KEY_CTRL_UP;
-                }
-                else if (key_control && ch == KEY_DOWN)
-                {
-                    ch = KEY_CTRL_DOWN;
-                }
-                else if (ch == KEY_ENTER) // enter key is returned as LF
-                {
-                    ch = KEY_RETURN; // convert LF to CR
+                    repeating_key_code = key_code;
+                    hardware_hold_seen = true;
                 }
 
-                uint16_t next_head = (rx_head + 1) & (KBD_BUFFER_SIZE - 1);
-                rx_buffer[rx_head] = ch;
-                rx_head = next_head;
-
-                // Notify that characters are available
-                if (keyboard_key_available_callback)
+                // HOLD repeats only navigation/editing keys. Enter, Space,
+                // and other actions remain one-shot physical key presses.
+                if (
+                    key_state == KEY_STATE_PRESSED ||
+                    (key_repeat_enabled && repeats)
+                )
                 {
-                    keyboard_key_available_callback();
+                    keyboard_buffer_key(key_code);
                 }
             }
         }
@@ -125,7 +191,30 @@ void keyboard_poll()
             {
                 key_shift = false;
             }
+            else if (key_code == KEY_MOD_ALT)
+            {
+                key_alt = false;
+            }
+            if (key_code == repeating_key_code)
+            {
+                repeating_key_code = 0;
+                hardware_hold_seen = false;
+            }
         }
+    }
+
+    // The PicoCalc keyboard pauses before its first HOLD event. Bridge that
+    // initial gap so directional movement starts continuously, then defer to
+    // the keyboard's own HOLD cadence as soon as it appears.
+    if (
+        key_repeat_enabled &&
+        repeating_key_code != 0 &&
+        !hardware_hold_seen &&
+        (int32_t)(now_ms - next_repeat_ms) >= 0
+    )
+    {
+        keyboard_buffer_key(repeating_key_code);
+        next_repeat_ms = now_ms + KEYBOARD_REPEAT_INTERVAL_MS;
     }
 }
 
@@ -183,6 +272,16 @@ void keyboard_set_background_poll(bool enable)
     {
         // Stop the repeating timer
         cancel_repeating_timer(&key_timer);
+    }
+}
+
+void keyboard_set_key_repeat(bool enable)
+{
+    key_repeat_enabled = enable;
+    if (!enable)
+    {
+        repeating_key_code = 0;
+        hardware_hold_seen = false;
     }
 }
 

--- a/src/MicroPython/PicoCalc/picoware_keyboard/keyboard.h
+++ b/src/MicroPython/PicoCalc/picoware_keyboard/keyboard.h
@@ -76,6 +76,7 @@ extern "C"
     void keyboard_init(void);
     void keyboard_set_key_available_callback(keyboard_key_available_callback_t callback);
     void keyboard_set_background_poll(bool enable);
+    void keyboard_set_key_repeat(bool enable);
     void keyboard_poll(void);
     bool keyboard_key_available(void);
     char keyboard_get_key(void);

--- a/src/MicroPython/PicoCalc/picoware_keyboard/picoware_keyboard.c
+++ b/src/MicroPython/PicoCalc/picoware_keyboard/picoware_keyboard.c
@@ -73,6 +73,14 @@ STATIC mp_obj_t picoware_keyboard_set_background_poll(mp_obj_t enable_obj)
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_1(picoware_keyboard_set_background_poll_obj, picoware_keyboard_set_background_poll);
 
+// set_key_repeat(enable) - Enable/disable navigation key repeats
+STATIC mp_obj_t picoware_keyboard_set_key_repeat(mp_obj_t enable_obj)
+{
+    keyboard_set_key_repeat(mp_obj_is_true(enable_obj));
+    return mp_const_none;
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_1(picoware_keyboard_set_key_repeat_obj, picoware_keyboard_set_key_repeat);
+
 // poll() - Poll the keyboard
 STATIC mp_obj_t picoware_keyboard_poll(void)
 {
@@ -117,6 +125,7 @@ STATIC const mp_rom_map_elem_t picoware_keyboard_module_globals_table[] = {
     {MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&picoware_keyboard_init_obj)},
     {MP_ROM_QSTR(MP_QSTR_set_key_available_callback), MP_ROM_PTR(&picoware_keyboard_set_key_available_callback_obj)},
     {MP_ROM_QSTR(MP_QSTR_set_background_poll), MP_ROM_PTR(&picoware_keyboard_set_background_poll_obj)},
+    {MP_ROM_QSTR(MP_QSTR_set_key_repeat), MP_ROM_PTR(&picoware_keyboard_set_key_repeat_obj)},
     {MP_ROM_QSTR(MP_QSTR_poll), MP_ROM_PTR(&picoware_keyboard_poll_obj)},
     {MP_ROM_QSTR(MP_QSTR_key_available), MP_ROM_PTR(&picoware_keyboard_key_available_obj)},
     {MP_ROM_QSTR(MP_QSTR_get_key), MP_ROM_PTR(&picoware_keyboard_get_key_obj)},

--- a/src/MicroPython/picoware/system/input.py
+++ b/src/MicroPython/picoware/system/input.py
@@ -554,6 +554,16 @@ class Input:
         """Returns True if the last button was held for the specified duration."""
         return self._was_pressed and self._elapsed_time >= duration
 
+    def set_key_repeat(self, enable: bool = False) -> bool:
+        """Enable navigation-key repeat for the active app when supported."""
+        try:
+            from picoware_keyboard import set_key_repeat
+        except (ImportError, AttributeError):
+            return False
+
+        set_key_repeat(bool(enable))
+        return True
+
     def on_key_callback(self, _=None) -> None:
         """Callback invoked when a key becomes available.
 


### PR DESCRIPTION
## Summary

- add opt-in PicoCalc navigation/editing-key repeat to the native keyboard driver
- expose the control as `picoware_keyboard.set_key_repeat()` and `Input.set_key_repeat()`
- keep Enter, Space, and other action keys one-shot
- stop repeat immediately on release or when the feature is disabled

## Hardware finding and design choice

Pico Bomber originally moved one tile on the first press and only became fluid after later HOLD events. Enabling repeat globally fixed the game but also changed every menu and application, which was not acceptable.

The repeat behavior is therefore disabled by default and must be explicitly enabled by an active app or gameplay state. Normal Picoware menus retain their existing input behavior.

The driver bridges the delay before the PicoCalc keyboard's first HOLD event, then follows the keyboard HOLD cadence. Only navigation/editing keys are eligible, so rapid Enter or Space actions are not synthesized.

## Validation

- Python syntax compilation for `input.py`
- full PicoCalc Pico 2 W firmware build
- tested on hardware with repeat enabled only during active Pico Bomber gameplay
- `git diff --check`
- source-only four-file scope

