### PR TITLE
Use Picoware-managed clock lifecycle for Bohrgeschwindigkeit

### DIFF
--- a/builds/MicroPython/apps_unfrozen/bohrgesch_v2.py
+++ b/builds/MicroPython/apps_unfrozen/bohrgesch_v2.py
@@ -2,7 +2,6 @@ import json
 import gc
 import os
 import math
-from utime import ticks_diff, ticks_ms
 
 from picoware.system.system import System
 from picoware.system.vector import Vector
@@ -18,50 +17,6 @@ from picoware.system.buttons import (
     BUTTON_PERIOD, BUTTON_BACKSPACE,
     BUTTON_S, BUTTON_M, BUTTON_D, BUTTON_V, BUTTON_R, BUTTON_H, BUTTON_ESCAPE
 )
-
-APP_CPU_FREQUENCY = 220000000
-FREQUENCY_SETTLE_MS = 100
-_clock_changed = False
-_startup_pending = False
-_frequency_idle_since = 0
-
-
-def _thread_manager_is_idle(view_manager):
-    thread_manager = view_manager.thread_manager
-    return thread_manager is None or thread_manager.is_idle
-
-
-def _prepare_app_frequency(view_manager):
-    global _clock_changed, _frequency_idle_since
-
-    now = ticks_ms()
-    if not _thread_manager_is_idle(view_manager):
-        _frequency_idle_since = 0
-        return False
-    if _frequency_idle_since == 0:
-        _frequency_idle_since = now
-        return False
-    if ticks_diff(now, _frequency_idle_since) < FREQUENCY_SETTLE_MS:
-        return False
-    view_manager.freq(False, APP_CPU_FREQUENCY)
-    _clock_changed = True
-    _frequency_idle_since = 0
-    return True
-
-
-def _restore_frequency(view_manager):
-    global _clock_changed
-
-    if not _clock_changed:
-        return
-    if _thread_manager_is_idle(view_manager):
-        view_manager.freq()
-        _clock_changed = False
-    else:
-        view_manager.log(
-            "[bohrgesch_v2] Keeping 220 MHz because background work is active.",
-            2,
-        )
 
 _SETTINGS_FILE = "/picoware/settings/drill_pro_settings.json" 
 _VERSION = "1.82"
@@ -436,27 +391,18 @@ def _finish_start(view_manager):
 
 
 def start(view_manager):
-    global storage, _startup_pending, _frequency_idle_since
+    global storage
     storage = None
-    _startup_pending = True
-    _frequency_idle_since = 0
-    return True
+    view_manager.freq(True)
+    try:
+        return _finish_start(view_manager)
+    except Exception:
+        view_manager.freq()
+        raise
 
 
 def run(view_manager):
     global rpm_result, current_mode, dirty_ui, blink_counter, cursor_visible, pending_save, save_timer
-    global _startup_pending
-    if _startup_pending:
-        if not _prepare_app_frequency(view_manager):
-            return
-        _startup_pending = False
-        try:
-            _finish_start(view_manager)
-        except Exception:
-            _restore_frequency(view_manager)
-            raise
-        return
-    
     draw = view_manager.draw; input_mgr = view_manager.input_manager; button = input_mgr.button
     screen_w = draw.size.x; screen_h = draw.size.y
     
@@ -498,15 +444,6 @@ def stop(view_manager):
     global INPUT_DISPATCH, VIEW_DISPATCH
     global rpm_result, storage, current_mode, active_typing_field
     global dirty_ui, blink_counter, cursor_visible, pending_save, save_timer, help_scroll
-    global _startup_pending, _frequency_idle_since
-
-    was_pending = _startup_pending
-    _startup_pending = False
-    _frequency_idle_since = 0
-    if was_pending:
-        _restore_frequency(view_manager)
-        return
-    
     save_settings()
     
     # Teardown large persistent objects to free RAM for OS
@@ -529,4 +466,4 @@ def stop(view_manager):
     cursor_visible = True
     
     gc.collect()
-    _restore_frequency(view_manager)
+    view_manager.freq()

--- a/builds/MicroPython/apps_unfrozen/bohrgesch_v2.py
+++ b/builds/MicroPython/apps_unfrozen/bohrgesch_v2.py
@@ -2,6 +2,7 @@ import json
 import gc
 import os
 import math
+from utime import ticks_diff, ticks_ms
 
 from picoware.system.system import System
 from picoware.system.vector import Vector
@@ -17,6 +18,50 @@ from picoware.system.buttons import (
     BUTTON_PERIOD, BUTTON_BACKSPACE,
     BUTTON_S, BUTTON_M, BUTTON_D, BUTTON_V, BUTTON_R, BUTTON_H, BUTTON_ESCAPE
 )
+
+APP_CPU_FREQUENCY = 220000000
+FREQUENCY_SETTLE_MS = 100
+_clock_changed = False
+_startup_pending = False
+_frequency_idle_since = 0
+
+
+def _thread_manager_is_idle(view_manager):
+    thread_manager = view_manager.thread_manager
+    return thread_manager is None or thread_manager.is_idle
+
+
+def _prepare_app_frequency(view_manager):
+    global _clock_changed, _frequency_idle_since
+
+    now = ticks_ms()
+    if not _thread_manager_is_idle(view_manager):
+        _frequency_idle_since = 0
+        return False
+    if _frequency_idle_since == 0:
+        _frequency_idle_since = now
+        return False
+    if ticks_diff(now, _frequency_idle_since) < FREQUENCY_SETTLE_MS:
+        return False
+    view_manager.freq(False, APP_CPU_FREQUENCY)
+    _clock_changed = True
+    _frequency_idle_since = 0
+    return True
+
+
+def _restore_frequency(view_manager):
+    global _clock_changed
+
+    if not _clock_changed:
+        return
+    if _thread_manager_is_idle(view_manager):
+        view_manager.freq()
+        _clock_changed = False
+    else:
+        view_manager.log(
+            "[bohrgesch_v2] Keeping 220 MHz because background work is active.",
+            2,
+        )
 
 _SETTINGS_FILE = "/picoware/settings/drill_pro_settings.json" 
 _VERSION = "1.82"
@@ -378,7 +423,7 @@ VIEW_DISPATCH = {
     MODE_TYPING: draw_main
 }
 
-def start(view_manager):
+def _finish_start(view_manager):
     global rpm_result, storage, dirty_ui, current_mode, active_typing_field
     current_mode = MODE_MAIN
     active_typing_field = TYPING_NONE
@@ -389,8 +434,28 @@ def start(view_manager):
     dirty_ui = True
     return True
 
+
+def start(view_manager):
+    global storage, _startup_pending, _frequency_idle_since
+    storage = None
+    _startup_pending = True
+    _frequency_idle_since = 0
+    return True
+
+
 def run(view_manager):
     global rpm_result, current_mode, dirty_ui, blink_counter, cursor_visible, pending_save, save_timer
+    global _startup_pending
+    if _startup_pending:
+        if not _prepare_app_frequency(view_manager):
+            return
+        _startup_pending = False
+        try:
+            _finish_start(view_manager)
+        except Exception:
+            _restore_frequency(view_manager)
+            raise
+        return
     
     draw = view_manager.draw; input_mgr = view_manager.input_manager; button = input_mgr.button
     screen_w = draw.size.x; screen_h = draw.size.y
@@ -433,6 +498,14 @@ def stop(view_manager):
     global INPUT_DISPATCH, VIEW_DISPATCH
     global rpm_result, storage, current_mode, active_typing_field
     global dirty_ui, blink_counter, cursor_visible, pending_save, save_timer, help_scroll
+    global _startup_pending, _frequency_idle_since
+
+    was_pending = _startup_pending
+    _startup_pending = False
+    _frequency_idle_since = 0
+    if was_pending:
+        _restore_frequency(view_manager)
+        return
     
     save_settings()
     
@@ -456,3 +529,4 @@ def stop(view_manager):
     cursor_visible = True
     
     gc.collect()
+    _restore_frequency(view_manager)


### PR DESCRIPTION
## Summary

- wait for the shared `ThreadManager` to remain idle for 100 ms before changing the clock
- run bohrgesch_v2 at 220 MHz
- defer application initialization until the clock transition is safe
- restore the board default after teardown and roll back cleanly when initialization fails

## Validation

- Python AST and `mpy-cross` compilation
- mocked busy/idle clock lifecycle
- headless bohrgesch_v2 simulator launch
- full `simulator/run.py --sim-check`
- PicoCalc Pico 2W test confirmed 220 MHz during the app lifecycle and restoration to 240 MHz
- deployed `.mpy` was pulled back from the device and matched the compiled artifact exactly
