### PR TITLE
Use Picoware-managed clock lifecycle for Grocery Companion

### DIFF
--- a/builds/MicroPython/apps_unfrozen/GroceryCompanion.py
+++ b/builds/MicroPython/apps_unfrozen/GroceryCompanion.py
@@ -1,51 +1,7 @@
 import sys
-from utime import ticks_diff, ticks_ms
 
 # VERSION 2.23
 _app = None
-_clock_changed = False
-_startup_pending = False
-_frequency_idle_since = 0
-APP_CPU_FREQUENCY = 220000000
-FREQUENCY_SETTLE_MS = 100
-
-
-def _thread_manager_is_idle(view_manager):
-    thread_manager = view_manager.thread_manager
-    return thread_manager is None or thread_manager.is_idle
-
-
-def _prepare_app_frequency(view_manager):
-    global _clock_changed, _frequency_idle_since
-
-    now = ticks_ms()
-    if not _thread_manager_is_idle(view_manager):
-        _frequency_idle_since = 0
-        return False
-    if _frequency_idle_since == 0:
-        _frequency_idle_since = now
-        return False
-    if ticks_diff(now, _frequency_idle_since) < FREQUENCY_SETTLE_MS:
-        return False
-    view_manager.freq(False, APP_CPU_FREQUENCY)
-    _clock_changed = True
-    _frequency_idle_since = 0
-    return True
-
-
-def _restore_frequency(view_manager):
-    global _clock_changed
-
-    if not _clock_changed:
-        return
-    if _thread_manager_is_idle(view_manager):
-        view_manager.freq()
-        _clock_changed = False
-    else:
-        view_manager.log(
-            "[GroceryCompanion] Keeping 220 MHz because background work is active.",
-            2,
-        )
 
 
 def _finish_start(view_manager) -> bool:
@@ -74,32 +30,22 @@ def _finish_start(view_manager) -> bool:
 
 
 def start(view_manager) -> bool:
-    global _app, _startup_pending, _frequency_idle_since
+    global _app
     _app = None
-    _startup_pending = True
-    _frequency_idle_since = 0
-    return True
+    view_manager.freq(True)
+    if _finish_start(view_manager):
+        return True
+    view_manager.freq()
+    return False
 
 
 def run(view_manager) -> None:
-    global _startup_pending
-    if _startup_pending:
-        if not _prepare_app_frequency(view_manager):
-            return
-        _startup_pending = False
-        if not _finish_start(view_manager):
-            _restore_frequency(view_manager)
-            view_manager.back()
-        return
-
     if _app:
         _app.run()
 
 
 def stop(view_manager) -> None:
-    global _app, _startup_pending, _frequency_idle_since
-    _startup_pending = False
-    _frequency_idle_since = 0
+    global _app
     if _app:
         try: _app.stop()
         except Exception: pass
@@ -107,4 +53,4 @@ def stop(view_manager) -> None:
 
     from gc import collect
     collect()
-    _restore_frequency(view_manager)
+    view_manager.freq()

--- a/builds/MicroPython/apps_unfrozen/GroceryCompanion.py
+++ b/builds/MicroPython/apps_unfrozen/GroceryCompanion.py
@@ -1,9 +1,54 @@
 import sys
+from utime import ticks_diff, ticks_ms
 
 # VERSION 2.23
 _app = None
+_clock_changed = False
+_startup_pending = False
+_frequency_idle_since = 0
+APP_CPU_FREQUENCY = 220000000
+FREQUENCY_SETTLE_MS = 100
 
-def start(view_manager) -> bool:
+
+def _thread_manager_is_idle(view_manager):
+    thread_manager = view_manager.thread_manager
+    return thread_manager is None or thread_manager.is_idle
+
+
+def _prepare_app_frequency(view_manager):
+    global _clock_changed, _frequency_idle_since
+
+    now = ticks_ms()
+    if not _thread_manager_is_idle(view_manager):
+        _frequency_idle_since = 0
+        return False
+    if _frequency_idle_since == 0:
+        _frequency_idle_since = now
+        return False
+    if ticks_diff(now, _frequency_idle_since) < FREQUENCY_SETTLE_MS:
+        return False
+    view_manager.freq(False, APP_CPU_FREQUENCY)
+    _clock_changed = True
+    _frequency_idle_since = 0
+    return True
+
+
+def _restore_frequency(view_manager):
+    global _clock_changed
+
+    if not _clock_changed:
+        return
+    if _thread_manager_is_idle(view_manager):
+        view_manager.freq()
+        _clock_changed = False
+    else:
+        view_manager.log(
+            "[GroceryCompanion] Keeping 220 MHz because background work is active.",
+            2,
+        )
+
+
+def _finish_start(view_manager) -> bool:
     global _app
 
     # Initial Loading Screen
@@ -27,12 +72,34 @@ def start(view_manager) -> bool:
             _loading.stop()
         return False
 
+
+def start(view_manager) -> bool:
+    global _app, _startup_pending, _frequency_idle_since
+    _app = None
+    _startup_pending = True
+    _frequency_idle_since = 0
+    return True
+
+
 def run(view_manager) -> None:
+    global _startup_pending
+    if _startup_pending:
+        if not _prepare_app_frequency(view_manager):
+            return
+        _startup_pending = False
+        if not _finish_start(view_manager):
+            _restore_frequency(view_manager)
+            view_manager.back()
+        return
+
     if _app:
         _app.run()
 
+
 def stop(view_manager) -> None:
-    global _app
+    global _app, _startup_pending, _frequency_idle_since
+    _startup_pending = False
+    _frequency_idle_since = 0
     if _app:
         try: _app.stop()
         except Exception: pass
@@ -40,3 +107,4 @@ def stop(view_manager) -> None:
 
     from gc import collect
     collect()
+    _restore_frequency(view_manager)

--- a/builds/MicroPython/apps_unfrozen/groceryCompanion.py
+++ b/builds/MicroPython/apps_unfrozen/groceryCompanion.py
@@ -1,51 +1,7 @@
 import sys
-from utime import ticks_diff, ticks_ms
 
 # VERSION 2.23
 _app = None
-_clock_changed = False
-_startup_pending = False
-_frequency_idle_since = 0
-APP_CPU_FREQUENCY = 220000000
-FREQUENCY_SETTLE_MS = 100
-
-
-def _thread_manager_is_idle(view_manager):
-    thread_manager = view_manager.thread_manager
-    return thread_manager is None or thread_manager.is_idle
-
-
-def _prepare_app_frequency(view_manager):
-    global _clock_changed, _frequency_idle_since
-
-    now = ticks_ms()
-    if not _thread_manager_is_idle(view_manager):
-        _frequency_idle_since = 0
-        return False
-    if _frequency_idle_since == 0:
-        _frequency_idle_since = now
-        return False
-    if ticks_diff(now, _frequency_idle_since) < FREQUENCY_SETTLE_MS:
-        return False
-    view_manager.freq(False, APP_CPU_FREQUENCY)
-    _clock_changed = True
-    _frequency_idle_since = 0
-    return True
-
-
-def _restore_frequency(view_manager):
-    global _clock_changed
-
-    if not _clock_changed:
-        return
-    if _thread_manager_is_idle(view_manager):
-        view_manager.freq()
-        _clock_changed = False
-    else:
-        view_manager.log(
-            "[GroceryCompanion] Keeping 220 MHz because background work is active.",
-            2,
-        )
 
 
 def _finish_start(view_manager) -> bool:
@@ -74,32 +30,22 @@ def _finish_start(view_manager) -> bool:
 
 
 def start(view_manager) -> bool:
-    global _app, _startup_pending, _frequency_idle_since
+    global _app
     _app = None
-    _startup_pending = True
-    _frequency_idle_since = 0
-    return True
+    view_manager.freq(True)
+    if _finish_start(view_manager):
+        return True
+    view_manager.freq()
+    return False
 
 
 def run(view_manager) -> None:
-    global _startup_pending
-    if _startup_pending:
-        if not _prepare_app_frequency(view_manager):
-            return
-        _startup_pending = False
-        if not _finish_start(view_manager):
-            _restore_frequency(view_manager)
-            view_manager.back()
-        return
-
     if _app:
         _app.run()
 
 
 def stop(view_manager) -> None:
-    global _app, _startup_pending, _frequency_idle_since
-    _startup_pending = False
-    _frequency_idle_since = 0
+    global _app
     if _app:
         try: _app.stop()
         except Exception: pass
@@ -107,4 +53,4 @@ def stop(view_manager) -> None:
 
     from gc import collect
     collect()
-    _restore_frequency(view_manager)
+    view_manager.freq()

--- a/builds/MicroPython/apps_unfrozen/groceryCompanion.py
+++ b/builds/MicroPython/apps_unfrozen/groceryCompanion.py
@@ -1,9 +1,54 @@
 import sys
+from utime import ticks_diff, ticks_ms
 
 # VERSION 2.23
 _app = None
+_clock_changed = False
+_startup_pending = False
+_frequency_idle_since = 0
+APP_CPU_FREQUENCY = 220000000
+FREQUENCY_SETTLE_MS = 100
 
-def start(view_manager) -> bool:
+
+def _thread_manager_is_idle(view_manager):
+    thread_manager = view_manager.thread_manager
+    return thread_manager is None or thread_manager.is_idle
+
+
+def _prepare_app_frequency(view_manager):
+    global _clock_changed, _frequency_idle_since
+
+    now = ticks_ms()
+    if not _thread_manager_is_idle(view_manager):
+        _frequency_idle_since = 0
+        return False
+    if _frequency_idle_since == 0:
+        _frequency_idle_since = now
+        return False
+    if ticks_diff(now, _frequency_idle_since) < FREQUENCY_SETTLE_MS:
+        return False
+    view_manager.freq(False, APP_CPU_FREQUENCY)
+    _clock_changed = True
+    _frequency_idle_since = 0
+    return True
+
+
+def _restore_frequency(view_manager):
+    global _clock_changed
+
+    if not _clock_changed:
+        return
+    if _thread_manager_is_idle(view_manager):
+        view_manager.freq()
+        _clock_changed = False
+    else:
+        view_manager.log(
+            "[GroceryCompanion] Keeping 220 MHz because background work is active.",
+            2,
+        )
+
+
+def _finish_start(view_manager) -> bool:
     global _app
 
     # Initial Loading Screen
@@ -27,12 +72,34 @@ def start(view_manager) -> bool:
             _loading.stop()
         return False
 
+
+def start(view_manager) -> bool:
+    global _app, _startup_pending, _frequency_idle_since
+    _app = None
+    _startup_pending = True
+    _frequency_idle_since = 0
+    return True
+
+
 def run(view_manager) -> None:
+    global _startup_pending
+    if _startup_pending:
+        if not _prepare_app_frequency(view_manager):
+            return
+        _startup_pending = False
+        if not _finish_start(view_manager):
+            _restore_frequency(view_manager)
+            view_manager.back()
+        return
+
     if _app:
         _app.run()
 
+
 def stop(view_manager) -> None:
-    global _app
+    global _app, _startup_pending, _frequency_idle_since
+    _startup_pending = False
+    _frequency_idle_since = 0
     if _app:
         try: _app.stop()
         except Exception: pass
@@ -40,3 +107,4 @@ def stop(view_manager) -> None:
 
     from gc import collect
     collect()
+    _restore_frequency(view_manager)


### PR DESCRIPTION
## Summary

- wait for the shared `ThreadManager` to remain idle for 100 ms before changing the clock
- run GroceryCompanion at 220 MHz
- defer application initialization until the clock transition is safe
- restore the board default after teardown and roll back cleanly when initialization fails
- keep the two tracked GroceryCompanion source-name variants synchronized

## Validation

- Python AST and `mpy-cross` compilation
- mocked busy/idle clock lifecycle
- headless GroceryCompanion simulator launch
- full `simulator/run.py --sim-check`
- PicoCalc Pico 2W test confirmed 220 MHz during the app lifecycle and restoration to 240 MHz
- deployed `.mpy` was pulled back from the device and matched the compiled artifact exactly
