### PR TITLE
Remove unnecessary Pico Bomber clock changes

### DIFF
--- a/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
+++ b/builds/MicroPython/apps_unfrozen/games/pico_bomber/app.py
@@ -258,22 +258,17 @@ def _finish_start(view_manager):
 
 
 def start(view_manager):
-    """Create a fresh title screen at Picoware's managed low clock."""
+    """Create a fresh Pico Bomber startup splash."""
     global _mode_start_pending, _redraw_pending, _mode_idle_since
 
-    view_manager.freq(True)
     _mode_start_pending = False
     _redraw_pending = False
     _mode_idle_since = 0
     _write_start_marker(view_manager, "entered")
-    try:
-        _set_key_repeat(view_manager, False, True)
-        _write_start_marker(view_manager, "repeat-off")
-        _finish_start(view_manager)
-        return True
-    except Exception:
-        view_manager.freq()
-        raise
+    _set_key_repeat(view_manager, False, True)
+    _write_start_marker(view_manager, "repeat-off")
+    _finish_start(view_manager)
+    return True
 
 
 def _run_once(view_manager):
@@ -497,4 +492,3 @@ def stop(view_manager):
     _redraw_pending = False
     _mode_idle_since = 0
     collect()
-    view_manager.freq()


### PR DESCRIPTION
## Summary

- remove Pico Bomber's app-specific frequency change from `start()`
- rely on Picoware's `start` -> `run` -> `stop` lifecycle instead of restoring frequency inside startup exception handling
- remove the matching `stop()` frequency restore because Pico Bomber does not require a custom clock

## Validation

- Python compile check for the launcher and all package modules
- `mpy-cross` compilation for the launcher and all package modules
- deployed the resulting package to PicoCalc and verified all six installed files byte-for-byte
- `git diff --check`

Simulator note: current `origin/dev` aborts before Pico Bomber import because the simulator keyboard shim does not export `set_background_poll`; that unrelated base issue is intentionally excluded from this one-file PR.