### PR TITLE
Fix Waveshare 1.69 simulator parity

### DIFF
--- a/simulator/hardware/machine.py
+++ b/simulator/hardware/machine.py
@@ -43,10 +43,12 @@ class Pin:
         self._mode = args[1] if len(args) > 1 else kwargs.get("mode", self.IN)
         self._pull = args[2] if len(args) > 2 else kwargs.get("pull", None)
         self._irq_trigger = None
+        self._irq_hard = False
 
-    def irq(self, handler=None, trigger=None):
+    def irq(self, handler=None, trigger=None, hard=False):
         self._handler = handler
         self._irq_trigger = trigger
+        self._irq_hard = bool(hard)
         if self.id in (11, 20, 21):
             try:
                 import sim_runtime

--- a/simulator/hardware/waveshare_battery.py
+++ b/simulator/hardware/waveshare_battery.py
@@ -1,3 +1,7 @@
+def init():
+    return None
+
+
 def get_percentage():
     try:
         import sim_runtime
@@ -5,6 +9,14 @@ def get_percentage():
         return sim_runtime.battery_percentage()
     except Exception:
         return 87
+
+
+def get_voltage():
+    return 3.3 + get_percentage() * 0.9 / 100
+
+
+def read():
+    return int(get_voltage() * 4096 / 6.6)
 
 
 def set_percentage(value):

--- a/simulator/hardware/waveshare_touch.py
+++ b/simulator/hardware/waveshare_touch.py
@@ -9,6 +9,7 @@ TOUCH_GESTURE_LONG_PRESS = 5
 TOUCH_GESTURE_CLICK = 6
 
 _mode = TOUCH_POINT_MODE
+_cached_point = (0, 0)
 
 
 def init(mode=TOUCH_POINT_MODE):
@@ -35,7 +36,25 @@ def get_touch_point():
         return (0, 0)
 
 
+def get_cached_point():
+    return _cached_point
+
+
+def read_data(_=None):
+    """Refresh the IRQ-safe touch cache from the scripted touch state."""
+    global _cached_point
+    try:
+        import sim_runtime
+
+        _cached_point = sim_runtime.touch_point()
+    except Exception:
+        _cached_point = (0, 0)
+    return None
+
+
 def reset_state():
+    global _cached_point
+    _cached_point = (0, 0)
     try:
         import sim_runtime
 
@@ -43,6 +62,10 @@ def reset_state():
     except Exception:
         pass
     return True
+
+
+def reset():
+    return reset_state()
 
 
 def set_touch_point(x, y, gesture=TOUCH_GESTURE_CLICK):

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -604,6 +604,12 @@ def _run_sim_check(opts):
         + _quote(opts["apps_source"]),
         "micropython "
         + _quote(THIS_DIR + "/run.py")
+        + " --headless --board waveshare-1.69-rp2350 --frames 30 --wait-view desktop_view --audio silent --network offline --sd "
+        + _quote(opts["sd"])
+        + " --apps-source "
+        + _quote(opts["apps_source"]),
+        "micropython "
+        + _quote(THIS_DIR + "/run.py")
         + " --headless --board waveshare-2.06 --frames 30 --wait-view desktop_view --audio silent --network offline --sd "
         + _quote(opts["sd"])
         + " --apps-source "
@@ -640,6 +646,7 @@ def _run_sim_check(opts):
     _run_font_parity_check()
     _run_scripts_fixture_check(opts)
     _run_touch_check()
+    _run_waveshare_169_check()
     _run_v8_battery_check()
     _run_flipper_battery_check()
     _run_log_storage_check(opts)
@@ -1017,7 +1024,21 @@ def _run_board_parity_check():
         raise RuntimeError("simulator V8 audio capability mismatch")
     if boards.has_psram(boards.BOARD_V8):
         raise RuntimeError("simulator V8 PSRAM capability mismatch")
-    print("[sim-check:ok] V8 board profile and capabilities")
+    if boards.get_name(boards.BOARD_WAVESHARE_1_69_RP2350) != "Waveshare 1.69":
+        raise RuntimeError("simulator Waveshare 1.69 board name mismatch")
+    if boards.get_display_size(boards.BOARD_WAVESHARE_1_69_RP2350) != (240, 280):
+        raise RuntimeError("simulator Waveshare 1.69 display size mismatch")
+    if boards.has_sd_card(boards.BOARD_WAVESHARE_1_69_RP2350):
+        raise RuntimeError("simulator Waveshare 1.69 SD capability mismatch")
+    if not boards.has_touch(boards.BOARD_WAVESHARE_1_69_RP2350):
+        raise RuntimeError("simulator Waveshare 1.69 touch capability mismatch")
+    if boards.has_wifi(boards.BOARD_WAVESHARE_1_69_RP2350):
+        raise RuntimeError("simulator Waveshare 1.69 WiFi capability mismatch")
+    if boards.has_audio(boards.BOARD_WAVESHARE_1_69_RP2350):
+        raise RuntimeError("simulator Waveshare 1.69 audio capability mismatch")
+    if boards.has_psram(boards.BOARD_WAVESHARE_1_69_RP2350):
+        raise RuntimeError("simulator Waveshare 1.69 PSRAM capability mismatch")
+    print("[sim-check:ok] V8 and Waveshare 1.69 board profiles and capabilities")
 
 
 def _run_touch_check():
@@ -1102,6 +1123,49 @@ def _run_v8_battery_check():
     finally:
         sim_runtime.set_battery_percentage(original_percentage)
     print("[sim-check:ok] V8 battery percentage and voltage")
+
+
+def _run_waveshare_169_check():
+    """Exercise the Waveshare 1.69 hard-IRQ touch and battery shims."""
+    from machine import Pin
+    import sim_runtime
+    import waveshare_battery
+    import waveshare_touch
+
+    original_percentage = sim_runtime.battery_percentage()
+    pin = Pin(21, Pin.IN, Pin.PULL_UP)
+    try:
+        waveshare_touch.reset_state()
+        pin.irq(
+            handler=waveshare_touch.read_data,
+            trigger=Pin.IRQ_FALLING,
+            hard=True,
+        )
+        waveshare_touch.set_touch_point(120, 140)
+        if waveshare_touch.get_cached_point() != (120, 140):
+            raise RuntimeError("simulator Waveshare 1.69 cached touch mismatch")
+        if not pin._irq_hard:
+            raise RuntimeError("simulator Waveshare 1.69 hard IRQ flag mismatch")
+        waveshare_touch.reset()
+        if waveshare_touch.get_cached_point() != (0, 0):
+            raise RuntimeError("simulator Waveshare 1.69 touch reset mismatch")
+
+        if waveshare_battery.init() is not None:
+            raise RuntimeError("simulator Waveshare battery init return mismatch")
+        sim_runtime.set_battery_percentage(64)
+        if waveshare_battery.get_percentage() != 64:
+            raise RuntimeError("simulator Waveshare battery percentage mismatch")
+        voltage = waveshare_battery.get_voltage()
+        if voltage < 3.0 or voltage > 5.0:
+            raise RuntimeError("simulator Waveshare battery voltage mismatch")
+        raw = waveshare_battery.read()
+        if raw < 0 or raw > 4095:
+            raise RuntimeError("simulator Waveshare battery ADC mismatch")
+    finally:
+        pin.irq(handler=None)
+        waveshare_touch.reset_state()
+        sim_runtime.set_battery_percentage(original_percentage)
+    print("[sim-check:ok] Waveshare 1.69 hard IRQ touch and battery")
 
 
 def _run_flipper_battery_check():


### PR DESCRIPTION
## Summary

- mirror the Waveshare touch cache APIs used by the new 1.69-inch board
- accept and retain the `hard=True` pin IRQ option in the simulator shim
- provide the Waveshare battery voltage, raw-read, and initialization APIs
- add Waveshare 1.69 boot, capability, hard-IRQ touch, and battery regression coverage

## Root cause

The Waveshare 1.69 board profile was added to the simulator, but its runtime path uses newer native APIs that the shared simulator shims did not yet expose. In particular, `Input` imports `waveshare_touch.read_data`, registers it with a hard pin IRQ, and later reads the cached touch point. The generic simulator suite did not boot this board profile, so it passed while a targeted Waveshare 1.69 run failed during startup.

## Impact

The Waveshare 1.69 profile now reaches the simulated desktop and its touch IRQ/cache and battery interfaces can be exercised deterministically. Existing simulator board behavior is unchanged.

## Validation

- `python3 -m py_compile simulator/hardware/machine.py simulator/hardware/waveshare_touch.py simulator/hardware/waveshare_battery.py simulator/run.py`
- `sh simulator/build.sh --check`
- targeted headless Waveshare 1.69 boot reaching `desktop_view`
- `micropython simulator/run.py --sim-check --audio silent --network offline --sd <fresh temp directory>`
- `git diff --check origin/dev...HEAD`

The full simulator self-check passes, including the new Waveshare 1.69 board profile, hard-IRQ touch/cache, and battery checks.
