### PR TITLE
Fix SimpleRPN keyboard and beginner workflow

### DIFF
--- a/builds/MicroPython/apps_unfrozen/SimpleRPN.py
+++ b/builds/MicroPython/apps_unfrozen/SimpleRPN.py
@@ -709,8 +709,8 @@ def _draw_help(view_manager):
     if help_page == 0:
         lines = (
             ("FAST INPUT", COLOR_AMBER),
-            ("RETURN / SPACE / TOUCH  use key", TFT_WHITE),
-            ("=             always enter / lift", TFT_WHITE),
+            ("RETURN / =   enter / lift", TFT_WHITE),
+            ("SPACE / TOUCH  use selected key", TFT_WHITE),
             ("ARROWS       move keypad cursor", TFT_WHITE),
             ("0-9 . + - * / \\  direct input", TFT_WHITE),
             ("% or P       percent of Y", TFT_WHITE),
@@ -1014,7 +1014,12 @@ def run(view_manager):
     elif button == BUTTON_DOWN:
         selected_index = (selected_index + 4) % len(KEYS)
     elif button == BUTTON_CENTER:
-        action = KEYS[selected_index][1]
+        # PicoCalc Return arrives as CENTER; touch CENTER selects the UI key.
+        if inp.has_touch_support:
+            action = KEYS[selected_index][1]
+        else:
+            action = "enter"
+            direct_action = True
     elif button == BUTTON_SPACE:
         action = KEYS[selected_index][1]
     elif BUTTON_0 <= button <= BUTTON_9:

--- a/builds/MicroPython/apps_unfrozen/SimpleRPN.py
+++ b/builds/MicroPython/apps_unfrozen/SimpleRPN.py
@@ -762,15 +762,15 @@ def _draw_help(view_manager):
             ("Operators calculate Y op X", COLOR_AMBER),
             ("Example: 8 RET 2 / -> 4", TFT_WHITE),
             ("No final equals is needed", COLOR_MUTED),
-            ("RETURN / SPACE / = enters X", TFT_WHITE),
+            ("RETURN / = enters X", TFT_WHITE),
             ("H / ESC / BACK  close help", COLOR_MUTED),
             ("LEFT / RIGHT  change help page", COLOR_MUTED),
         )
     elif help_page == 1:
         lines = (
             ("KEYBOARD", COLOR_AMBER),
-            ("RETURN / SPACE / =  enter / lift", TFT_WHITE),
-            ("TAB / TOUCH  use selected key", TFT_WHITE),
+            ("RETURN / =  enter / lift", TFT_WHITE),
+            ("SPACE / TOUCH  use selected key", TFT_WHITE),
             ("ARROWS       move keypad cursor", TFT_WHITE),
             ("0-9 . + - * / \\  direct input", TFT_WHITE),
             ("BS / DEL     edit entry / clear X", TFT_WHITE),
@@ -1200,7 +1200,7 @@ def run(view_manager):
             action = "enter"
             direct_action = True
     elif button == BUTTON_SPACE:
-        action = "enter"
+        action = KEYS[selected_index][1]
         direct_action = True
     elif button == BUTTON_TAB:
         action = KEYS[selected_index][1]
@@ -1310,7 +1310,7 @@ def run(view_manager):
 
     if old_selected_index != selected_index:
         escape_armed = False
-        calculator.status = KEYS[selected_index][0] + ": TAB USES; RET ENTERS"
+        calculator.status = KEYS[selected_index][0] + ": SPACE USES; RET ENTERS"
         _refresh_stack(view_manager, False)
         draw = view_manager.draw
         if flash_index >= 0:

--- a/builds/MicroPython/apps_unfrozen/SimpleRPN.py
+++ b/builds/MicroPython/apps_unfrozen/SimpleRPN.py
@@ -29,6 +29,7 @@ from picoware.system.buttons import (
     BUTTON_BACKSPACE,
     BUTTON_DELETE,
     BUTTON_SPACE,
+    BUTTON_TAB,
     BUTTON_ESCAPE,
     BUTTON_C,
     BUTTON_D,
@@ -168,7 +169,7 @@ class RPNStack:
         self.entering = False
         self.lift_on_entry = False
         self.error = ""
-        self.status = "X CLEARED - ESC AGAIN: ALL"
+        self.status = "X CLEARED - C/ESC AGAIN: ALL"
 
     def _dismiss_error(self):
         self.error = ""
@@ -397,7 +398,10 @@ help_visible = False
 help_page = 0
 variable_view_mode = None
 selected_variable = 0
+variable_confirm_action = None
+variable_confirm_index = -1
 escape_armed = False
+back_exit_armed = False
 flash_index = -1
 flash_until = 0
 storage = None
@@ -681,11 +685,11 @@ def _draw_variable_viewer(view_manager):
         status = status[:38]
     draw.text(Vector(7, height - 43), status, COLOR_AMBER, FONT_XTRA_SMALL)
     if variable_view_mode in ("store", "recall"):
-        control_line = "A-Z ACT  CENTER/=/SPACE CONFIRM"
-        close_line = "ARROWS SELECT  ESC/BACK CANCEL"
+        control_line = "A-Z SELECT  ENTER/=/SPACE ACT"
+        close_line = "ARROWS SELECT  ESC/BACK/DEL CANCEL"
     else:
-        control_line = "CENTER/= RCL  SPACE STO  BS/DEL CLR"
-        close_line = "ARROWS/A-Z SELECT  ESC/BACK CLOSE"
+        control_line = "ENTER/= RCL  SPACE STORE?"
+        close_line = "DEL CLEAR?  ESC/BACK CLOSE"
     draw.text(Vector(7, height - 27), control_line, COLOR_MUTED, FONT_XTRA_SMALL)
     draw.text(Vector(7, height - 14), close_line, COLOR_MUTED, FONT_XTRA_SMALL)
     draw.swap()
@@ -709,19 +713,19 @@ def _draw_help(view_manager):
     if help_page == 0:
         lines = (
             ("FAST INPUT", COLOR_AMBER),
-            ("RETURN / =   enter / lift", TFT_WHITE),
-            ("SPACE / TOUCH  use selected key", TFT_WHITE),
+            ("RETURN / SPACE / =  enter / lift", TFT_WHITE),
+            ("TAB / TOUCH  use selected key", TFT_WHITE),
             ("ARROWS       move keypad cursor", TFT_WHITE),
             ("0-9 . + - * / \\  direct input", TFT_WHITE),
             ("% or P       percent of Y", TFT_WHITE),
             ("BS / DEL     edit entry / clear X", TFT_WHITE),
-            ("ESC          clear X; again: all", TFT_WHITE),
-            ("BACK         edit entry; else exit", TFT_WHITE),
+            ("C / ESC      clear X; again: all", TFT_WHITE),
+            ("SYSTEM BACK x2  exit app", TFT_WHITE),
             ("OPERATOR SHORTCUTS", COLOR_AMBER),
             ("U divide          I multiply", TFT_WHITE),
             ("J subtract        K add", TFT_WHITE),
             ("OTHER SHORTCUTS", COLOR_AMBER),
-            ("C clear  D drop  S swap  N sign", TFT_WHITE),
+            ("C clear X  D drop  S swap  N sign", TFT_WHITE),
             ("Q sqrt  X square  R reciprocal", TFT_WHITE),
             ("T store  L recall  V vars  H help", TFT_WHITE),
             ("H / ESC / BACK  close help", COLOR_MUTED),
@@ -735,13 +739,13 @@ def _draw_help(view_manager):
             ("V / VARS   open variable viewer", TFT_WHITE),
             ("STO copies X; RCL lifts into X", COLOR_MUTED),
             ("VARIABLE VIEWER", COLOR_AMBER),
-            ("A-Z         select variable", TFT_WHITE),
-            ("ARROWS      move selection", TFT_WHITE),
+            ("A-Z / ARROWS  select variable", TFT_WHITE),
             ("RET / TOUCH / =  recall selected", TFT_WHITE),
-            ("SPACE       store X to selected", TFT_WHITE),
-            ("BS / DEL    clear selected", TFT_WHITE),
-            ("ESC / BACK  close viewer", TFT_WHITE),
-            ("Pending: A-Z acts immediately", COLOR_MUTED),
+            ("SPACE       arm store X", TFT_WHITE),
+            ("DEL         arm variable clear", TFT_WHITE),
+            ("RET / =     confirm armed action", TFT_WHITE),
+            ("ESC / BACK  cancel / close", TFT_WHITE),
+            ("Pending STO/RCL: A-Z selects", COLOR_MUTED),
             ("RET / TOUCH / = / SPACE confirms", COLOR_MUTED),
             ("PERCENT", COLOR_AMBER),
             ("200 RET 15 % + = 230", TFT_WHITE),
@@ -757,9 +761,58 @@ def _draw_help(view_manager):
     draw.swap()
 
 
+def _reset_variable_confirmation():
+    global variable_confirm_action, variable_confirm_index
+    variable_confirm_action = None
+    variable_confirm_index = -1
+
+
+def _set_variable_selection_status():
+    name = chr(ord("A") + selected_variable)
+    if variable_view_mode == "store":
+        calculator.status = "STO " + name + ": ENTER TO CONFIRM"
+    elif variable_view_mode == "recall":
+        calculator.status = "RCL " + name + ": ENTER TO CONFIRM"
+    else:
+        calculator.status = "SELECTED " + name
+
+
+def _arm_variable_confirmation(action):
+    global variable_confirm_action, variable_confirm_index
+    variable_confirm_action = action
+    variable_confirm_index = selected_variable
+    name = chr(ord("A") + selected_variable)
+    if action == "store":
+        if calculator.variable_set[selected_variable]:
+            calculator.status = "OVERWRITE " + name + "? ENTER YES"
+        else:
+            calculator.status = "STORE X TO " + name + "? ENTER YES"
+    elif calculator.variable_set[selected_variable]:
+        calculator.status = "DELETE " + name + "? ENTER/DEL YES"
+    else:
+        calculator.status = name + " IS ALREADY EMPTY"
+        _reset_variable_confirmation()
+
+
+def _confirm_variable_action(view_manager):
+    action = variable_confirm_action
+    index = variable_confirm_index
+    _reset_variable_confirmation()
+    if action == "store" and index >= 0:
+        _complete_variable_action(view_manager, index, "store")
+        return True
+    if action == "delete" and index >= 0:
+        calculator.clear_variable(index)
+        _queue_save()
+        _draw_variable_viewer(view_manager)
+        return True
+    return False
+
+
 def _open_variable_viewer(view_manager, mode):
     global variable_view_mode, flash_index, escape_armed
     variable_view_mode = mode
+    _reset_variable_confirmation()
     flash_index = -1
     escape_armed = False
     if mode == "store":
@@ -774,6 +827,7 @@ def _open_variable_viewer(view_manager, mode):
 def _close_variable_viewer(view_manager):
     global variable_view_mode, flash_index, escape_armed
     variable_view_mode = None
+    _reset_variable_confirmation()
     flash_index = -1
     escape_armed = False
     _redraw(view_manager)
@@ -783,6 +837,7 @@ def _complete_variable_action(view_manager, index, action=None):
     """Apply a viewer action, returning True when the viewer closes."""
     global variable_view_mode, selected_variable
     selected_variable = index
+    _reset_variable_confirmation()
     action = action or variable_view_mode
 
     if action == "store":
@@ -863,37 +918,69 @@ def _finish_flash(view_manager):
 def _run_variable_viewer(view_manager, button):
     global selected_variable
     if button in (BUTTON_BACK, BUTTON_ESCAPE):
+        if variable_confirm_action is not None:
+            _reset_variable_confirmation()
+            calculator.status = "ACTION CANCELLED"
+            _draw_variable_viewer(view_manager)
+            return
         _close_variable_viewer(view_manager)
         return
 
     if button in (BUTTON_UP, BUTTON_DOWN, BUTTON_LEFT, BUTTON_RIGHT):
+        _reset_variable_confirmation()
         _move_variable_selection(view_manager, button)
+        _set_variable_selection_status()
         _draw_variable_viewer(view_manager)
         return
 
     if BUTTON_A <= button <= BUTTON_Z:
+        _reset_variable_confirmation()
         index = button - BUTTON_A
-        if variable_view_mode in ("store", "recall"):
-            _complete_variable_action(view_manager, index)
-        else:
-            selected_variable = index
-            _draw_variable_viewer(view_manager)
+        selected_variable = index
+        _set_variable_selection_status()
+        _draw_variable_viewer(view_manager)
         return
 
     if button in (BUTTON_BACKSPACE, BUTTON_DELETE):
-        calculator.clear_variable(selected_variable)
-        _queue_save()
+        if variable_view_mode in ("store", "recall"):
+            calculator.status = variable_view_mode.upper() + " CANCELLED"
+            _close_variable_viewer(view_manager)
+            return
+        if (
+            variable_confirm_action == "delete"
+            and variable_confirm_index == selected_variable
+        ):
+            _confirm_variable_action(view_manager)
+            return
+        _arm_variable_confirmation("delete")
         _draw_variable_viewer(view_manager)
         return
 
     if button in (BUTTON_CENTER, BUTTON_EQUAL):
+        if variable_confirm_action is not None:
+            _confirm_variable_action(view_manager)
+            return
         action = variable_view_mode if variable_view_mode != "view" else "recall"
         _complete_variable_action(view_manager, selected_variable, action)
         return
 
     if button == BUTTON_SPACE:
-        action = variable_view_mode if variable_view_mode != "view" else "store"
-        _complete_variable_action(view_manager, selected_variable, action)
+        if variable_view_mode != "view":
+            _complete_variable_action(view_manager, selected_variable, variable_view_mode)
+            return
+        _arm_variable_confirmation("store")
+        _draw_variable_viewer(view_manager)
+
+
+def _perform_clear():
+    global escape_armed
+    if escape_armed:
+        calculator.clear()
+        escape_armed = False
+    else:
+        calculator.clear_x()
+        escape_armed = True
+    _queue_save()
 
 
 def _perform(action):
@@ -904,7 +991,8 @@ def _perform(action):
     elif action == "enter":
         calculator.enter()
     elif action == "clear":
-        calculator.clear()
+        _perform_clear()
+        return
     elif action == "drop":
         calculator.drop()
     elif action == "swap":
@@ -924,7 +1012,8 @@ def _perform(action):
 
 def start(view_manager):
     global calculator, selected_index, help_visible, help_page, variable_view_mode
-    global selected_variable, escape_armed, flash_index, storage, state_dirty
+    global selected_variable, variable_confirm_action, variable_confirm_index
+    global escape_armed, back_exit_armed, flash_index, storage, state_dirty
     global save_due, last_saved_state
     calculator = RPNStack()
     storage = view_manager.storage
@@ -937,7 +1026,10 @@ def start(view_manager):
     help_page = 0
     variable_view_mode = None
     selected_variable = 0
+    variable_confirm_action = None
+    variable_confirm_index = -1
     escape_armed = False
+    back_exit_armed = False
     flash_index = -1
     view_manager.input_manager.reset()
     _redraw(view_manager)
@@ -945,7 +1037,8 @@ def start(view_manager):
 
 
 def run(view_manager):
-    global selected_index, help_visible, help_page, escape_armed, flash_index
+    global selected_index, help_visible, help_page, escape_armed, back_exit_armed
+    global flash_index
     inp = view_manager.input_manager
     button = inp.button
     if button == -1:
@@ -954,6 +1047,9 @@ def run(view_manager):
         if not help_visible and variable_view_mode is None:
             _finish_flash(view_manager)
         return
+
+    if button != BUTTON_BACK:
+        back_exit_armed = False
 
     if variable_view_mode is not None:
         _run_variable_viewer(view_manager, button)
@@ -990,13 +1086,22 @@ def run(view_manager):
         return
 
     if button == BUTTON_BACK:
+        escape_armed = False
         if calculator.entering:
             calculator.backspace()
             _queue_save()
+            back_exit_armed = False
             escape_armed = False
             inp.reset()
             _refresh_stack(view_manager)
             return
+        if not back_exit_armed:
+            back_exit_armed = True
+            calculator.status = "BACK AGAIN: EXIT"
+            inp.reset()
+            _refresh_stack(view_manager)
+            return
+        back_exit_armed = False
         _save_state(force=True)
         inp.reset()
         view_manager.back()
@@ -1021,6 +1126,9 @@ def run(view_manager):
             action = "enter"
             direct_action = True
     elif button == BUTTON_SPACE:
+        action = "enter"
+        direct_action = True
+    elif button == BUTTON_TAB:
         action = KEYS[selected_index][1]
     elif BUTTON_0 <= button <= BUTTON_9:
         action = str(button - BUTTON_0)
@@ -1052,12 +1160,7 @@ def run(view_manager):
         escape_armed = False
         _refresh_stack(view_manager)
     elif button == BUTTON_ESCAPE:
-        if escape_armed:
-            calculator.clear()
-        else:
-            calculator.clear_x()
-            escape_armed = True
-        _queue_save()
+        _perform_clear()
         _refresh_stack(view_manager, False)
         _flash_action(view_manager, "clear")
     elif button == BUTTON_C:
@@ -1107,7 +1210,8 @@ def run(view_manager):
         direct_action = True
 
     if action is not None:
-        escape_armed = False
+        if action != "clear":
+            escape_armed = False
         if action == "help":
             help_visible = True
             help_page = 0
@@ -1142,7 +1246,8 @@ def run(view_manager):
 
 def stop(view_manager):
     global calculator, selected_index, help_visible, help_page, variable_view_mode
-    global selected_variable, escape_armed, flash_index, storage, state_dirty
+    global selected_variable, variable_confirm_action, variable_confirm_index
+    global escape_armed, back_exit_armed, flash_index, storage, state_dirty
     global save_due, last_saved_state
     _save_state(force=True)
     calculator = None
@@ -1155,7 +1260,10 @@ def stop(view_manager):
     help_page = 0
     variable_view_mode = None
     selected_variable = 0
+    variable_confirm_action = None
+    variable_confirm_index = -1
     escape_armed = False
+    back_exit_armed = False
     flash_index = -1
     from gc import collect
 

--- a/builds/MicroPython/apps_unfrozen/SimpleRPN.py
+++ b/builds/MicroPython/apps_unfrozen/SimpleRPN.py
@@ -72,10 +72,11 @@ COLOR_ERROR = _rgb565(244, 102, 83)
 STATE_FILE = "picoware/settings/srpn.json"
 STATE_VERSION = 1
 SAVE_DELAY_MS = 1000
+HELP_PAGE_COUNT = 3
 
 
 KEYS = (
-    ("CLR", "clear", "function"),
+    ("CLX", "clear", "function"),
     ("+/-", "negate", "function"),
     ("%", "percent", "function"),
     ("/", "divide", "operator"),
@@ -101,7 +102,7 @@ KEYS = (
     ("SWAP", "swap", "function"),
     ("STO", "store", "memory"),
     ("RCL", "recall", "memory"),
-    ("VARS", "variables", "memory"),
+    ("UNDO", "undo", "function"),
     ("HELP", "help", "function"),
 )
 
@@ -118,7 +119,7 @@ def format_number(value):
         return "NAN"
     if abs(value) == float("inf"):
         return "OVERFLOW"
-    if abs(value) < 1e-12:
+    if value == 0.0:
         value = 0.0
     if abs(value) < 1000000000000.0 and value == int(value):
         return str(int(value))
@@ -140,6 +141,8 @@ class RPNStack:
         "status",
         "variables",
         "variable_set",
+        "undo_state",
+        "undo_label",
     )
 
     def __init__(self):
@@ -151,6 +154,41 @@ class RPNStack:
         self.status = "READY"
         self.variables = [0.0] * 26
         self.variable_set = [False] * 26
+        self.undo_state = None
+        self.undo_label = ""
+
+    def remember_undo(self, label):
+        """Remember one complete pre-action state for mistake recovery."""
+        self.undo_state = (
+            self.stack[:],
+            self.entry,
+            self.entering,
+            self.lift_on_entry,
+            self.error,
+            self.variables[:],
+            self.variable_set[:],
+        )
+        self.undo_label = label
+
+    def undo(self):
+        """Restore and consume the most recently remembered state."""
+        if self.undo_state is None:
+            self.error = ""
+            self.status = "NOTHING TO UNDO"
+            return False
+        state = self.undo_state
+        label = self.undo_label
+        self.undo_state = None
+        self.undo_label = ""
+        self.stack = state[0]
+        self.entry = state[1]
+        self.entering = state[2]
+        self.lift_on_entry = state[3]
+        self.error = state[4]
+        self.status = "UNDID " + label
+        self.variables = state[5]
+        self.variable_set = state[6]
+        return True
 
     def clear(self):
         self.stack[0] = 0.0
@@ -704,7 +742,7 @@ def _draw_help(view_manager):
     draw.text(Vector(7, 5), "SimpleRPN HELP", TFT_WHITE, FONT_SMALL)
     draw.text(
         Vector(width - 94, 8),
-        str(help_page + 1) + "/2",
+        str(help_page + 1) + "/" + str(HELP_PAGE_COUNT),
         COLOR_MUTED,
         FONT_XTRA_SMALL,
     )
@@ -712,24 +750,41 @@ def _draw_help(view_manager):
 
     if help_page == 0:
         lines = (
-            ("FAST INPUT", COLOR_AMBER),
+            ("RPN QUICK START", COLOR_AMBER),
+            ("1  Type first value: 2", TFT_WHITE),
+            ("2  Press RETURN", TFT_WHITE),
+            ("3  Type next value: 3", TFT_WHITE),
+            ("4  Press +       result: 5", TFT_WHITE),
+            ("THE STACK", COLOR_AMBER),
+            ("X  current value / input", TFT_WHITE),
+            ("Y  previous value", TFT_WHITE),
+            ("Z/T older values", TFT_WHITE),
+            ("Operators calculate Y op X", COLOR_AMBER),
+            ("Example: 8 RET 2 / -> 4", TFT_WHITE),
+            ("No final equals is needed", COLOR_MUTED),
+            ("RETURN / SPACE / = enters X", TFT_WHITE),
+            ("H / ESC / BACK  close help", COLOR_MUTED),
+            ("LEFT / RIGHT  change help page", COLOR_MUTED),
+        )
+    elif help_page == 1:
+        lines = (
+            ("KEYBOARD", COLOR_AMBER),
             ("RETURN / SPACE / =  enter / lift", TFT_WHITE),
             ("TAB / TOUCH  use selected key", TFT_WHITE),
             ("ARROWS       move keypad cursor", TFT_WHITE),
             ("0-9 . + - * / \\  direct input", TFT_WHITE),
-            ("% or P       percent of Y", TFT_WHITE),
             ("BS / DEL     edit entry / clear X", TFT_WHITE),
             ("C / ESC      clear X; again: all", TFT_WHITE),
-            ("SYSTEM BACK x2  exit app", TFT_WHITE),
-            ("OPERATOR SHORTCUTS", COLOR_AMBER),
+            ("SYSTEM EXIT KEY x2  exit app", TFT_WHITE),
+            ("STACK TOOLS", COLOR_AMBER),
+            ("D drop     S swap     Z undo", TFT_WHITE),
+            ("N sign     Q sqrt     X square", TFT_WHITE),
+            ("R reciprocal       P percent", TFT_WHITE),
+            ("FAST OPERATORS", COLOR_AMBER),
             ("U divide          I multiply", TFT_WHITE),
             ("J subtract        K add", TFT_WHITE),
-            ("OTHER SHORTCUTS", COLOR_AMBER),
-            ("C clear X  D drop  S swap  N sign", TFT_WHITE),
-            ("Q sqrt  X square  R reciprocal", TFT_WHITE),
             ("T store  L recall  V vars  H help", TFT_WHITE),
-            ("H / ESC / BACK  close help", COLOR_MUTED),
-            ("LEFT / RIGHT  change help page", COLOR_MUTED),
+            ("H/ESC/BACK close; LEFT/RIGHT page", COLOR_MUTED),
         )
     else:
         lines = (
@@ -748,7 +803,7 @@ def _draw_help(view_manager):
             ("Pending STO/RCL: A-Z selects", COLOR_MUTED),
             ("RET / TOUCH / = / SPACE confirms", COLOR_MUTED),
             ("PERCENT", COLOR_AMBER),
-            ("200 RET 15 % + = 230", TFT_WHITE),
+            ("200 RET 15 % + -> 230", TFT_WHITE),
             ("Y remains base after % for + / -", COLOR_MUTED),
             ("H/ESC/BACK close; LEFT/RIGHT page", COLOR_MUTED),
         )
@@ -802,6 +857,7 @@ def _confirm_variable_action(view_manager):
         _complete_variable_action(view_manager, index, "store")
         return True
     if action == "delete" and index >= 0:
+        calculator.remember_undo("DELETE " + chr(ord("A") + index))
         calculator.clear_variable(index)
         _queue_save()
         _draw_variable_viewer(view_manager)
@@ -841,6 +897,7 @@ def _complete_variable_action(view_manager, index, action=None):
     action = action or variable_view_mode
 
     if action == "store":
+        calculator.remember_undo("STO " + chr(ord("A") + index))
         calculator.store(index)
         _queue_save()
         if variable_view_mode == "view":
@@ -851,6 +908,11 @@ def _complete_variable_action(view_manager, index, action=None):
         return True
 
     if action == "recall":
+        if not calculator.variable_set[index]:
+            calculator.recall(index)
+            _draw_variable_viewer(view_manager)
+            return False
+        calculator.remember_undo("RCL " + chr(ord("A") + index))
         if not calculator.recall(index):
             _draw_variable_viewer(view_manager)
             return False
@@ -978,6 +1040,7 @@ def _perform_clear():
         calculator.clear()
         escape_armed = False
     else:
+        calculator.remember_undo("CLEAR")
         calculator.clear_x()
         escape_armed = True
     _queue_save()
@@ -989,21 +1052,30 @@ def _perform(action):
     elif action == "decimal":
         calculator.decimal()
     elif action == "enter":
+        calculator.remember_undo("ENTER")
         calculator.enter()
+    elif action == "undo":
+        calculator.undo()
     elif action == "clear":
         _perform_clear()
         return
     elif action == "drop":
+        calculator.remember_undo("DROP")
         calculator.drop()
     elif action == "swap":
+        calculator.remember_undo("SWAP")
         calculator.swap()
     elif action == "negate":
+        calculator.remember_undo("SIGN")
         calculator.negate()
     elif action == "percent":
+        calculator.remember_undo("PERCENT")
         calculator.percent()
     elif action in ("square", "sqrt", "reciprocal"):
+        calculator.remember_undo(action.upper())
         calculator.unary(action)
     elif action in ("add", "subtract", "multiply", "divide"):
+        calculator.remember_undo(action.upper())
         calculator.binary(action)
     else:
         return
@@ -1020,7 +1092,9 @@ def start(view_manager):
     state_dirty = False
     save_due = 0
     last_saved_state = ""
-    _load_state()
+    restored = _load_state()
+    if not restored:
+        calculator.status = "TRY: 2 RET 3 + -> 5"
     selected_index = ENTER_INDEX
     help_visible = False
     help_page = 0
@@ -1064,12 +1138,12 @@ def run(view_manager):
             _redraw(view_manager)
             return
         if button == BUTTON_LEFT:
-            help_page = (help_page - 1) % 2
+            help_page = (help_page - 1) % HELP_PAGE_COUNT
             inp.reset()
             _draw_help(view_manager)
             return
         if button == BUTTON_RIGHT:
-            help_page = (help_page + 1) % 2
+            help_page = (help_page + 1) % HELP_PAGE_COUNT
             inp.reset()
             _draw_help(view_manager)
             return
@@ -1208,6 +1282,9 @@ def run(view_manager):
     elif button == BUTTON_X:
         action = "square"
         direct_action = True
+    elif button == BUTTON_Z:
+        action = "undo"
+        direct_action = True
 
     if action is not None:
         if action != "clear":
@@ -1233,6 +1310,8 @@ def run(view_manager):
 
     if old_selected_index != selected_index:
         escape_armed = False
+        calculator.status = KEYS[selected_index][0] + ": TAB USES; RET ENTERS"
+        _refresh_stack(view_manager, False)
         draw = view_manager.draw
         if flash_index >= 0:
             _draw_key(draw, flash_index, flash_index == old_selected_index)


### PR DESCRIPTION
## Summary

- make PicoCalc Return consistently perform RPN ENTER while Space activates the highlighted on-screen key
- harden editing, clear, exit, and STO/RCL variable workflows against accidental actions
- add one-level undo for stack and memory operations
- replace the dense shortcut-first help with a three-page beginner guide and explicit `Y op X` examples
- preserve small non-zero results such as `1E-13` instead of displaying them as zero

## Why

PicoCalc Return arrives as `BUTTON_CENTER`, which previously coupled RPN ENTER to the highlighted keypad key. That made normal calculator muscle memory dependent on cursor position. Several contextual keys also performed destructive actions too easily, while the help screen documented controls without first teaching the RPN input model.

The revised workflow keeps Return dedicated to RPN ENTER, uses Space for the selected on-screen key, adds visible key-routing feedback, and provides recoverable stack and variable operations.

## User impact

- `2 Return 3 +` reliably produces `5` regardless of cursor position.
- Moving the cursor and pressing Space activates the highlighted key.
- Mistaken operators, clears, ENTER, DROP/SWAP, and STO/RCL/delete actions can be undone once.
- New users get an immediate quick-start example and a clearer explanation of X/Y/Z/T.

## Validation

- MicroPython syntax compilation
- `mpy-cross` compilation
- targeted simulator workflows for arithmetic, Return/Space/Tab routing, editing, clear/exit, undo, STO/RCL/delete, variable browsing, persistence, help navigation, and small scientific values
- 320x320 screenshot review of the calculator, cursor hint, undo feedback, and all three help pages
- physical PicoCalc deployment with matching SHA-256 hashes and live Space-versus-Return button-routing smoke tests

The repository-wide simulator check still has the unrelated stale `--open System` menu-index failure introduced when Email moved into the Library. Simulator menu synchronization is intentionally deferred to separate work.
