### PR TITLE
Polish Pico Bomber controls and game pacing

### DIFF
--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -11,6 +11,7 @@ from picoware.system.buttons import (
     BUTTON_DOWN,
     BUTTON_ENTER,
     BUTTON_LEFT,
+    BUTTON_P,
     BUTTON_RIGHT,
     BUTTON_SPACE,
     BUTTON_UP,
@@ -23,8 +24,11 @@ from .model import (
     STATE_LEADERBOARD,
     STATE_MODE_SELECT,
     STATE_NAME_ENTRY,
+    STATE_PAUSED,
     STATE_PLAYER_DYING,
     STATE_PLAYING,
+    STATE_STAGE_CLEAR,
+    STATE_STAGE_INTRO,
     STATE_TITLE,
     GameModel,
 )
@@ -39,8 +43,23 @@ _score_saved = False
 _frequency_changed = False
 _frequency_pending = False
 _mode_start_pending = False
+_redraw_pending = False
+_key_repeat_enabled = False
 FRAME_MS = 50
 GAME_CPU_FREQUENCY = 230000000
+
+
+def _set_key_repeat(view_manager, enable, force=False):
+    """Use opt-in navigation repeat when the active firmware supports it."""
+    global _key_repeat_enabled
+
+    enable = bool(enable)
+    if not force and enable == _key_repeat_enabled:
+        return
+    setter = getattr(view_manager.input_manager, "set_key_repeat", None)
+    if setter is not None:
+        setter(enable)
+    _key_repeat_enabled = enable
 
 
 def _thread_idle(view_manager):
@@ -130,10 +149,13 @@ def start(view_manager):
     """Create a fresh Pico Bomber title screen."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
     global _frequency_changed, _frequency_pending, _mode_start_pending
+    global _redraw_pending
 
     _frequency_changed = False
     _frequency_pending = True
     _mode_start_pending = False
+    _redraw_pending = False
+    _set_key_repeat(view_manager, False, True)
     _try_game_frequency(view_manager)
     _game = GameModel()
     _renderer = Renderer(view_manager.draw)
@@ -147,24 +169,28 @@ def start(view_manager):
 
 def run(view_manager):
     """Handle one Picoware input/update/render cycle."""
-    global _next_frame, _score_saved, _mode_start_pending
+    global _next_frame, _score_saved, _mode_start_pending, _redraw_pending
 
     if _game is None or _renderer is None:
         return
 
     _try_game_frequency(view_manager)
+    _set_key_repeat(view_manager, _game.state == STATE_PLAYING)
     input_manager = view_manager.input_manager
     button = view_manager.button
     now = ticks_ms()
     changed = False
 
     if _game.state == STATE_NAME_ENTRY:
-        if button < 0:
-            return
-        changed = _handle_name_input(input_manager, button)
-        input_manager.reset()
+        if button >= 0:
+            changed = _handle_name_input(input_manager, button)
+            input_manager.reset()
         if changed:
+            _redraw_pending = True
+        if _redraw_pending and ticks_diff(now, _next_frame) >= 0:
             _renderer.draw_frame(_game)
+            _redraw_pending = False
+            _next_frame = ticks_add(now, FRAME_MS)
         return
 
     if button == BUTTON_BACK:
@@ -172,12 +198,26 @@ def run(view_manager):
         if _game.state == STATE_LEADERBOARD:
             _game.open_mode_menu()
             changed = True
-        elif _game.state == STATE_MODE_SELECT:
-            _game.state = STATE_TITLE
+        elif _game.state in (
+            STATE_PLAYING,
+            STATE_PAUSED,
+            STATE_PLAYER_DYING,
+            STATE_GAME_OVER,
+        ):
+            _game.open_mode_menu()
+            _mode_start_pending = False
             changed = True
+        elif _game.state == STATE_MODE_SELECT:
+            view_manager.back()
+            return
         else:
             view_manager.back()
             return
+    if button == BUTTON_P:
+        if _game.state == STATE_PLAYING:
+            changed = _game.pause(now)
+        elif _game.state == STATE_PAUSED:
+            changed = _game.resume(now)
     if button == BUTTON_UP:
         if _game.state == STATE_MODE_SELECT:
             changed = _game.select_mode(-1)
@@ -218,13 +258,20 @@ def run(view_manager):
     if button >= 0:
         input_manager.reset()
 
-    try:
-        updated = _game.update(now)
-    except Exception as error:
-        if _mode_start_pending:
-            _log_mode_start_error(view_manager, "first-update", error)
-            _mode_start_pending = False
-        raise
+    updated = False
+    if _game.state in (
+        STATE_PLAYING,
+        STATE_PLAYER_DYING,
+        STATE_STAGE_CLEAR,
+        STATE_STAGE_INTRO,
+    ):
+        try:
+            updated = _game.update(now)
+        except Exception as error:
+            if _mode_start_pending:
+                _log_mode_start_error(view_manager, "first-update", error)
+                _mode_start_pending = False
+            raise
     if updated:
         changed = True
 
@@ -236,8 +283,14 @@ def run(view_manager):
             _score_saved = True
         changed = True
 
+    _set_key_repeat(view_manager, _game.state == STATE_PLAYING)
     animated = _game.state in (STATE_PLAYING, STATE_PLAYER_DYING)
-    if changed or (animated and ticks_diff(now, _next_frame) >= 0):
+    if changed:
+        _redraw_pending = True
+    if (
+        ticks_diff(now, _next_frame) >= 0
+        and (_redraw_pending or animated)
+    ):
         try:
             _renderer.draw_frame(_game)
         except Exception as error:
@@ -246,6 +299,7 @@ def run(view_manager):
                 _mode_start_pending = False
             raise
         _mode_start_pending = False
+        _redraw_pending = False
         _next_frame = ticks_add(now, FRAME_MS)
 
 
@@ -253,7 +307,9 @@ def stop(view_manager):
     """Release the game state when leaving the Picoware view."""
     global _game, _renderer, _leaderboard, _next_frame, _score_saved
     global _frequency_changed, _frequency_pending, _mode_start_pending
+    global _redraw_pending
 
+    _set_key_repeat(view_manager, False, True)
     _game = None
     _renderer = None
     _leaderboard = None
@@ -261,6 +317,7 @@ def stop(view_manager):
     _score_saved = False
     _frequency_pending = False
     _mode_start_pending = False
+    _redraw_pending = False
     if _frequency_changed:
         view_manager.freq()
     _frequency_changed = False

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/model.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/model.py
@@ -51,6 +51,7 @@ STATE_STAGE_INTRO = 5
 STATE_MODE_SELECT = 6
 STATE_LEADERBOARD = 7
 STATE_NAME_ENTRY = 8
+STATE_PAUSED = 9
 
 DEATH_PLAYER = 0
 DEATH_ENEMY_BLOB = 1
@@ -74,7 +75,11 @@ PLAYER_MOVE_ANIMATION_MS = 150
 ENEMY_MOVE_ANIMATION_MS = 190
 STAGE_INTRO_MS = 900
 POSITION_SCALE = 256
+PLAYER_MOVE_QUEUE_THRESHOLD = POSITION_SCALE // 3
 MAX_DECALS = 12
+DECAL_SCORCH_MS = 12000
+DECAL_DEBRIS_MS = 8000
+DECAL_ENEMY_MS = 10000
 
 DIRECTIONS = ((0, -1), (0, 1), (-1, 0), (1, 0))
 SAFE_TILES = (
@@ -120,11 +125,50 @@ class GameModel:
         self.player_facing = 0
         self.player_draw_x = POSITION_SCALE
         self.player_draw_y = POSITION_SCALE
+        self.paused_at = 0
 
     def open_mode_menu(self):
         """Open the mode chooser with the current mode highlighted."""
         self.menu_selection = self.mode
+        self.paused_at = 0
         self.state = STATE_MODE_SELECT
+
+    def pause(self, now):
+        """Freeze active gameplay until the player resumes."""
+        if self.state != STATE_PLAYING:
+            return False
+        self.paused_at = now
+        self.state = STATE_PAUSED
+        return True
+
+    def resume(self, now):
+        """Resume gameplay without advancing any active timers."""
+        if self.state != STATE_PAUSED:
+            return False
+
+        paused_for = max(0, ticks_diff(now, self.paused_at))
+        self.invulnerable_until = ticks_add(
+            self.invulnerable_until,
+            paused_for,
+        )
+        for bomb in self.bombs:
+            bomb[2] = ticks_add(bomb[2], paused_for)
+        for flame in self.explosions:
+            flame[2] = ticks_add(flame[2], paused_for)
+        for enemy in self.enemies:
+            enemy[2] = ticks_add(enemy[2], paused_for)
+            enemy[9] = ticks_add(enemy[9], paused_for)
+        for decal in self.decals:
+            if len(decal) >= 6:
+                decal[5] = ticks_add(decal[5], paused_for)
+        for effect in self.death_effects:
+            effect[3] = ticks_add(effect[3], paused_for)
+            effect[4] = ticks_add(effect[4], paused_for)
+
+        self.animation_last = now
+        self.paused_at = 0
+        self.state = STATE_PLAYING
+        return True
 
     def select_mode(self, direction):
         """Move the mode chooser selection."""
@@ -146,6 +190,7 @@ class GameModel:
         self.player_name = ""
         self.flame_range = 2
         self.bomb_limit = 1
+        self.paused_at = 0
         self._build_stage(now)
 
     def _build_stage(self, now):
@@ -227,6 +272,7 @@ class GameModel:
                     y * POSITION_SCALE,
                     elite,
                     ticks_add(now, randint(1600, 3000)),
+                    randint(-70, 100),
                 ]
             )
 
@@ -247,9 +293,9 @@ class GameModel:
                     (GRID_HEIGHT - 2) * POSITION_SCALE,
                     0,
                     ticks_add(now, 2200),
+                    randint(-70, 100),
                 ]
             )
-
     def _choose_theme(self):
         theme = randint(0, len(THEME_NAMES) - 1)
         if theme == self.theme:
@@ -302,10 +348,19 @@ class GameModel:
         return True
 
     def move_player(self, dx, dy, now):
-        """Attempt to move the player by one grid tile."""
+        """Attempt to queue one grid tile of player movement."""
         if self.state != STATE_PLAYING:
             return False
         self.player_facing = self._facing_for_direction(dx, dy)
+        target_draw_x = self.player_x * POSITION_SCALE
+        target_draw_y = self.player_y * POSITION_SCALE
+        if (
+            abs(self.player_draw_x - target_draw_x)
+            > PLAYER_MOVE_QUEUE_THRESHOLD
+            or abs(self.player_draw_y - target_draw_y)
+            > PLAYER_MOVE_QUEUE_THRESHOLD
+        ):
+            return False
         x = self.player_x + dx
         y = self.player_y + dy
         if not self._can_enter(x, y):
@@ -359,8 +414,8 @@ class GameModel:
                 return True
         return False
 
-    def _add_explosion(self, x, y, expires, owner=0):
-        self._scorch_decals_at(x, y)
+    def _add_explosion(self, x, y, expires, now, owner=0):
+        self._scorch_decals_at(x, y, now)
         for flame in self.explosions:
             if flame[0] == x and flame[1] == y:
                 flame[2] = expires
@@ -379,9 +434,18 @@ class GameModel:
         kind = POWER_FLAME if randint(0, 1) == 0 else POWER_BOMB
         self.powerups.append([x, y, kind])
 
-    def _add_decal(self, draw_x, draw_y, kind):
+    @staticmethod
+    def _decal_lifetime(kind):
+        if kind == DECAL_SCORCH:
+            return DECAL_SCORCH_MS
+        if kind == DECAL_DEBRIS:
+            return DECAL_DEBRIS_MS
+        return DECAL_ENEMY_MS
+
+    def _add_decal(self, draw_x, draw_y, kind, now):
         tile_x = (draw_x + POSITION_SCALE // 2) // POSITION_SCALE
         tile_y = (draw_y + POSITION_SCALE // 2) // POSITION_SCALE
+        expires = ticks_add(now, self._decal_lifetime(kind))
         if kind == DECAL_SCORCH:
             for decal in self.decals:
                 decal_x = (decal[0] + POSITION_SCALE // 2) // POSITION_SCALE
@@ -390,6 +454,10 @@ class GameModel:
                     decal[2] = DECAL_SCORCH
                     decal[3] = self.theme
                     decal[4] = randint(0, 3)
+                    if len(decal) >= 6:
+                        decal[5] = expires
+                    else:
+                        decal.append(expires)
                     return
         if len(self.decals) >= MAX_DECALS:
             replace_index = -1
@@ -410,16 +478,30 @@ class GameModel:
                 kind,
                 self.theme,
                 randint(0, 3),
+                expires,
             ]
         )
 
-    def _scorch_decals_at(self, x, y):
+    def _scorch_decals_at(self, x, y, now):
+        expires = ticks_add(now, DECAL_SCORCH_MS)
         for decal in self.decals:
             decal_x = (decal[0] + POSITION_SCALE // 2) // POSITION_SCALE
             decal_y = (decal[1] + POSITION_SCALE // 2) // POSITION_SCALE
             if decal_x == x and decal_y == y:
                 decal[2] = DECAL_SCORCH
                 decal[3] = self.theme
+                if len(decal) >= 6:
+                    decal[5] = expires
+                else:
+                    decal.append(expires)
+
+    def _cleanup_decals(self, now):
+        changed = False
+        for decal in self.decals[:]:
+            if len(decal) >= 6 and ticks_diff(now, decal[5]) >= 0:
+                self.decals.remove(decal)
+                changed = True
+        return changed
 
     def _detonate(self, bomb, now):
         """Turn one bomb into blast tiles and arm bombs caught in the blast."""
@@ -428,11 +510,12 @@ class GameModel:
         self.bombs.remove(bomb)
         expires = ticks_add(now, EXPLOSION_MS)
         owner = bomb[4] if len(bomb) >= 5 else 0
-        self._add_explosion(bomb[0], bomb[1], expires, owner)
+        self._add_explosion(bomb[0], bomb[1], expires, now, owner)
         self._add_decal(
             bomb[0] * POSITION_SCALE,
             bomb[1] * POSITION_SCALE,
             DECAL_SCORCH,
+            now,
         )
 
         for dx, dy in DIRECTIONS:
@@ -442,7 +525,7 @@ class GameModel:
                 tile = self.grid[y][x]
                 if tile == TILE_SOLID:
                     break
-                self._add_explosion(x, y, expires, owner)
+                self._add_explosion(x, y, expires, now, owner)
 
                 chained = None
                 for other in self.bombs:
@@ -460,6 +543,7 @@ class GameModel:
                         x * POSITION_SCALE,
                         y * POSITION_SCALE,
                         DECAL_DEBRIS,
+                        now,
                     )
                     self._reveal_powerup(x, y)
                     break
@@ -508,6 +592,7 @@ class GameModel:
                 enemy[6],
                 enemy[7],
                 decal_kind,
+                now,
             )
             self.score += 250 if enemy[8] else 100
 
@@ -648,10 +733,19 @@ class GameModel:
             enemy[4] = (enemy[4] + 1) % 4
             enemy[5] = self._facing_for_direction(chosen[2], chosen[3])
 
-        interval = max(190, 520 - self.stage * 24)
+        pace = enemy[10] if len(enemy) >= 11 else 0
+        interval = max(190, 520 - self.stage * 24 + pace)
         if enemy[8]:
             interval = max(150, interval * 3 // 4)
-        enemy[2] = ticks_add(now, interval + randint(0, 100))
+        enemy[2] = ticks_add(now, interval + randint(20, 120))
+
+    def _stagger_enemy_moves(self, now):
+        """Give every enemy a fresh, visibly separate first move deadline."""
+        for index, enemy in enumerate(self.enemies):
+            enemy[2] = ticks_add(
+                now,
+                80 + index * 105 + randint(0, 55),
+            )
 
     def _enemy_try_bomb(self, enemy, now):
         if (
@@ -763,11 +857,14 @@ class GameModel:
 
         if self._cleanup_death_effects(now):
             changed = True
+        if self._cleanup_decals(now):
+            changed = True
 
         if self.state == STATE_STAGE_INTRO:
             if ticks_diff(now, self.state_until) >= 0:
                 self.state = STATE_PLAYING
                 self.state_until = 0
+                self._stagger_enemy_moves(now)
                 return True
             return changed
 

--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/render.py
@@ -37,6 +37,7 @@ from .model import (
     STATE_LEADERBOARD,
     STATE_MODE_SELECT,
     STATE_NAME_ENTRY,
+    STATE_PAUSED,
     STATE_PLAYER_DYING,
     STATE_STAGE_CLEAR,
     STATE_STAGE_INTRO,
@@ -209,7 +210,7 @@ class Renderer:
                     0,
                 )
         if not compact:
-            self._center_text("BACK  TITLE", self.height - 16, TFT_LIGHTGREY, 0)
+            self._center_text("BACK  EXIT", self.height - 16, TFT_LIGHTGREY, 0)
 
     def _draw_leaderboard(self, game):
         draw = self.draw
@@ -1340,5 +1341,7 @@ class Renderer:
             self._draw_overlay("STAGE CLEAR", "+250 BONUS", TFT_GREEN)
         elif game.state == STATE_GAME_OVER:
             self._draw_overlay("GAME OVER", "CENTER FOR MODES", TFT_RED)
+        elif game.state == STATE_PAUSED:
+            self._draw_overlay("PAUSED", "P RESUME - BACK MODES", TFT_YELLOW)
 
         self.draw.swap()


### PR DESCRIPTION
## Summary

- make held player movement become fluid after the first queued tile instead of stopping at every grid boundary
- add pause/resume on the P key while preserving bomb, flame, enemy, decal, effect, and invulnerability timers
- expire scorch, debris, and enemy decals over time
- stagger enemy movement deadlines and add small per-enemy pace differences
- make Back return active gameplay to the mode menu, while Back from the mode menu exits the app
- enable navigation repeat only during active gameplay when the optional input API is available

## Separation

This PR contains gameplay and control behavior only.

It does not change CPU frequency, NTP scheduling, the native keyboard driver, score persistence, level themes, firmware binaries, or compiled `.mpy` files.

The game probes `Input.set_key_repeat()` with `getattr`, so it remains compatible before the native opt-in repeat PR is merged. When that API is available, repeat is enabled only while `STATE_PLAYING` is active and is disabled in the title, mode menu, name entry, pause screen, and on app exit.

## Validation

- Python syntax compilation
- `mpy-cross` for all three changed modules
- headless Pico Bomber launch with title assertion
- full simulator build and parity checks
- physical-device testing of movement, pause, menu navigation, decal expiry, and independent enemy timing in the combined test build
- `git diff --check`

