### PR TITLE
Fix simulator parity for Picoware 2.1

### DIFF
--- a/simulator/hardware/engine.py
+++ b/simulator/hardware/engine.py
@@ -690,6 +690,8 @@ class Level(_Native):
         self.entities = []
         self.clear_allowed = True
         self.is_active = True
+        self.light_direction = self._vector(0.577, 0.577, 0.577)
+        self.shadow_color = 0
 
     @property
     def entity_count(self):
@@ -779,6 +781,162 @@ class Level(_Native):
         Engine(game, 0).draw()
         return True
 
+    def set_light_direction(self, x, y, z):
+        x = float(x)
+        y = float(y)
+        z = float(z)
+        length = sqrt(x * x + y * y + z * z)
+        if length > 0.0001:
+            self.light_direction = self._vector(
+                x / length, y / length, z / length
+            )
+        return None
+
+    def set_shadow_color(self, color):
+        self.shadow_color = int(color) & 0xFFFF
+        return None
+
+    def render_3d_sprite(
+        self, path, view_height=0.0, clamp=False, wireframe=True
+    ):
+        game = getattr(self, "game", None)
+        draw = getattr(game, "draw", None) if game is not None else None
+        if draw is None:
+            raise ValueError("Draw context is null")
+
+        player = None
+        for entity in self.entities:
+            if getattr(entity, "is_player", False):
+                player = entity
+                break
+        if player is None:
+            return None
+
+        sprite = Sprite3D()
+        if not sprite.from_path(path, wireframe):
+            return None
+        self._draw_sprite_triangles(
+            draw,
+            sprite,
+            getattr(player, "position", None),
+            getattr(player, "direction", None),
+            float(view_height),
+            bool(clamp),
+        )
+        return None
+
+    def _draw_sprite_triangles(
+        self, draw, sprite, player_position, player_direction, view_height, clamp
+    ):
+        player_position = player_position or self._vector(0, 0, 0)
+        player_direction = player_direction or self._vector(1, 0, 0)
+        direction_x = float(getattr(player_direction, "x", 1) or 0)
+        direction_y = float(getattr(player_direction, "y", 0) or 0)
+        direction_length = sqrt(
+            direction_x * direction_x + direction_y * direction_y
+        )
+        if direction_length <= 0.0001:
+            direction_x, direction_y, direction_length = 1.0, 0.0, 1.0
+        direction_x /= direction_length
+        direction_y /= direction_length
+
+        width = int(
+            getattr(draw, "width", getattr(getattr(draw, "size", None), "x", 320))
+        )
+        height = int(
+            getattr(
+                draw, "height", getattr(getattr(draw, "size", None), "y", 320)
+            )
+        )
+        half_width = width * 0.5
+        half_height = height * 0.5
+        camera_a = -direction_y
+        camera_b = direction_x
+        camera_c = direction_x
+        camera_d = direction_y
+
+        for triangle in sprite.triangles:
+            points = sprite.transformed_points(triangle)
+            projected = []
+            for x, y, z in points:
+                world_x = x - float(getattr(player_position, "x", 0) or 0)
+                world_y = y - view_height
+                world_z = z - float(getattr(player_position, "y", 0) or 0)
+                camera_z = world_x * camera_c + world_z * camera_d
+                if camera_z <= 0.1:
+                    projected = []
+                    break
+                inverse_z = 1.0 / camera_z
+                screen_x = (
+                    (world_x * camera_a + world_z * camera_b)
+                    * inverse_z
+                    * height
+                    + half_width
+                )
+                screen_y = -world_y * inverse_z * height + half_height
+                projected.append((screen_x, screen_y))
+            if len(projected) != 3:
+                continue
+
+            if not clamp:
+                if (
+                    all(point[0] < 0 for point in projected)
+                    or all(point[0] > width for point in projected)
+                    or all(point[1] < 0 for point in projected)
+                    or all(point[1] > height for point in projected)
+                ):
+                    continue
+            else:
+                projected = [
+                    (
+                        max(0, min(width, point[0])),
+                        max(0, min(height, point[1])),
+                    )
+                    for point in projected
+                ]
+
+            coords = []
+            for point in projected:
+                coords.extend((int(point[0]), int(point[1])))
+            draw._fill_triangle(
+                coords[0],
+                coords[1],
+                coords[2],
+                coords[3],
+                coords[4],
+                coords[5],
+                int(getattr(triangle, "color", 0)) & 0xFFFF,
+            )
+            if getattr(triangle, "wireframe", True):
+                draw._triangle(
+                    coords[0],
+                    coords[1],
+                    coords[2],
+                    coords[3],
+                    coords[4],
+                    coords[5],
+                    self._outline_color(int(getattr(triangle, "color", 0))),
+                )
+
+    def _outline_color(self, color):
+        red = (color >> 11) & 0x1F
+        green = (color >> 5) & 0x3F
+        blue = color & 0x1F
+        red += (0x1F - red) >> 1
+        green += (0x3F - green) >> 1
+        blue += (0x1F - blue) >> 1
+        return (red << 11) | (green << 5) | blue
+
+    def _vector(self, x, y, z):
+        class V:
+            pass
+
+        value = V()
+        value.x = x
+        value.y = y
+        value.z = z
+        return value
+
     def _call_callback(self, callback, *args):
         for count in range(len(args), -1, -1):
             try:
@@ -829,6 +987,10 @@ class Image(_Native):
 
 
 class Sprite3D(_Native):
+    MAX_TRIANGLES_PER_SPRITE = 2048
+    _TRIANGLE_FORMAT = "<9fB3xfBxHB3x"
+    _TRIANGLE_SIZE = 52
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if len(args) >= 6:
@@ -866,6 +1028,105 @@ class Sprite3D(_Native):
         fields["scale"] = value
         return None
 
+    def set_wireframe(self, wireframe):
+        state = bool(wireframe)
+        for triangle in self.triangles:
+            triangle.wireframe = state
+        return None
+
+    def from_path(self, path, wireframe=True):
+        import sd_mp
+        import ustruct
+
+        self.triangles = []
+        try:
+            data = sd_mp.read(path)
+        except Exception:
+            return False
+        count = min(
+            len(data) // self._TRIANGLE_SIZE, self.MAX_TRIANGLES_PER_SPRITE
+        )
+        for index in range(count):
+            values = ustruct.unpack_from(
+                self._TRIANGLE_FORMAT, data, index * self._TRIANGLE_SIZE
+            )
+            triangle = Triangle3D(
+                values[0],
+                values[1],
+                values[2],
+                values[3],
+                values[4],
+                values[5],
+                values[6],
+                values[7],
+                values[8],
+                values[12],
+                bool(values[9]),
+                values[10],
+            )
+            triangle.set = bool(values[11])
+            triangle.wireframe = bool(wireframe)
+            self.triangles.append(triangle)
+        return count > 0
+
+    def to_path(self, path):
+        import sd_mp
+        import ustruct
+
+        if not self.triangles:
+            return False
+        data = bytearray()
+        for triangle in self.triangles[: self.MAX_TRIANGLES_PER_SPRITE]:
+            data.extend(
+                ustruct.pack(
+                    self._TRIANGLE_FORMAT,
+                    float(triangle.x1),
+                    float(triangle.y1),
+                    float(triangle.z1),
+                    float(triangle.x2),
+                    float(triangle.y2),
+                    float(triangle.z2),
+                    float(triangle.x3),
+                    float(triangle.y3),
+                    float(triangle.z3),
+                    1 if getattr(triangle, "visible", True) else 0,
+                    float(getattr(triangle, "distance", 0)),
+                    1 if getattr(triangle, "set", True) else 0,
+                    int(getattr(triangle, "color", 0)) & 0xFFFF,
+                    1 if getattr(triangle, "wireframe", True) else 0,
+                )
+            )
+        try:
+            return bool(sd_mp.write(path, data, True))
+        except Exception:
+            return False
+
+    def transformed_points(self, triangle):
+        scale = float(self.scale_factor)
+        rotation = float(self.rotation_y)
+        cosine = cos(rotation) if cos is not None else 1.0
+        sine = sin(rotation) if sin is not None else 0.0
+        position = self.position
+        position_x = float(getattr(position, "x", 0) or 0)
+        position_y = float(getattr(position, "y", 0) or 0)
+        position_z = float(getattr(position, "z", 0) or 0)
+        output = []
+        for x, y, z in (
+            (triangle.x1, triangle.y1, triangle.z1),
+            (triangle.x2, triangle.y2, triangle.z2),
+            (triangle.x3, triangle.y3, triangle.z3),
+        ):
+            x = float(x) * scale
+            y = float(y) * scale
+            z = float(z) * scale
+            original_x = x
+            x = original_x * cosine - z * sine
+            z = original_x * sine + z * cosine
+            output.append(
+                (x + position_x, y + position_z, z + position_y)
+            )
+        return output
+
     def create_wall(self, x=0, y=0, z=0, length=1.0, height=1.0, depth=0.2, color=0x7BEF):
         self.wall_length = float(length)
         self.wall_height = float(height)
@@ -893,3 +1154,5 @@ class Triangle3D(_Native):
         self.color = color
         self.visible = visible
         self.distance = distance
+        self.set = True
+        self.wireframe = True

--- a/simulator/hardware/font.py
+++ b/simulator/hardware/font.py
@@ -13,7 +13,7 @@ class FontSize:
         elif size == 2:
             object.__setattr__(self, "width", 11)
             object.__setattr__(self, "height", 16)
-            object.__setattr__(self, "spacing", 0)
+            object.__setattr__(self, "spacing", 1)
         elif size == 3:
             object.__setattr__(self, "width", 14)
             object.__setattr__(self, "height", 20)

--- a/simulator/hardware/lcd.py
+++ b/simulator/hardware/lcd.py
@@ -3,6 +3,20 @@ import sim_font
 import ustruct
 
 
+def default_font_for_board(board_id, boards=None):
+    """Return the firmware's compile-time default font for a board."""
+    if boards is None:
+        import picoware_boards as boards
+    if board_id in (boards.BOARD_CARDPUTER, boards.BOARD_WAVESHARE_2_06):
+        return 1
+    if board_id in (
+        boards.BOARD_WAVESHARE_1_43_RP2350,
+        boards.BOARD_WAVESHARE_3_49_RP2350,
+    ):
+        return 2
+    return 0
+
+
 def _rgb565_to_rgb(color):
     color = int(color) & 0xFFFF
     r = ((color >> 11) & 31) * 255 // 31
@@ -15,7 +29,7 @@ class LCD:
     width = 320
     height = 320
 
-    FONT_DEFAULT = 1
+    FONT_DEFAULT = 0
     FONT_XTRA_SMALL = 0
     FONT_SMALL = 1
     FONT_MEDIUM = 2
@@ -30,6 +44,9 @@ class LCD:
             import picoware_boards
 
             self.width, self.height = picoware_boards.get_current_display_size()
+            self.FONT_DEFAULT = default_font_for_board(
+                picoware_boards.BOARD_ID, picoware_boards
+            )
             if self.width * self.height > 320 * 480:
                 self.width, self.height = 320, 320
         except Exception:
@@ -199,10 +216,12 @@ class LCD:
         self._fill_rectangle(x, y, w, h, color)
 
     def _font_metrics(self, font_size):
+        if font_size is None:
+            font_size = self.FONT_DEFAULT
         if font_size == 0:
             return 5, 8, 1
         if font_size == 2:
-            return 11, 16, 0
+            return 11, 16, 1
         if font_size == 3:
             return 14, 20, 0
         if font_size == 4:

--- a/simulator/hardware/picoware_keyboard.py
+++ b/simulator/hardware/picoware_keyboard.py
@@ -1,12 +1,30 @@
 import sim_runtime
 
+_initialized = False
+
 
 def init():
+    global _initialized
+    _initialized = True
     return True
 
 
 def deinit():
+    global _initialized
+    _initialized = False
+    sim_runtime.set_background_key_poll(False)
+    sim_runtime.register_key_callback(None)
     return True
+
+
+def set_background_poll(enable):
+    sim_runtime.set_background_key_poll(bool(enable))
+
+
+def set_key_available_callback(callback):
+    if callback is not None and not callable(callback):
+        raise TypeError("callback must be callable or None")
+    sim_runtime.register_key_callback(callback)
 
 
 def poll():

--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -65,6 +65,9 @@ _record_text = ""
 _touch_point = (0, 0)
 _touch_gesture = 0
 _touch_callbacks = []
+_key_callback = None
+_background_key_poll = False
+_notifying_key = False
 _battery_percentage = 87
 
 
@@ -146,6 +149,7 @@ def configure(_root, _sd_root, _apps_source, _scale, _board, _max_frames, _headl
     global frame_count, loop_count, open_target, _keys, _delayed_keys, _held_keys, _lcd
     global _wait_view, _assert_text, _seen_wait_view, _seen_assert_text, _current_view_name, _recent_text
     global _recent_input, _record_text
+    global _key_callback, _background_key_poll, _notifying_key
     root = _root
     sd_root = _sd_root
     apps_source = _apps_source
@@ -192,6 +196,9 @@ def configure(_root, _sd_root, _apps_source, _scale, _board, _max_frames, _headl
     _recent_text = []
     _recent_input = []
     _record_text = ""
+    _key_callback = None
+    _background_key_poll = False
+    _notifying_key = False
     if record_path:
         parent = record_path.rsplit("/", 1)[0] if "/" in record_path else "."
         mkdir_p(parent)
@@ -339,6 +346,7 @@ def seed_sd(profile="dev"):
         "picoware/apps/games/ghouls",
         "picoware/apps/games/ghouls/assets",
         "picoware/bluetooth",
+        "picoware/scripts",
     )
     media_dirs = dev_dirs + (
         "picoware/vibesmp",
@@ -406,6 +414,8 @@ def seed_sd(profile="dev"):
 
     # Symlink apps for __import__
     _link_app_files()
+    if profile != "clean":
+        _link_script_files()
 
 
 def _link_app_files():
@@ -416,6 +426,13 @@ def _link_app_files():
     _compiled = root + "/builds/MicroPython/apps"
     if _compiled != apps_source:
         _link_app_files_into(_compiled, target, skip_if_py_exists=True)
+
+
+def _link_script_files():
+    """Symlink bundled JavaScript examples into the simulated SD card."""
+    source = root + "/builds/MicroPython/scripts"
+    target = sd_root + "/picoware/scripts"
+    _link_app_files_into(source, target)
 
 
 def _link_app_files_into(src_dir, dst_dir, skip_if_py_exists=False, include_init=False):
@@ -576,6 +593,35 @@ def push_key(code):
         print("[sim:key]", code)
     _keys.append(code)
     _remember_input(code)
+
+
+def register_key_callback(callback):
+    """Register the callback used by native background keyboard polling."""
+    global _key_callback
+    _key_callback = callback
+
+
+def set_background_key_poll(enable):
+    """Enable or disable simulated background keyboard polling."""
+    global _background_key_poll
+    _background_key_poll = bool(enable)
+
+
+def _dispatch_key_callback():
+    """Deliver at most one queued key per simulated hardware poll."""
+    global _notifying_key
+    if (
+        _notifying_key
+        or not _background_key_poll
+        or _key_callback is None
+        or not _keys
+    ):
+        return
+    _notifying_key = True
+    try:
+        _key_callback(None)
+    finally:
+        _notifying_key = False
 
 
 def _remember_input(code):
@@ -1040,6 +1086,18 @@ def frame_swapped():
     if screenshot_path and _lcd is not None:
         _lcd.screenshot(screenshot_path)
     if max_frames and frame_count >= max_frames:
+        _check_expectations(True)
+        raise StopSimulation()
+
+
+def input_polled():
+    """Advance background hardware when Picoware observes its input state."""
+    global loop_count
+    loop_count += 1
+    poll_events()
+    _dispatch_key_callback()
+    _write_status(False)
+    if max_frames and loop_count >= max_frames * 200:
         _check_expectations(True)
         raise StopSimulation()
 

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -296,6 +296,7 @@ def _install_view_tracking():
     """Report ViewManager transitions to the simulator harness."""
     try:
         import sim_runtime
+        from picoware.system.input import Input
         from picoware.system.view_manager import ViewManager
     except Exception:
         return
@@ -351,10 +352,41 @@ def _install_view_tracking():
         note(self)
         return result
 
+    def tracked_input_button(self):
+        from picoware.system.boards import (
+            BOARD_CARDPUTER,
+            BOARD_CROWPANEL_10_1,
+            BOARD_FLIPPER_ZERO,
+            BOARD_PANCAKE,
+            BOARD_WAVESHARE_2_06,
+        )
+
+        sim_runtime.input_polled()
+        if self._current_board_id in (
+            BOARD_CROWPANEL_10_1,
+            BOARD_WAVESHARE_2_06,
+            BOARD_PANCAKE,
+        ):
+            self._poll_touch()
+        elif self._current_board_id == BOARD_CARDPUTER:
+            from cardputer_keyboard import key_available, poll
+
+            poll()
+            if key_available():
+                self.on_key_callback()
+        elif self._current_board_id == BOARD_FLIPPER_ZERO:
+            from flipper_input import key_available, poll
+
+            poll()
+            if key_available():
+                self.on_key_callback()
+        return self._last_button
+
     ViewManager.set = tracked_set
     ViewManager.switch_to = tracked_switch_to
     ViewManager.back = tracked_back
     ViewManager.remove = tracked_remove
+    Input.button = property(tracked_input_button)
     ViewManager._sim_view_tracking_installed = True
 
 
@@ -563,6 +595,10 @@ def _run_sim_check(opts):
         if status != 0:
             print("[sim-check:fail]", cmd, status)
             raise SystemExit(1)
+    _run_keyboard_background_check()
+    _run_engine_parity_check()
+    _run_font_parity_check()
+    _run_scripts_fixture_check(opts)
     _run_touch_check()
     _run_flipper_battery_check()
     _run_log_storage_check(opts)
@@ -570,6 +606,154 @@ def _run_sim_check(opts):
     _run_fatal_exit_check(opts)
     _run_mjs_check()
     print("[sim-check:pass]")
+
+
+def _run_keyboard_background_check():
+    """Exercise the PicoCalc background-poll callback contract."""
+    import picoware_keyboard
+    import sim_runtime
+
+    received = []
+
+    def on_key(_):
+        received.append(picoware_keyboard.get_key_nonblocking())
+
+    sim_runtime._keys = []
+    picoware_keyboard.init()
+    picoware_keyboard.set_key_available_callback(on_key)
+    picoware_keyboard.set_background_poll(True)
+    sim_runtime.push_key(ord("a"))
+    sim_runtime.push_key(ord("b"))
+    sim_runtime.input_polled()
+    if received != [ord("a")]:
+        raise RuntimeError("simulator background keyboard dispatched wrong first key")
+    sim_runtime.input_polled()
+    if received != [ord("a"), ord("b")]:
+        raise RuntimeError("simulator background keyboard did not dispatch queued keys")
+
+    picoware_keyboard.set_background_poll(False)
+    sim_runtime.push_key(ord("c"))
+    sim_runtime.input_polled()
+    if received != [ord("a"), ord("b")]:
+        raise RuntimeError("simulator background keyboard ignored disabled state")
+    if sim_runtime.pop_key() != ord("c"):
+        raise RuntimeError("simulator disabled background keyboard consumed a key")
+    picoware_keyboard.deinit()
+    print("[sim-check:ok] picocalc background keyboard callbacks")
+
+
+def _run_engine_parity_check():
+    """Exercise the latest Level and Sprite3D native API additions."""
+    import sd_mp
+    import sim_runtime
+    from engine import Level, Sprite3D, Triangle3D
+    from picoware.gui.draw import Draw
+    from picoware.system.vector import Vector
+
+    path = "sim_reports/engine-roundtrip.sprite3d"
+    sprite = Sprite3D()
+    triangle = Triangle3D(
+        2.0,
+        -0.5,
+        -0.5,
+        2.0,
+        0.5,
+        0.0,
+        2.0,
+        -0.5,
+        0.5,
+        0x07E0,
+        True,
+        0,
+    )
+    triangle.wireframe = False
+    sprite.triangles.append(triangle)
+    if not sprite.to_path(path):
+        raise RuntimeError("simulator Sprite3D.to_path failed")
+
+    loaded = Sprite3D()
+    if not loaded.from_path(path, False) or len(loaded.triangles) != 1:
+        raise RuntimeError("simulator Sprite3D.from_path failed")
+    loaded_triangle = loaded.triangles[0]
+    if loaded_triangle.color != 0x07E0 or loaded_triangle.wireframe:
+        raise RuntimeError("simulator Sprite3D round-trip data mismatch")
+    loaded.set_wireframe(True)
+    if not loaded_triangle.wireframe:
+        raise RuntimeError("simulator Sprite3D.set_wireframe failed")
+
+    class GameProbe:
+        pass
+
+    class PlayerProbe:
+        pass
+
+    original_headless = sim_runtime.headless
+    draw = None
+    try:
+        sim_runtime.headless = True
+        draw = Draw()
+        game = GameProbe()
+        game.draw = draw
+        player = PlayerProbe()
+        player.is_player = True
+        player.position = Vector(0, 0, 0)
+        player.direction = Vector(1, 0, 0)
+        level = Level(game=game)
+        level.entities.append(player)
+        if abs(level.light_direction.x - 0.577) > 0.001:
+            raise RuntimeError("simulator Level default light direction mismatch")
+        level.set_light_direction(0, 3, 4)
+        if (
+            abs(level.light_direction.y - 0.6) > 0.001
+            or abs(level.light_direction.z - 0.8) > 0.001
+        ):
+            raise RuntimeError("simulator Level.set_light_direction failed")
+        level.set_shadow_color(0x39E7)
+        if level.shadow_color != 0x39E7:
+            raise RuntimeError("simulator Level.set_shadow_color failed")
+        level.render_3d_sprite(path, 0.0, False, True)
+        if not any(draw._buffer):
+            raise RuntimeError("simulator Level.render_3d_sprite drew no pixels")
+    finally:
+        draw = None
+        sim_runtime.set_lcd(None)
+        sim_runtime.headless = original_headless
+        sd_mp.remove(path)
+        gc.collect()
+    print("[sim-check:ok] engine Level and Sprite3D parity")
+
+
+def _run_font_parity_check():
+    """Verify board-default fonts and the corrected Font16 spacing."""
+    import lcd
+    import picoware_boards as boards
+    from font import FontSize
+
+    small = (boards.BOARD_CARDPUTER, boards.BOARD_WAVESHARE_2_06)
+    medium = (
+        boards.BOARD_WAVESHARE_1_43_RP2350,
+        boards.BOARD_WAVESHARE_3_49_RP2350,
+    )
+    for board_id in range(boards.BOARD_FLIPPER_ZERO + 1):
+        expected = 1 if board_id in small else 2 if board_id in medium else 0
+        if lcd.default_font_for_board(board_id, boards) != expected:
+            raise RuntimeError("simulator board default font mismatch")
+    if FontSize(2).spacing != 1:
+        raise RuntimeError("simulator Font16 spacing mismatch")
+    print("[sim-check:ok] board default fonts and Font16 spacing")
+
+
+def _run_scripts_fixture_check(opts):
+    """Verify bundled JavaScript files are linked into the simulated SD."""
+    path = opts["sd"].rstrip("/") + "/picoware/scripts/hello.js"
+    try:
+        with open(path, "r") as handle:
+            contents = handle.read()
+    except OSError:
+        contents = ""
+    if 'draw.text(0, 10, "Hello From JavaScript")' not in contents:
+        raise RuntimeError("simulator bundled scripts fixture is missing")
+    print("[sim-check:ok] bundled JavaScript scripts fixture")
 
 
 def _run_touch_check():


### PR DESCRIPTION
## What changed

- restore the PicoCalc background keyboard callback API in the simulator and deliver queued input when Picoware observes input state
- add simulator parity for the new `Level` lighting/shadow/rendering methods and `Sprite3D` wireframe/file APIs
- match board-specific default fonts and Font16 spacing
- expose bundled JavaScript examples on the simulated SD card
- add focused regression checks for each parity update

## Why

Recent Picoware 2.1 firmware changes restored native background keyboard callbacks and added engine, font, and bundled-script behavior that the MicroPython simulator did not yet model. The missing keyboard methods prevented the simulator from booting, while the remaining gaps made simulator behavior diverge from supported devices.

The input implementation advances background polling when Picoware reads its input state. This preserves deterministic scripted navigation, including apps that wait for input without drawing another frame.

## Impact

The simulator boots current `dev` again, scripted app navigation remains deterministic, and applications can exercise the new engine and script APIs without requiring hardware.

## Validation

- `sh simulator/build.sh`
- `python3 -m py_compile` for all six modified Python files
- `git diff --check`
- `micropython simulator/run.py --sim-check`
- headless desktop boot on all 13 supported board profiles
