### PR TITLE
Restore simulator parity for recent Picoware APIs

### DIFF
--- a/simulator/hardware/lcd.py
+++ b/simulator/hardware/lcd.py
@@ -55,6 +55,7 @@ class LCD:
         self._scale_y_factor = scale_y
         self.scale_position = scale_position
         self._mode = self.MODE_HEAP
+        self._brightness = 100
         self._buffer = bytearray(self.width * self.height * 2)
         self._sdl = None
         self._window = 0
@@ -115,6 +116,14 @@ class LCD:
             color = int(color) & 0xFFFF
             self._buffer[off] = color & 0xFF
             self._buffer[off + 1] = (color >> 8) & 0xFF
+
+    def _get_pixel(self, x, y):
+        x = int(x)
+        y = int(y)
+        if not (0 <= x < self.width and 0 <= y < self.height):
+            return 0
+        off = self._offset(x, y)
+        return self._buffer[off] | (self._buffer[off + 1] << 8)
 
     def _clear(self, color=0):
         color = int(color) & 0xFFFF
@@ -210,7 +219,67 @@ class LCD:
         self._line(x3, y3, x1, y1, color)
 
     def _fill_triangle(self, x1, y1, x2, y2, x3, y3, color):
-        self._triangle(x1, y1, x2, y2, x3, y3, color)
+        self._fill_triangle_alpha(x1, y1, x2, y2, x3, y3, color, 255)
+
+    def _fill_triangle_alpha(self, x1, y1, x2, y2, x3, y3, color, alpha):
+        points = (
+            [int(x1), int(y1)],
+            [int(x2), int(y2)],
+            [int(x3), int(y3)],
+        )
+        if self.scale_position:
+            for point in points:
+                point[0] = self.scale_x(point[0])
+                point[1] = self.scale_y(point[1])
+
+        alpha = int(alpha) & 0xFF
+        if alpha == 0:
+            return
+
+        x1, y1 = points[0]
+        x2, y2 = points[1]
+        x3, y3 = points[2]
+        area = self._triangle_edge(x1, y1, x2, y2, x3, y3)
+        if area == 0:
+            return
+
+        min_x = max(0, min(x1, x2, x3))
+        max_x = min(self.width - 1, max(x1, x2, x3))
+        min_y = max(0, min(y1, y2, y3))
+        max_y = min(self.height - 1, max(y1, y2, y3))
+        positive = area > 0
+        color = int(color) & 0xFFFF
+
+        for y in range(min_y, max_y + 1):
+            for x in range(min_x, max_x + 1):
+                e1 = self._triangle_edge(x1, y1, x2, y2, x, y)
+                e2 = self._triangle_edge(x2, y2, x3, y3, x, y)
+                e3 = self._triangle_edge(x3, y3, x1, y1, x, y)
+                inside = e1 >= 0 and e2 >= 0 and e3 >= 0
+                if not positive:
+                    inside = e1 <= 0 and e2 <= 0 and e3 <= 0
+                if inside:
+                    if alpha == 255:
+                        blended = color
+                    else:
+                        blended = self._blend_rgb565(color, self._get_pixel(x, y), alpha)
+                    self._set_pixel(x, y, blended)
+
+    def _triangle_edge(self, ax, ay, bx, by, px, py):
+        return (px - ax) * (by - ay) - (py - ay) * (bx - ax)
+
+    def _blend_rgb565(self, source, destination, alpha):
+        inverse = 255 - alpha
+        sr = (source >> 11) & 0x1F
+        sg = (source >> 5) & 0x3F
+        sb = source & 0x1F
+        dr = (destination >> 11) & 0x1F
+        dg = (destination >> 5) & 0x3F
+        db = destination & 0x1F
+        red = (sr * alpha + dr * inverse) // 255
+        green = (sg * alpha + dg * inverse) // 255
+        blue = (sb * alpha + db * inverse) // 255
+        return (red << 11) | (green << 5) | blue
 
     def _fill_round_rectangle(self, x, y, w, h, radius, color):
         self._fill_rectangle(x, y, w, h, color)
@@ -258,16 +327,46 @@ class LCD:
     def _char(self, x, y, char, color, font_size=None):
         self._text(x, y, char, color, font_size)
 
-    def _bytearray(self, x, y, w, h, data):
-        idx = 0
-        for yy in range(int(h)):
-            for xx in range(int(w)):
-                if idx >= len(data):
-                    return
-                value = data[idx]
-                if value:
-                    self._set_pixel(int(x) + xx, int(y) + yy, self._rgb332_to_565(value))
-                idx += 1
+    def _bytearray(self, x, y, w, h, data, invert=False):
+        width = int(w)
+        height = int(h)
+        pixel_count = width * height
+        data_len = len(data)
+        if data_len < pixel_count:
+            raise ValueError("buffer too small for blit operation")
+
+        is_16bit = data_len >= pixel_count * 2
+        scaled = self._scale_x_factor != 1.0 or self._scale_y_factor != 1.0
+        dst_x = self.scale_x(x) if scaled and self.scale_position else int(x)
+        dst_y = self.scale_y(y) if scaled and self.scale_position else int(y)
+        dst_w = self.scale_x(width) if scaled else width
+        dst_h = self.scale_y(height) if scaled else height
+        if dst_w <= 0 or dst_h <= 0:
+            return
+
+        for dy in range(dst_h):
+            sy = dy * height // dst_h
+            for dx in range(dst_w):
+                sx = dx * width // dst_w
+                index = sy * width + sx
+                if is_16bit:
+                    offset = index * 2
+                    value = int(data[offset]) | (int(data[offset + 1]) << 8)
+                    if invert:
+                        if value == 0xFFFF:
+                            value = 0x0000
+                        elif value == 0x0000:
+                            value = 0xFFFF
+                    color = value
+                else:
+                    value = int(data[index])
+                    if invert:
+                        if value == 0xFF:
+                            value = 0x00
+                        elif value == 0x00:
+                            value = 0xFF
+                    color = self._rgb332_to_565(value)
+                self._set_pixel(dst_x + dx, dst_y + dy, color)
 
     def _rgb332_to_565(self, value):
         value = int(value) & 0xFF
@@ -415,6 +514,9 @@ class LCD:
 
     def set_mode(self, mode):
         self._mode = mode
+
+    def set_brightness(self, level):
+        self._brightness = max(0, min(100, int(level)))
 
     def set_scaling(self, scale_x, scale_y, scale_position=False):
         self._scale_x_factor = scale_x

--- a/simulator/hardware/mjs.py
+++ b/simulator/hardware/mjs.py
@@ -465,6 +465,7 @@ def _buttons_module():
 
 def _draw_module():
     import lcd
+    import sim_runtime
 
     module = _Module()
     passthrough = (
@@ -487,6 +488,23 @@ def _draw_module():
             module[js_name] = getattr(lcd, name)
         else:
             module[js_name] = lambda *args, **kwargs: None
+
+    def text_len(text, font_size=None):
+        display = sim_runtime.get_lcd()
+        if display is not None:
+            width, _, spacing = display._font_metrics(font_size)
+        else:
+            width, spacing = (5, 1) if font_size in (None, 0) else (7, 0)
+        return len(str(text)) * (width + spacing)
+
+    def screenshot(path):
+        display = sim_runtime.get_lcd()
+        if display is None:
+            display = lcd.LCD()
+        return display.screenshot(sim_runtime.host_path(path))
+
+    module["len"] = text_len
+    module["screenshot"] = screenshot
     module["swap"] = getattr(lcd, "swap", lambda: None)
     return module
 
@@ -603,19 +621,24 @@ def _psram_module():
 
 def _settings_module():
     defaults = {
+        "anthropicApiKey": "",
         "darkMode": False,
         "debug": False,
         "deepseekApiKey": "",
         "exitButton": 5,
+        "geminiApiKey": "",
         "gmtOffset": 0,
+        "localUrl": "http://127.0.0.1:8080/v1/chat/completions",
         "lvglMode": False,
         "onscreenKeyboard": False,
         "openaiApiKey": "",
         "openApiKey": "",
+        "screenBrightness": 100,
         "serverSettings": {"username": "", "password": ""},
         "themeColor": 0,
         "usbStream": False,
         "wifiSettings": {"ssid": "", "password": ""},
+        "xaiApiKey": "",
     }
     return _Module(defaults)
 

--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -540,6 +540,10 @@ def set_lcd(lcd):
     _lcd = lcd
 
 
+def get_lcd():
+    return _lcd
+
+
 def set_script_expectations(wait_view="", assert_text=""):
     global _wait_view, _assert_text, _seen_wait_view, _seen_assert_text
     _wait_view = str(wait_view or "")

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -603,6 +603,7 @@ def _run_sim_check(opts):
             print("[sim-check:fail]", cmd, status)
             raise SystemExit(1)
     _run_keyboard_background_check()
+    _run_lcd_parity_check()
     _run_engine_parity_check()
     _run_board_parity_check()
     _run_font_parity_check()
@@ -649,6 +650,28 @@ def _run_keyboard_background_check():
         raise RuntimeError("simulator disabled background keyboard consumed a key")
     picoware_keyboard.deinit()
     print("[sim-check:ok] picocalc background keyboard callbacks")
+
+
+def _run_lcd_parity_check():
+    """Verify LCD APIs added by the current Picoware runtime."""
+    import lcd
+
+    display = lcd.LCD()
+    display.set_brightness(37)
+    if display._brightness != 37:
+        raise RuntimeError("simulator LCD brightness state mismatch")
+
+    display._clear(0)
+    display._bytearray(0, 0, 2, 1, bytearray((0x00, 0xFF)), True)
+    if display._get_pixel(0, 0) != 0xFFFF or display._get_pixel(1, 0) != 0x0000:
+        raise RuntimeError("simulator LCD bytearray inversion mismatch")
+
+    display._clear(0x001F)
+    display._fill_triangle_alpha(1, 1, 5, 1, 1, 5, 0xF800, 128)
+    blended = display._get_pixel(2, 2)
+    if blended in (0x001F, 0xF800):
+        raise RuntimeError("simulator LCD alpha triangle mismatch")
+    print("[sim-check:ok] lcd brightness bytearray inversion alpha triangle")
 
 
 def _run_engine_parity_check():
@@ -1020,6 +1043,7 @@ def _run_fatal_exit_check(opts):
 def _run_mjs_check():
     """Smoke-test the JavaScript modules supplied by the simulator shim."""
     import mjs
+    import sim_runtime
 
     js = mjs.MJS()
     js.run('let audio = import("audio");')
@@ -1038,7 +1062,31 @@ def _run_mjs_check():
     js.run('let websocket = import("websocket");')
     if js.run("websocket.isConnected();") is not False:
         raise RuntimeError("simulator mjs websocket state mismatch")
-    print("[sim-check:ok] mjs audio bluetooth psram websocket")
+
+    js.run('let draw = import("draw");')
+    if js.run('draw.len("Hello World");') != 66:
+        raise RuntimeError("simulator mjs draw length mismatch")
+    screenshot_path = sim_runtime.host_path("sim_reports/mjs.bmp")
+    _mkdir_p(_dirname(screenshot_path))
+    js.run('draw.screenshot("sim_reports/mjs.bmp");')
+    try:
+        if os.stat(screenshot_path)[6] <= 54:
+            raise RuntimeError("simulator mjs screenshot is empty")
+    except OSError:
+        raise RuntimeError("simulator mjs screenshot missing")
+
+    js.run('let settings = import("settings");')
+    expected_settings = (
+        ("settings.anthropicApiKey", ""),
+        ("settings.geminiApiKey", ""),
+        ("settings.localUrl", "http://127.0.0.1:8080/v1/chat/completions"),
+        ("settings.screenBrightness", 100),
+        ("settings.xaiApiKey", ""),
+    )
+    for expression, expected in expected_settings:
+        if js.run(expression + ";") != expected:
+            raise RuntimeError("simulator mjs setting mismatch: " + expression)
+    print("[sim-check:ok] mjs draw settings audio bluetooth psram websocket")
 
 
 def _write_error_file(path, exc):

--- a/simulator/start.sh
+++ b/simulator/start.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-set -eu
-
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-repo_root=$(dirname -- "$script_dir")
-
-cd "$repo_root"
-exec micropython simulator/run.py --viewer "$@"

--- a/simulator/start.sh
+++ b/simulator/start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(dirname -- "$script_dir")
+
+cd "$repo_root"
+exec micropython simulator/run.py --viewer "$@"


### PR DESCRIPTION
## Summary

- restore LCD shim parity for brightness, bytearray inversion/scaling, and alpha-filled triangles
- add the latest JavaScript draw and settings APIs to the simulator shim
- extend `--sim-check` with focused LCD and JavaScript regression coverage

## Root cause

Recent `dev` changes began calling `Draw.set_brightness()` during startup and passing the new `invert` argument to bytearray drawing, while the simulator still exposed the older LCD API. Viewer mode caught the resulting boot exception and waited for the viewer to close, which made the simulator appear open but left it at an error screen.

## Impact

The simulator now reaches `desktop_view` normally in viewer mode and covers the recent LCD and MJS API additions instead of failing during boot or silently omitting them.

This PR changes simulator code only and does not claim physical-device validation.

## Validation

- `sh simulator/build.sh --check`
- `micropython simulator/run.py --sim-check --sd /tmp/picoware-pr239-no-launcher.*`
- `git diff --check origin/dev...HEAD`
