### PR TITLE
Use Picoware-managed clock lifecycle for Pico Bomber

### DIFF
--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -37,35 +37,72 @@ _leaderboard = None
 _next_frame = 0
 _score_saved = False
 _frequency_changed = False
-_frequency_pending = False
+_startup_pending = False
+_frequency_idle_since = 0
 _mode_start_pending = False
 FRAME_MS = 50
-GAME_CPU_FREQUENCY = 230000000
+GAME_CPU_FREQUENCY = 220000000
+FREQUENCY_SETTLE_MS = 100
 
 
-def _thread_idle(view_manager):
-    """Return whether changing the global CPU clock is currently safe."""
-    thread_manager = getattr(view_manager, "thread_manager", None)
-    if thread_manager is None:
-        return True
-    public_idle = getattr(thread_manager, "is_idle", None)
-    if public_idle is not None:
-        return bool(public_idle)
-    return (
-        getattr(thread_manager, "thread", None) is None
-        and not getattr(thread_manager, "_tasks", ())
-    )
+def _thread_manager_is_idle(view_manager):
+    """Return whether it is safe to change the RP2350 system clock."""
+    thread_manager = view_manager.thread_manager
+    return thread_manager is None or thread_manager.is_idle
 
 
-def _try_game_frequency(view_manager):
-    """Apply the game clock once inherited background work has drained."""
-    global _frequency_changed, _frequency_pending
+def _write_start_marker(view_manager, phase):
+    """Persist the last completed startup step for hard-freeze diagnosis."""
+    try:
+        from gc import mem_free
+        from machine import freq
 
-    if not _frequency_pending or not _thread_idle(view_manager):
+        thread_manager = view_manager.thread_manager
+        thread = None if thread_manager is None else thread_manager.thread
+        thread_running = (
+            1
+            if thread is not None and thread.is_running
+            else 0
+        )
+        queued_tasks = (
+            0
+            if thread_manager is None
+            else thread_manager.pending_count
+        )
+        view_manager.storage.write(
+            "picoware/pico_bomber_start.log",
+            "phase=%s freq=%d free=%d thread=%d queued=%d\n"
+            % (
+                phase,
+                freq(),
+                mem_free(),
+                thread_running,
+                queued_tasks,
+            ),
+            "w",
+        )
+    except Exception:
+        pass
+
+
+def _prepare_game_frequency(view_manager, now):
+    """Change clocks only after core 1 has remained idle long enough to settle."""
+    global _frequency_changed, _frequency_idle_since
+
+    if not _thread_manager_is_idle(view_manager):
+        _frequency_idle_since = 0
         return False
+    if _frequency_idle_since == 0:
+        _frequency_idle_since = now
+        return False
+    if ticks_diff(now, _frequency_idle_since) < FREQUENCY_SETTLE_MS:
+        return False
+
+    _write_start_marker(view_manager, "frequency-before")
     view_manager.freq(False, GAME_CPU_FREQUENCY)
     _frequency_changed = True
-    _frequency_pending = False
+    _frequency_idle_since = 0
+    _write_start_marker(view_manager, "frequency-game")
     return True
 
 
@@ -126,33 +163,49 @@ def _handle_name_input(input_manager, button):
     return False
 
 
-def start(view_manager):
-    """Create a fresh Pico Bomber title screen."""
+def _finish_start(view_manager):
+    """Create the game only after the safe clock transition has completed."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
-    global _frequency_changed, _frequency_pending, _mode_start_pending
 
-    _frequency_changed = False
-    _frequency_pending = True
-    _mode_start_pending = False
-    _try_game_frequency(view_manager)
     _game = GameModel()
+    _write_start_marker(view_manager, "model")
     _renderer = Renderer(view_manager.draw)
+    _write_start_marker(view_manager, "renderer")
     _leaderboard = Leaderboard(view_manager.storage)
+    _write_start_marker(view_manager, "leaderboard")
     _game.leaderboard = _leaderboard.entries
     _score_saved = False
-    _next_frame = ticks_ms()
     _renderer.draw_frame(_game)
+    _write_start_marker(view_manager, "title-render")
+    _next_frame = ticks_add(ticks_ms(), FRAME_MS)
+    _write_start_marker(view_manager, "complete")
+
+
+def start(view_manager):
+    """Wait for a safe clock boundary before creating a fresh title screen."""
+    global _mode_start_pending, _startup_pending, _frequency_idle_since
+
+    _mode_start_pending = False
+    _startup_pending = True
+    _frequency_idle_since = 0
+    _write_start_marker(view_manager, "frequency-wait")
     return True
 
 
 def run(view_manager):
     """Handle one Picoware input/update/render cycle."""
-    global _next_frame, _score_saved, _mode_start_pending
+    global _next_frame, _score_saved, _mode_start_pending, _startup_pending
+
+    if _startup_pending:
+        if not _prepare_game_frequency(view_manager, ticks_ms()):
+            return
+        _startup_pending = False
+        _finish_start(view_manager)
+        return
 
     if _game is None or _renderer is None:
         return
 
-    _try_game_frequency(view_manager)
     input_manager = view_manager.input_manager
     button = view_manager.button
     now = ticks_ms()
@@ -252,16 +305,24 @@ def run(view_manager):
 def stop(view_manager):
     """Release the game state when leaving the Picoware view."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
-    global _frequency_changed, _frequency_pending, _mode_start_pending
+    global _frequency_changed, _frequency_idle_since, _mode_start_pending
+    global _startup_pending
 
     _game = None
     _renderer = None
     _leaderboard = None
     _next_frame = 0
     _score_saved = False
-    _frequency_pending = False
+    _startup_pending = False
+    _frequency_idle_since = 0
     _mode_start_pending = False
-    if _frequency_changed:
-        view_manager.freq()
-    _frequency_changed = False
     collect()
+    if _frequency_changed:
+        if _thread_manager_is_idle(view_manager):
+            view_manager.freq()
+            _frequency_changed = False
+        else:
+            view_manager.log(
+                "[Pico Bomber] Keeping 220 MHz because background work is active.",
+                2,
+            )

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -36,74 +36,8 @@ _renderer = None
 _leaderboard = None
 _next_frame = 0
 _score_saved = False
-_frequency_changed = False
-_startup_pending = False
-_frequency_idle_since = 0
 _mode_start_pending = False
 FRAME_MS = 50
-GAME_CPU_FREQUENCY = 220000000
-FREQUENCY_SETTLE_MS = 100
-
-
-def _thread_manager_is_idle(view_manager):
-    """Return whether it is safe to change the RP2350 system clock."""
-    thread_manager = view_manager.thread_manager
-    return thread_manager is None or thread_manager.is_idle
-
-
-def _write_start_marker(view_manager, phase):
-    """Persist the last completed startup step for hard-freeze diagnosis."""
-    try:
-        from gc import mem_free
-        from machine import freq
-
-        thread_manager = view_manager.thread_manager
-        thread = None if thread_manager is None else thread_manager.thread
-        thread_running = (
-            1
-            if thread is not None and thread.is_running
-            else 0
-        )
-        queued_tasks = (
-            0
-            if thread_manager is None
-            else thread_manager.pending_count
-        )
-        view_manager.storage.write(
-            "picoware/pico_bomber_start.log",
-            "phase=%s freq=%d free=%d thread=%d queued=%d\n"
-            % (
-                phase,
-                freq(),
-                mem_free(),
-                thread_running,
-                queued_tasks,
-            ),
-            "w",
-        )
-    except Exception:
-        pass
-
-
-def _prepare_game_frequency(view_manager, now):
-    """Change clocks only after core 1 has remained idle long enough to settle."""
-    global _frequency_changed, _frequency_idle_since
-
-    if not _thread_manager_is_idle(view_manager):
-        _frequency_idle_since = 0
-        return False
-    if _frequency_idle_since == 0:
-        _frequency_idle_since = now
-        return False
-    if ticks_diff(now, _frequency_idle_since) < FREQUENCY_SETTLE_MS:
-        return False
-
-    _write_start_marker(view_manager, "frequency-before")
-    view_manager.freq(False, GAME_CPU_FREQUENCY)
-    _frequency_changed = True
-    _frequency_idle_since = 0
-    _write_start_marker(view_manager, "frequency-game")
-    return True
 
 
 def _log_mode_start_error(view_manager, phase, error):
@@ -163,45 +97,30 @@ def _handle_name_input(input_manager, button):
     return False
 
 
-def _finish_start(view_manager):
-    """Create the game only after the safe clock transition has completed."""
-    global _game, _renderer, _leaderboard, _next_frame, _score_saved
-
-    _game = GameModel()
-    _write_start_marker(view_manager, "model")
-    _renderer = Renderer(view_manager.draw)
-    _write_start_marker(view_manager, "renderer")
-    _leaderboard = Leaderboard(view_manager.storage)
-    _write_start_marker(view_manager, "leaderboard")
-    _game.leaderboard = _leaderboard.entries
-    _score_saved = False
-    _renderer.draw_frame(_game)
-    _write_start_marker(view_manager, "title-render")
-    _next_frame = ticks_add(ticks_ms(), FRAME_MS)
-    _write_start_marker(view_manager, "complete")
-
-
 def start(view_manager):
-    """Wait for a safe clock boundary before creating a fresh title screen."""
-    global _mode_start_pending, _startup_pending, _frequency_idle_since
+    """Create a fresh Pico Bomber title screen at the portable low clock."""
+    global _game, _renderer, _leaderboard, _next_frame, _score_saved
+    global _mode_start_pending
 
+    view_manager.freq(True)
     _mode_start_pending = False
-    _startup_pending = True
-    _frequency_idle_since = 0
-    _write_start_marker(view_manager, "frequency-wait")
-    return True
+    try:
+        _game = GameModel()
+        _renderer = Renderer(view_manager.draw)
+        _leaderboard = Leaderboard(view_manager.storage)
+        _game.leaderboard = _leaderboard.entries
+        _score_saved = False
+        _renderer.draw_frame(_game)
+        _next_frame = ticks_add(ticks_ms(), FRAME_MS)
+        return True
+    except Exception:
+        view_manager.freq()
+        raise
 
 
 def run(view_manager):
     """Handle one Picoware input/update/render cycle."""
-    global _next_frame, _score_saved, _mode_start_pending, _startup_pending
-
-    if _startup_pending:
-        if not _prepare_game_frequency(view_manager, ticks_ms()):
-            return
-        _startup_pending = False
-        _finish_start(view_manager)
-        return
+    global _next_frame, _score_saved, _mode_start_pending
 
     if _game is None or _renderer is None:
         return
@@ -305,24 +224,13 @@ def run(view_manager):
 def stop(view_manager):
     """Release the game state when leaving the Picoware view."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
-    global _frequency_changed, _frequency_idle_since, _mode_start_pending
-    global _startup_pending
+    global _mode_start_pending
 
     _game = None
     _renderer = None
     _leaderboard = None
     _next_frame = 0
     _score_saved = False
-    _startup_pending = False
-    _frequency_idle_since = 0
     _mode_start_pending = False
     collect()
-    if _frequency_changed:
-        if _thread_manager_is_idle(view_manager):
-            view_manager.freq()
-            _frequency_changed = False
-        else:
-            view_manager.log(
-                "[Pico Bomber] Keeping 220 MHz because background work is active.",
-                2,
-            )
+    view_manager.freq()


### PR DESCRIPTION
## Summary

- keep the Pico 2 W firmware default at 240 MHz
- run Pico Bomber at the hardware-tested 220 MHz
- require no active or queued background tasks plus 100 ms of continuous idle before changing the system clock
- reset the settle timer whenever background work reappears
- restore the normal firmware clock on game exit only from an idle state
- record the last startup phase, frequency, free memory, and task state for freeze diagnosis

## Device findings

During PicoCalc testing:

- Pico Bomber at 240 MHz stopped crashing, but visible pixel corruption returned.
- Running the whole firmware at 220 MHz removed those pixel glitches.
- 220 MHz has remained stable in repeated gameplay and is the current known-good game frequency.
- Earlier direct per-game transitions, including the previous 230 MHz path, coincided with intermittent startup freezes and invalid-opcode failures.

The opcode failures were not proof that 230 MHz itself was invalid. The stronger finding was that changing the global RP2350 clock while core 1 or queued background work could still be active was unsafe.

`Thread` marks its public running state false immediately before the worker fully returns. The 100 ms continuous-idle window is a defensive settling period for that tail. This is the race hypothesis supported by the hardware tests, not a claim that every previous opcode error had one cause.

## Transition sequence

1. Enter the Pico Bomber view at the normal 240 MHz system clock.
2. Wait until `ThreadManager` has neither an active thread nor queued tasks.
3. Require that idle state to remain continuous for 100 ms.
4. Change to 220 MHz before constructing or rendering the game.
5. Run the complete game lifecycle at 220 MHz.
6. Restore the board default on exit when the manager is idle.
7. If unexpected background work exists during exit, retain the safe 220 MHz clock and log the condition rather than transition during active work.

## Hardware proof

A real-device test started a three-second core-1 task before Pico Bomber:

- before game: 240 MHz
- throughout active core-1 work: 240 MHz
- after worker completion and idle settlement: 220 MHz
- game startup marker: `phase=complete`, 220 MHz, no active or queued work
- after game stop: 240 MHz

The same device showed pixel glitches at 240 MHz in-game and no pixel glitches at 220 MHz.

## Validation

- focused busy/idle/settle/reset test
- real PicoCalc core-1 race proof
- Python syntax compilation
- `mpy-cross`
- headless Pico Bomber launch
- full simulator parity checks
- `git diff --check`
- app-only source scope

