### PR TITLE
Fix simulator audio shutdown

### DIFF
--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -1120,6 +1120,65 @@ def finish_recording():
     _flush_record_text()
 
 
+def _audio_sidecar_status_paths():
+    """Return status files belonging to simulator-owned audio helpers."""
+    try:
+        names = os.listdir(sd_root)
+    except OSError:
+        return []
+    paths = []
+    for name in names:
+        if name == "sim_audio.status" or (
+            name.startswith("sim_audio_mix_") and name.endswith(".status")
+        ):
+            paths.append(sd_root.rstrip("/") + "/" + name)
+    return paths
+
+
+def _audio_sidecar_stopped(status_path):
+    try:
+        with open(status_path, "r") as handle:
+            for line in handle.read().split("\n"):
+                if line.strip() == "playing=0":
+                    return True
+    except OSError:
+        return True
+    return False
+
+
+def _send_audio_sidecar_stop(status_path):
+    command_path = status_path[:-7] + ".cmd"
+    try:
+        # Do not overwrite a command that the helper has not consumed yet.
+        for _ in range(20):
+            if not _exists(command_path):
+                break
+            time.sleep(0.01)
+        with open(command_path, "w") as handle:
+            handle.write("stop\n")
+        return True
+    except OSError:
+        return False
+
+
+def shutdown_audio_sidecars(timeout_ms=1000):
+    """Stop audio helpers before the simulator process releases ownership."""
+    pending = []
+    for status_path in _audio_sidecar_status_paths():
+        if not _audio_sidecar_stopped(status_path):
+            pending.append(status_path)
+            _send_audio_sidecar_stop(status_path)
+    if not pending:
+        return True
+
+    started = _ticks_ms()
+    while _ticks_diff(_ticks_ms(), started) < max(0, int(timeout_ms)):
+        if all(_audio_sidecar_stopped(path) for path in pending):
+            return True
+        time.sleep(0.01)
+    return all(_audio_sidecar_stopped(path) for path in pending)
+
+
 def _write_status(force=False):
     global _last_status_ms
     if not status_path:

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -612,6 +612,7 @@ def _run_sim_check(opts):
     _run_v8_battery_check()
     _run_flipper_battery_check()
     _run_log_storage_check(opts)
+    _run_audio_shutdown_check()
     _run_circular_choice_check()
     _run_fatal_exit_check(opts)
     _run_mjs_check()
@@ -969,6 +970,56 @@ def _run_log_storage_check(opts):
     print("[sim-check:ok] storage log persistence reset")
 
 
+def _run_audio_shutdown_check():
+    """Verify shutdown signals every active simulator audio helper."""
+    import sim_runtime
+
+    probe_root = "/tmp/picoware-sim-audio-shutdown-check"
+    filenames = (
+        "sim_audio.status",
+        "sim_audio.cmd",
+        "sim_audio_mix_1.status",
+        "sim_audio_mix_1.cmd",
+        "unrelated.status",
+    )
+    original_sd_root = sim_runtime.sd_root
+    _mkdir_p(probe_root)
+    try:
+        for name in filenames:
+            try:
+                os.remove(probe_root + "/" + name)
+            except OSError:
+                pass
+        with open(probe_root + "/sim_audio.status", "w") as handle:
+            handle.write("playing=1\n")
+        with open(probe_root + "/sim_audio_mix_1.status", "w") as handle:
+            handle.write("playing=1\n")
+        with open(probe_root + "/unrelated.status", "w") as handle:
+            handle.write("playing=1\n")
+
+        sim_runtime.sd_root = probe_root
+        if sim_runtime.shutdown_audio_sidecars(0):
+            raise RuntimeError("simulator audio shutdown ignored active helpers")
+        for name in ("sim_audio.cmd", "sim_audio_mix_1.cmd"):
+            with open(probe_root + "/" + name, "r") as handle:
+                if handle.read() != "stop\n":
+                    raise RuntimeError("simulator audio shutdown command mismatch")
+        if sim_runtime._exists(probe_root + "/unrelated.cmd"):
+            raise RuntimeError("simulator audio shutdown signaled an unrelated helper")
+    finally:
+        sim_runtime.sd_root = original_sd_root
+        for name in filenames + ("unrelated.cmd",):
+            try:
+                os.remove(probe_root + "/" + name)
+            except OSError:
+                pass
+        try:
+            os.rmdir(probe_root)
+        except OSError:
+            pass
+    print("[sim-check:ok] audio sidecar shutdown")
+
+
 def _run_circular_choice_check():
     """Render the native circular Choice path without board-module reloading."""
     import sim_runtime
@@ -1319,6 +1370,10 @@ def main():
             _write_error_file(opts["sd"] + "/sim_error.txt", e)
         raise SystemExit(1)
     finally:
+        try:
+            sim_runtime.shutdown_audio_sidecars()
+        except Exception:
+            pass
         try:
             sim_runtime.finish_recording()
         except Exception:


### PR DESCRIPTION
## Summary

- stop simulator-owned audio sidecars during top-level simulator teardown
- handle both the primary audio helper and mixed sound-effect helpers
- add a simulator self-check for shutdown signaling and helper filtering

## Root cause

Closing the SDL viewer raises `StopSimulation` and enters the simulator's top-level `finally` block. That block stopped the viewer and recording, but it did not signal the independently running audio helper processes. If an app did not get a chance to stop its own audio instance, playback could continue after the simulator exited.

## Impact

Viewer close, frame-limited exit, and other normal simulator shutdown paths now signal active audio helpers and wait briefly for their final `playing=0` status. Unrelated sidecar status files are ignored.

## Validation

- `python3 -B` syntax compilation for both modified Python files
- `sh simulator/build.sh --check`
- `micropython simulator/run.py --sim-check`
- visible viewer regression: closed the viewer while the WAV helper reported `playing=1`; the simulator exited and the helper reported `playing=0`
