### PR TITLE
Restore simulator parity for MMBasic and recent apps

### DIFF
--- a/simulator/hardware/sd_mp.py
+++ b/simulator/hardware/sd_mp.py
@@ -107,20 +107,24 @@ def list_directory(path=""):
     source = _source_path(path)
     if source:
         try:
-            for name in os.listdir(source):
-                if name not in seen:
-                    names.append(name)
-                    seen[name] = True
+            _append_unique_names(names, seen, os.listdir(source))
         except OSError:
             pass
     try:
-        for name in os.listdir(_path(path)):
-            if name not in seen:
-                names.append(name)
-                seen[name] = True
+        _append_unique_names(names, seen, os.listdir(_path(path)))
     except OSError:
         pass
     return names
+
+
+def _append_unique_names(names, seen, entries):
+    """Merge directory entries using FAT-style case-insensitive names."""
+    entries.sort()
+    for name in entries:
+        normalized = name.lower()
+        if normalized not in seen:
+            names.append(name)
+            seen[normalized] = True
 
 
 def read_directory(path=""):

--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -127,17 +127,18 @@ LIBRARY_ITEMS = {
     "gameboy emulator": 6,
     "gameboy": 6,
     "games": 7,
-    "python editor": 8,
-    "pythoneditor": 8,
-    "python repl": 9,
-    "repl": 9,
-    "screensavers": 10,
-    "scripts": 11,
-    "system": 12,
-    "text editor": 13,
-    "texteditor": 13,
-    "usb": 14,
-    "wifi": 15,
+    "mmbasic": 8,
+    "python editor": 9,
+    "pythoneditor": 9,
+    "python repl": 10,
+    "repl": 10,
+    "screensavers": 11,
+    "scripts": 12,
+    "system": 13,
+    "text editor": 14,
+    "texteditor": 14,
+    "usb": 15,
+    "wifi": 16,
 }
 
 
@@ -417,6 +418,7 @@ def seed_sd(profile="dev"):
     _link_app_files()
     if profile != "clean":
         _link_script_files()
+        _link_mmbasic_files()
 
 
 def _link_app_files():
@@ -433,6 +435,13 @@ def _link_script_files():
     """Symlink bundled JavaScript examples into the simulated SD card."""
     source = root + "/builds/MicroPython/scripts"
     target = sd_root + "/picoware/scripts"
+    _link_app_files_into(source, target)
+
+
+def _link_mmbasic_files():
+    """Symlink bundled MMBasic examples into the simulated SD card."""
+    source = root + "/builds/MicroPython/mmbasic"
+    target = sd_root + "/picoware/mmbasic"
     _link_app_files_into(source, target)
 
 

--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -461,6 +461,8 @@ def _link_app_files_into(src_dir, dst_dir, skip_if_py_exists=False, include_init
         entries = os.listdir(src_dir)
     except OSError:
         return
+    entries.sort()
+    seen_names = {}
     for entry in entries:
         if entry.startswith("."):
             continue
@@ -470,6 +472,14 @@ def _link_app_files_into(src_dir, dst_dir, skip_if_py_exists=False, include_init
             continue
         src = src_dir + "/" + entry
         dst = dst_dir + "/" + entry
+        normalized = entry.lower()
+        if normalized in seen_names:
+            # The simulated SD represents FAT, where names differing only by
+            # case cannot coexist.  Remove only the duplicate managed link.
+            if _same_file(dst, src):
+                _rm_f(dst)
+            continue
+        seen_names[normalized] = True
         try:
             st = os.stat(src)
         except OSError:
@@ -482,6 +492,11 @@ def _link_app_files_into(src_dir, dst_dir, skip_if_py_exists=False, include_init
                 _py_name = entry[:-4] + ".py"
                 _py_dst = dst_dir + "/" + _py_name
                 if _exists(_py_dst):
+                    # A previous simulator run may have linked the compiled
+                    # app before its source became available.  Remove only
+                    # that managed link; preserve regular user SD files.
+                    if _same_file(dst, src):
+                        _rm_f(dst)
                     continue
             # Remove stale symlink first
             _rm_f(dst)
@@ -522,6 +537,16 @@ def _rm_f(path):
         os.remove(path)
     except OSError:
         pass
+
+
+def _same_file(left, right):
+    """Return True when two host paths resolve to the same file."""
+    try:
+        left_stat = os.stat(left)
+        right_stat = os.stat(right)
+        return left_stat[1] == right_stat[1] and left_stat[2] == right_stat[2]
+    except OSError:
+        return False
 
 
 def _copy_file(src, dst):

--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -446,20 +446,25 @@ def _link_mmbasic_files():
 
 
 def _link_app_files_into(src_dir, dst_dir, skip_if_py_exists=False, include_init=False):
-    """Recursively symlink .py/.mpy files from src_dir into dst_dir.
+    """Recursively symlink bundled files from src_dir into dst_dir.
 
     When *skip_if_py_exists* is True, a .mpy file is skipped if a .py
     file with the same base name already exists (or is symlinked) in
     *dst_dir*.  This avoids duplicate app listings when both a source
     .py and a compiled .mpy are available.  Package __init__.py files
-    are included below the app root so libraries remain importable."""
+    are included below the app root so libraries remain importable.
+    Broken links from bundled files removed by later commits are pruned,
+    while regular user-installed files are preserved."""
     mkdir_p(dst_dir)
+    _prune_stale_links(dst_dir)
     try:
         entries = os.listdir(src_dir)
     except OSError:
         return
     for entry in entries:
         if entry.startswith("."):
+            continue
+        if entry == "__pycache__" or entry.endswith((".pyc", ".pyo")):
             continue
         if entry == "__init__.py" and not include_init:
             continue
@@ -488,6 +493,26 @@ def _link_app_files_into(src_dir, dst_dir, skip_if_py_exists=False, include_init
                 if status != 0:
                     # fallback: copy the file
                     _copy_file(src, dst)
+
+
+def _prune_stale_links(path):
+    """Remove broken simulator links without touching regular SD files."""
+    try:
+        entries = os.listdir(path)
+    except OSError:
+        return
+    for entry in entries:
+        child = path.rstrip("/") + "/" + entry
+        try:
+            st = os.stat(child)
+        except OSError:
+            # A listed entry that cannot be stat'ed is a broken symlink on
+            # the simulator host.  FAT-backed user files cannot have this
+            # state, so removing it is safe and restores the SD view.
+            _rm_f(child)
+            continue
+        if st[0] & 0x4000:
+            _prune_stale_links(child)
 
 
 def _rm_f(path):

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -546,6 +546,7 @@ def _run_sim_check(opts):
     """Run the simulator self-check suite."""
     _run_library_route_check()
     _run_stale_app_link_check(opts)
+    _run_duplicate_app_link_check(opts)
     commands = (
         "sh "
         + _quote(THIS_DIR + "/build.sh")
@@ -710,6 +711,84 @@ def _run_stale_app_link_check(opts):
         raise RuntimeError("simulator stale-link cleanup removed a local app")
     _remove_tree(probe)
     print("[sim-check:ok] stale app links pruned, local apps preserved")
+
+
+def _run_duplicate_app_link_check(opts):
+    """Remove managed .mpy duplicates while preserving regular SD files."""
+    import sd_mp
+    import sim_runtime
+
+    probe = opts["sd"] + "/sim-duplicate-link-check"
+    source_py = probe + "/source-py"
+    source_mpy = probe + "/source-mpy"
+    destination = probe + "/apps"
+    _mkdir_p(source_py)
+    _mkdir_p(source_mpy)
+    _mkdir_p(destination)
+    with open(source_py + "/ManagedApp.py", "w") as handle:
+        handle.write("# managed source app\n")
+    with open(source_py + "/CaseApp.py", "w") as handle:
+        handle.write("# canonical case app\n")
+    with open(source_py + "/caseApp.py", "w") as handle:
+        handle.write("# duplicate case app\n")
+    with open(source_mpy + "/ManagedApp.mpy", "w") as handle:
+        handle.write("managed compiled app\n")
+    with open(source_mpy + "/LocalApp.mpy", "w") as handle:
+        handle.write("compiled source placeholder\n")
+    with open(destination + "/LocalApp.py", "w") as handle:
+        handle.write("# local source app\n")
+    with open(destination + "/LocalApp.mpy", "w") as handle:
+        handle.write("local compiled app\n")
+
+    status = os.system(
+        "ln -sf "
+        + _quote(source_py + "/caseApp.py")
+        + " "
+        + _quote(destination + "/caseApp.py")
+    )
+    if status != 0:
+        _remove_tree(probe)
+        raise RuntimeError("simulator case-duplicate fixture setup failed")
+    sim_runtime._link_app_files_into(source_py, destination)
+    case_entries = [name for name in os.listdir(destination)
+                    if name.lower() == "caseapp.py"]
+    if case_entries != ["CaseApp.py"]:
+        _remove_tree(probe)
+        raise RuntimeError("simulator case-insensitive app duplicate was not removed")
+    merged_names = []
+    seen_names = {}
+    sd_mp._append_unique_names(
+        merged_names, seen_names, ["caseApp.py", "CaseApp.py"]
+    )
+    if merged_names != ["CaseApp.py"]:
+        _remove_tree(probe)
+        raise RuntimeError("simulator FAT directory view exposed case duplicates")
+    status = os.system(
+        "ln -sf "
+        + _quote(source_mpy + "/ManagedApp.mpy")
+        + " "
+        + _quote(destination + "/ManagedApp.mpy")
+    )
+    if status != 0:
+        _remove_tree(probe)
+        raise RuntimeError("simulator duplicate-link fixture setup failed")
+    sim_runtime._link_app_files_into(
+        source_mpy, destination, skip_if_py_exists=True
+    )
+    entries = os.listdir(destination)
+    if "ManagedApp.mpy" in entries:
+        _remove_tree(probe)
+        raise RuntimeError("simulator managed .mpy duplicate was not removed")
+    try:
+        with open(destination + "/LocalApp.mpy", "r") as handle:
+            local_contents = handle.read()
+    except OSError:
+        local_contents = ""
+    if local_contents != "local compiled app\n":
+        _remove_tree(probe)
+        raise RuntimeError("simulator duplicate cleanup removed a local .mpy app")
+    _remove_tree(probe)
+    print("[sim-check:ok] duplicate managed apps pruned, local .mpy preserved")
 
 
 def _run_keyboard_background_check():

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -228,6 +228,12 @@ def _remove_tree(path):
         try:
             mode = os.stat(child)[0]
         except OSError:
+            # os.stat() fails for a broken symlink.  Remove the link node so
+            # --reset-sd can actually clear persistent simulator fixtures.
+            try:
+                os.remove(child)
+            except OSError:
+                pass
             continue
         if mode & 0x4000:
             _remove_tree(child)
@@ -539,6 +545,7 @@ def _build_native(target, check=False):
 def _run_sim_check(opts):
     """Run the simulator self-check suite."""
     _run_library_route_check()
+    _run_stale_app_link_check(opts)
     commands = (
         "sh "
         + _quote(THIS_DIR + "/build.sh")
@@ -672,6 +679,37 @@ def _run_library_route_check():
     if indices != list(range(len(items))):
         raise RuntimeError("simulator Library route indices are not contiguous")
     print("[sim-check:ok] Library routes synchronized (" + str(len(items)) + " items)")
+
+
+def _run_stale_app_link_check(opts):
+    """Verify persistent SD cleanup removes only broken managed links."""
+    import sim_runtime
+
+    probe = opts["sd"] + "/sim-stale-link-check"
+    broken = probe + "/RemovedApp.py"
+    local = probe + "/LocalApp.py"
+    _mkdir_p(probe)
+    with open(local, "w") as handle:
+        handle.write("# user-installed simulator app\n")
+    status = os.system(
+        "ln -sf "
+        + _quote(ROOT + "/builds/MicroPython/apps_unfrozen/RemovedApp.py")
+        + " "
+        + _quote(broken)
+    )
+    if status != 0 or "RemovedApp.py" not in os.listdir(probe):
+        _remove_tree(probe)
+        raise RuntimeError("simulator stale-link fixture setup failed")
+    sim_runtime._prune_stale_links(probe)
+    entries = os.listdir(probe)
+    if "RemovedApp.py" in entries:
+        _remove_tree(probe)
+        raise RuntimeError("simulator stale app link was not removed")
+    if "LocalApp.py" not in entries:
+        _remove_tree(probe)
+        raise RuntimeError("simulator stale-link cleanup removed a local app")
+    _remove_tree(probe)
+    print("[sim-check:ok] stale app links pruned, local apps preserved")
 
 
 def _run_keyboard_background_check():

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -538,6 +538,7 @@ def _build_native(target, check=False):
 
 def _run_sim_check(opts):
     """Run the simulator self-check suite."""
+    _run_library_route_check()
     commands = (
         "sh "
         + _quote(THIS_DIR + "/build.sh")
@@ -563,6 +564,26 @@ def _run_sim_check(opts):
         "micropython "
         + _quote(THIS_DIR + "/run.py")
         + " --headless --open System --wait-view system --frames 220 --audio silent --network offline --sd "
+        + _quote(opts["sd"])
+        + " --apps-source "
+        + _quote(opts["apps_source"]),
+        "micropython "
+        + _quote(THIS_DIR + "/run.py")
+        + " --headless --open MMBasic --wait-view mmbasic --keys enter --assert-text "
+        + _quote("MMBasic 6.03")
+        + " --frames 300 --audio silent --network offline --sd "
+        + _quote(opts["sd"])
+        + " --apps-source "
+        + _quote(opts["apps_source"]),
+        "micropython "
+        + _quote(THIS_DIR + "/run.py")
+        + " --headless --app Forecast --wait-view app_Forecast --frames 220 --audio silent --network offline --sd "
+        + _quote(opts["sd"])
+        + " --apps-source "
+        + _quote(opts["apps_source"]),
+        "micropython "
+        + _quote(THIS_DIR + "/run.py")
+        + " --headless --app MicroBrowser --wait-view app_MicroBrowser --frames 220 --audio silent --network offline --sd "
         + _quote(opts["sd"])
         + " --apps-source "
         + _quote(opts["apps_source"]),
@@ -618,6 +639,39 @@ def _run_sim_check(opts):
     _run_fatal_exit_check(opts)
     _run_mjs_check()
     print("[sim-check:pass]")
+
+
+def _run_library_route_check():
+    """Keep simulator --open routes synchronized with the Library menu."""
+    import sim_runtime
+
+    source = MICROPYTHON_DIR + "/picoware/applications/library.py"
+    marker = '_library.add_item("'
+    items = []
+    with open(source, "r") as handle:
+        for line in handle:
+            if marker not in line:
+                continue
+            label = line.split(marker, 1)[1].split('"', 1)[0]
+            items.append(label)
+
+    if not items:
+        raise RuntimeError("simulator Library route check found no menu items")
+    for index, label in enumerate(items):
+        actual = sim_runtime.LIBRARY_ITEMS.get(label.lower())
+        if actual != index:
+            raise RuntimeError(
+                "simulator Library route mismatch for "
+                + label
+                + ": expected "
+                + str(index)
+                + ", got "
+                + str(actual)
+            )
+    indices = sorted(set(sim_runtime.LIBRARY_ITEMS.values()))
+    if indices != list(range(len(items))):
+        raise RuntimeError("simulator Library route indices are not contiguous")
+    print("[sim-check:ok] Library routes synchronized (" + str(len(items)) + " items)")
 
 
 def _run_keyboard_background_check():


### PR DESCRIPTION
## Summary

- synchronize all 17 simulator Library routes with the current production menu after MMBasic was inserted
- expose bundled MMBasic examples on the simulated SD and add startup coverage for MMBasic, Forecast, and MicroBrowser
- prune broken simulator-managed app links from persistent SD state while preserving regular user-installed apps
- remove stale managed `.mpy` duplicates when a source `.py` app is present and merge directory names with FAT-style case-insensitive semantics
- make `--reset-sd` remove broken symlinks so fixed test directories are actually reset

## Root cause

MMBasic moved from an external SD application into Picoware's built-in Library, but persistent simulator SD directories could retain broken `MMBasic.py` and `MMBasic.mpy` links. Those ghost entries remained visible in Applications and failed through `AppLoader`. The simulator's Library route indices also still reflected the pre-MMBasic menu, and its reset helper skipped broken symlinks.

The persistent SD could also retain live compiled `.mpy` links after matching `.py` sources were linked. The application loader treats both extensions as separate menu entries, and the simulator's source/host directory merge was case-sensitive even though the target FAT filesystem is not.

## Impact

MMBasic now launches from **Library > MMBasic**, later Library destinations route correctly, bundled BASIC examples are available in the simulator, and normal startup repairs stale or duplicate managed links without deleting local user apps. Applications now contains one deterministic entry per FAT-style name.

## Validation

- `micropython simulator/run.py --sim-check --audio silent --network offline --sd <fresh-temp-dir>` - `[sim-check:pass]`
- persistent default-SD reproduction: obsolete `MMBasic.py` and `MMBasic.mpy` entries were pruned on normal boot
- persistent default-SD deduplication: 33 `.py`/`.mpy` pairs plus one case-only pair reduced to zero duplicates; 35 unique launchers remain and all 33 compiled build artifacts are intact
- built-in MMBasic startup exercised through its bundled clock example
- targeted `keyboard-simple` launch after FAT-style directory merging
- Python syntax compilation
- `git diff --check origin/dev...HEAD`
