### PR TITLE
Restore simulator MMBasic parity

### DIFF
--- a/simulator/hardware/mmbasic.py
+++ b/simulator/hardware/mmbasic.py
@@ -1,0 +1,287 @@
+"""Simulator adapter for Picoware's native ``mmbasic`` module.
+
+Firmware uses the C module in ``src/MicroPython/mmbasic``. The Unix simulator
+runs the last Python implementation from immediately before that C port, kept
+in ``mmbasic_runtime``. This adapter exposes the same constructor and lifecycle
+methods as the native module while rendering through the simulator LCD and SD
+shims.
+"""
+
+import sim_runtime
+
+from mmbasic_runtime.gfx import PicowareGraphics
+from mmbasic_runtime.interpreter import Interpreter
+from mmbasic_runtime.io import PicowareConsole
+from mmbasic_runtime.parser import create_default_def_type_map, parse_source
+from mmbasic_runtime.runtime import Runtime
+
+
+_STATUS_RUNNING = 0
+_STATUS_ENDED = 1
+_STATUS_STOPPED = 2
+_STATUS_INPUT = 3
+_STATUS_ERROR = 4
+
+
+class _Vector:
+    __slots__ = ("x", "y", "z")
+
+    def __init__(self, x=0, y=0, z=0):
+        self.x = int(x)
+        self.y = int(y)
+        self.z = int(z)
+
+
+class _Font:
+    __slots__ = ("size",)
+
+    def __init__(self, size):
+        self.size = int(size)
+
+
+class _DrawAdapter:
+    """Expose the draw attributes used by the Python MMBasic engine."""
+
+    __slots__ = ("size", "font_size", "_background", "_font_default")
+
+    def __init__(self, width, height, font_width, font_height, background, font):
+        self.size = _Vector(width, height)
+        self.font_size = _Vector(font_width, font_height)
+        self._background = int(background)
+        self._font_default = _Font(font)
+
+    def _display(self):
+        return sim_runtime.get_lcd()
+
+    def erase(self):
+        self._clear(self._background)
+
+    def fill_screen(self, color):
+        self._clear(color)
+
+    def _clear(self, color):
+        display = self._display()
+        if display is not None:
+            display._clear(color)
+
+    def _pixel(self, x, y, color):
+        display = self._display()
+        if display is not None:
+            display._pixel(x, y, color)
+
+    def _line(self, x1, y1, x2, y2, color):
+        display = self._display()
+        if display is not None:
+            display._line(x1, y1, x2, y2, color)
+
+    def _rectangle(self, x, y, width, height, color):
+        display = self._display()
+        if display is not None:
+            display._rectangle(x, y, width, height, color)
+
+    def _fill_rectangle(self, x, y, width, height, color):
+        display = self._display()
+        if display is not None:
+            display._fill_rectangle(x, y, width, height, color)
+
+    def _circle(self, x, y, radius, color):
+        display = self._display()
+        if display is not None:
+            display._circle(x, y, radius, color)
+
+    def _fill_circle(self, x, y, radius, color):
+        display = self._display()
+        if display is not None:
+            display._fill_circle(x, y, radius, color)
+
+    def _fill_triangle(self, x1, y1, x2, y2, x3, y3, color):
+        display = self._display()
+        if display is not None:
+            display._fill_triangle(x1, y1, x2, y2, x3, y3, color)
+
+    def _text(self, x, y, text, color, font_size=None):
+        display = self._display()
+        if display is not None:
+            display._text(x, y, text, color, font_size)
+        else:
+            sim_runtime.note_text(text)
+
+    def swap(self):
+        display = self._display()
+        if display is not None:
+            display.swap()
+
+
+class _StorageAdapter:
+    __slots__ = ()
+
+    def exists(self, path):
+        import sd_mp
+
+        return sd_mp.exists(path)
+
+    def read(self, path):
+        import sd_mp
+
+        data = sd_mp.read(path)
+        if isinstance(data, bytes):
+            return data.decode("utf-8")
+        return str(data)
+
+
+class _ViewManagerAdapter:
+    __slots__ = (
+        "draw",
+        "foreground_color",
+        "background_color",
+        "selected_color",
+        "storage",
+    )
+
+    def __init__(self, draw, foreground, background, selected):
+        self.draw = draw
+        self.foreground_color = int(foreground)
+        self.background_color = int(background)
+        self.selected_color = int(selected)
+        self.storage = _StorageAdapter()
+
+    def log(self, message, level=-1):
+        del level
+        print("[sim:mmbasic]", message)
+
+
+class MMBasic:
+    """Native-compatible MMBasic class backed by the Python interpreter."""
+
+    __slots__ = (
+        "_host",
+        "_console",
+        "_gfx",
+        "_interpreter",
+        "_source",
+        "_error",
+    )
+
+    def __init__(
+        self,
+        foreground_color,
+        background_color,
+        selected_color,
+        screen_width,
+        screen_height,
+        font_width,
+        font_height,
+        draw_background,
+        default_font_size,
+    ):
+        draw = _DrawAdapter(
+            screen_width,
+            screen_height,
+            font_width,
+            font_height,
+            draw_background,
+            default_font_size,
+        )
+        self._host = _ViewManagerAdapter(
+            draw,
+            foreground_color,
+            background_color,
+            selected_color,
+        )
+        self._console = PicowareConsole(self._host)
+        self._gfx = PicowareGraphics(self._host)
+        self._interpreter = None
+        self._source = ""
+        self._error = None
+
+    @property
+    def has_graphics(self):
+        """Return whether the running program has drawn graphics."""
+        return self._gfx is not None and self._gfx.has_drawn
+
+    def _start(self, source=None, path=None):
+        """Parse and start source text or a file on the simulated SD card."""
+        if source is None:
+            if path is None:
+                return False
+            try:
+                source = self._host.storage.read(path)
+            except Exception:
+                return False
+        if isinstance(source, bytes):
+            try:
+                source = source.decode("utf-8")
+            except Exception:
+                return False
+        if not isinstance(source, str) or not source.strip():
+            return False
+
+        try:
+            program = parse_source(source)
+            runtime = Runtime(program, def_type_map=create_default_def_type_map())
+            self._interpreter = Interpreter(
+                runtime,
+                console=self._console,
+                gfx=self._gfx,
+            )
+            self._interpreter.start()
+        except Exception as error:
+            self._interpreter = None
+            self._error = error
+            return False
+
+        self._source = source
+        self._error = None
+        self._console.footer = "BACK=exit"
+        self._console.output("MMBasic 6.03  (Picoware)\n")
+        self._console.output("-----------------------\n")
+        self._console.output("\n")
+        self._console.render()
+        return True
+
+    def tick(self, max_time_ms):
+        """Advance the interpreter and return the native three-item status."""
+        if self._interpreter is None:
+            message = str(self._error or "Program not started")
+            return (_STATUS_ERROR, message, 0)
+        try:
+            state = self._interpreter.tick(
+                max_statements=0,
+                max_time_ms=max(0, int(max_time_ms)),
+            )
+        except Exception as error:
+            self._error = error
+            return (_STATUS_ERROR, str(error), 0)
+
+        status = {
+            "running": _STATUS_RUNNING,
+            "ended": _STATUS_ENDED,
+            "stopped": _STATUS_STOPPED,
+            "input": _STATUS_INPUT,
+            "error": _STATUS_ERROR,
+        }.get(state.status, _STATUS_ERROR)
+        return (status, state.message, state.line)
+
+    def feed_char(self, char):
+        """Feed a character to INPUT, INPUT$, or INKEY$."""
+        if self._interpreter is not None:
+            self._interpreter.feed_char(str(char)[:1])
+
+    def render(self, force):
+        """Render the console or present the program framebuffer."""
+        del force
+        if self._interpreter is not None:
+            self._console.set_input_active(self._interpreter.is_input_pending())
+        if self.has_graphics:
+            self._gfx.present()
+        else:
+            self._console.render()
+
+    def set_footer(self, text):
+        """Set the console footer."""
+        self._console.footer = str(text)
+        self._console.dirty = True
+
+    def console_output(self, text):
+        """Append text to the MMBasic console."""
+        self._console.output(str(text))

--- a/simulator/hardware/mmbasic_runtime/__init__.py
+++ b/simulator/hardware/mmbasic_runtime/__init__.py
@@ -1,0 +1,6 @@
+"""Python MMBasic engine used only by the Unix simulator.
+
+This package is the final Python implementation from immediately before
+commit 393ebc5e converted firmware to the native C module. Keep firmware on
+the C implementation and update this simulator copy when its behavior changes.
+"""

--- a/simulator/hardware/mmbasic_runtime/builtins.py
+++ b/simulator/hardware/mmbasic_runtime/builtins.py
@@ -1,0 +1,618 @@
+import math
+import gc
+import struct
+
+from .runtime import RuntimeError_
+
+
+class TabMarker:
+    """TAB(n) marker returned by the TAB() function in a PRINT list."""
+
+    __slots__ = ("column",)
+
+    def __init__(self, column):
+        self.column = column
+
+    def __repr__(self):
+        return "TAB(%d)" % self.column
+
+
+class SpcMarker:
+    """SPC(n) marker returned by the SPC() function in a PRINT list."""
+
+    __slots__ = ("count",)
+
+    def __init__(self, count):
+        self.count = count
+
+    def __repr__(self):
+        return "SPC(%d)" % self.count
+
+
+class UsingFormatter:
+    """PRINT USING formatter: a small but faithful subset of MBASIC fields.
+
+    Supported:
+        #      digit placeholder
+        .      decimal point
+        ,      thousands separator
+        + / -  sign control
+        !      first character of a string
+        &      whole string
+        \\ \\   string of (n+2) characters, left-justified
+        _      next character is literal
+    Overflow prints a leading '%' like MBASIC.
+    """
+
+    __slots__ = ("format_string", "fields")
+
+    def __init__(self, format_string):
+        self.format_string = format_string
+        self.fields = self._parse(format_string)
+
+    def _parse(self, fmt):
+        """Split the format string into (literal_text, field_spec) segments."""
+        fields = []
+        i = 0
+        n = len(fmt)
+        literal = []
+        while i < n:
+            c = fmt[i]
+            if c == "_" and i + 1 < n:
+                literal.append(fmt[i + 1])
+                i += 2
+                continue
+            if c == "#" or c == "!" or c == "&" or c == "\\":
+                if literal:
+                    fields.append(("literal", "".join(literal)))
+                    literal = []
+                if c == "\\":
+                    j = i
+                    while j < n and fmt[j] == "\\":
+                        j += 1
+                    width = j - i + 2
+                    fields.append(("string", {"kind": "bs", "width": width}))
+                    i = j
+                    continue
+                if c == "!":
+                    fields.append(("string", {"kind": "bang"}))
+                    i += 1
+                    continue
+                if c == "&":
+                    fields.append(("string", {"kind": "amp"}))
+                    i += 1
+                    continue
+                # '#' numeric field
+                j = i
+                spec = {"sign": None, "digits": 0, "decimals": 0,
+                        "commas": False, "exponent": 0}
+                if j < n and fmt[j] in "+-":
+                    spec["sign"] = fmt[j]
+                    j += 1
+                while j < n and (fmt[j] in "#*$,"):
+                    if fmt[j] == ",":
+                        spec["commas"] = True
+                    elif fmt[j] in "*$":
+                        spec["fill"] = fmt[j]
+                    j += 1
+                while j < n and fmt[j] == "#":
+                    spec["digits"] += 1
+                    j += 1
+                if j < n and fmt[j] == ".":
+                    j += 1
+                    while j < n and fmt[j] == "#":
+                        spec["decimals"] += 1
+                        j += 1
+                if j < n and fmt[j] == "^":
+                    while j < n and fmt[j] == "^":
+                        spec["exponent"] += 1
+                        j += 1
+                fields.append(("number", spec))
+                i = j
+                continue
+            literal.append(c)
+            i += 1
+        if literal:
+            fields.append(("literal", "".join(literal)))
+        return fields
+
+    def format_values(self, values):
+        out = []
+        vi = 0
+        for kind, data in self.fields:
+            if kind == "literal":
+                out.append(data)
+            elif kind == "string":
+                if vi >= len(values):
+                    break
+                value = values[vi]
+                vi += 1
+                out.append(self._format_string(str(value), data))
+            else:  # number
+                if vi >= len(values):
+                    break
+                value = values[vi]
+                vi += 1
+                out.append(self._format_number(value, data))
+        return "".join(out)
+
+    def _format_string(self, value, spec):
+        kind = spec["kind"]
+        if kind == "bang":
+            return value[:1] if value else " "
+        if kind == "amp":
+            return value
+        # backslash field: width chars, left justified
+        return (value + " " * spec["width"])[:spec["width"]]
+
+    def _format_number(self, value, spec):
+        try:
+            x = float(value)
+        except (TypeError, ValueError):
+            return "%" + str(value)
+        overflow = False
+        digits = spec.get("digits", 1) or 1
+        decimals = spec.get("decimals", 0)
+        int_digits = digits - decimals
+        if int_digits < 1:
+            int_digits = 1
+
+        negative = x < 0
+        x = abs(x)
+        if spec.get("exponent", 0) > 0:
+            return self._exponential(x, negative, spec)
+
+        scaled = round(x, decimals)
+        max_int = 10 ** int_digits - 1
+        if scaled >= 10 ** (int_digits + decimals):
+            overflow = True
+        if scaled > max_int + (10 ** -decimals) * 0.999:
+            overflow = True
+
+        frac = int(round((scaled - int(scaled)) * (10 ** decimals))) if decimals else 0
+        whole = int(scaled)
+        if frac >= 10 ** decimals:
+            frac -= 10 ** decimals
+            whole += 1
+            if whole >= 10 ** int_digits:
+                overflow = True
+
+        num_text = ("%0*d" % (decimals, frac)) if decimals else ""
+        whole_text = str(whole)
+        if spec.get("commas"):
+            out = []
+            for i, c in enumerate(reversed(whole_text)):
+                if i and i % 3 == 0:
+                    out.append(",")
+                out.append(c)
+            whole_text = "".join(reversed(out))
+        if decimals:
+            num_text = whole_text + "." + num_text
+        else:
+            num_text = whole_text
+
+        fill = spec.get("fill")
+        if fill:
+            fill_n = int_digits - len(whole_text)
+            if fill_n > 0:
+                num_text = fill * fill_n + num_text
+            if negative:
+                num_text = "-" + num_text
+            elif spec.get("sign") == "+":
+                num_text = "+" + num_text
+            return ("%" if overflow else "") + num_text
+
+        sign = ""
+        if negative:
+            sign = "-"
+        elif spec.get("sign") == "+":
+            sign = "+"
+        elif spec.get("sign") == "-":
+            sign = " "
+        return ("%" if overflow else "") + sign + num_text
+
+    @staticmethod
+    def _exponential(x, negative, spec):
+        if x != 0:
+            exp = int(math.floor(math.log10(x)))
+            mant = x / (10.0 ** exp)
+        else:
+            exp = 0
+            mant = 0.0
+        decimals = spec.get("decimals", 2)
+        mant = round(mant, decimals)
+        if mant >= 10.0:
+            mant /= 10.0
+            exp += 1
+        text = ("%0.*f" % (decimals, mant))
+        sign = "-" if negative else "+"
+        return "%sE%s%02d" % (text, sign, abs(exp))
+
+
+class KeyInputPending(Exception):
+    """Raised when INPUT$ needs keys that have not arrived yet.
+
+    The interpreter catches this to yield control (cooperative tick), then
+    re-executes the statement once the keys arrive.
+    """
+
+    def __init__(self, remaining):
+        super().__init__("key input pending")
+        self.remaining = remaining
+
+
+class BuiltinFunctions:
+    """MBASIC 5.21 built-in functions."""
+
+    __slots__ = ("runtime", "_io_provider")
+
+    def __init__(self, runtime, io_provider=None):
+        self.runtime = runtime
+        self._io_provider = io_provider  # callable returning the console
+
+    def _io(self):
+        if self._io_provider:
+            return self._io_provider()
+        return None
+
+
+    def ABS(self, x):
+        return abs(self._num(x))
+
+    def ATN(self, x):
+        return math.atan(self._num(x))
+
+    def ATAN2(self, y, x):
+        """Arctangent of y/x with the correct quadrant, in radians."""
+        return math.atan2(self._num(y), self._num(x))
+
+    def COS(self, x):
+        return math.cos(self._num(x))
+
+    def EXP(self, x):
+        return math.exp(self._num(x))
+
+    def FIX(self, x):
+        return int(self._num(x))
+
+    def INT(self, x):
+        return math.floor(self._num(x))
+
+    def LOG(self, x):
+        return math.log(self._num(x))
+
+    def SGN(self, x):
+        v = self._num(x)
+        return -1 if v < 0 else (1 if v > 0 else 0)
+
+    def SIN(self, x):
+        return math.sin(self._num(x))
+
+    def SQR(self, x):
+        return math.sqrt(self._num(x))
+
+    def TAN(self, x):
+        return math.tan(self._num(x))
+
+    def RND(self, x=None):
+        if x is None:
+            return self.runtime.rnd.next()
+        return self.runtime.rnd.next(self._num(x))
+
+    def CINT(self, x):
+        from .number import to_integer
+        v = to_integer(self._num(x))
+        return (v + 0x8000) % 0x10000 - 0x8000  # wrap to signed 16-bit
+
+    def CSNG(self, x):
+        from .number import to_single
+        return to_single(self._num(x))
+
+    def CDBL(self, x):
+        return float(self._num(x))
+
+    def PEEK(self, addr):
+        memory = getattr(self.runtime, "memory", {})
+        return memory.get(int(self._num(addr)) & 0xFFFF, 0)
+
+    def INP(self, _port):
+        return 0
+
+    def POS(self, _dummy=None):
+        io = self._io()
+        if io is not None and hasattr(io, "pos"):
+            return io.pos()
+        return 0
+
+    def FRE(self, _x=None):
+        return gc.mem_free()
+
+    def ERR(self, *_a):
+        return getattr(self.runtime, "last_error_code", 0)
+
+    def ERL(self, *_a):
+        return getattr(self.runtime, "last_error_line", 0)
+
+    def LOC(self, file_num):
+        return 0
+
+    def LOF(self, file_num):
+        return 0
+
+    def EOF(self, file_num):
+        try:
+            fn = int(self._num(file_num))
+            return -1 if self.runtime.files.get(fn, {}).get("eof") else 0
+        except Exception:
+            return 0
+
+    def USR(self, *_a):
+        return 0
+
+    def VARPTR(self, *_a):
+        return 0
+
+
+    def ASC(self, s):
+        s = str(s)
+        if not s:
+            return 0  # MMBasic: ASC("") returns 0 (key-polling idiom)
+        return ord(s[0])
+
+    def EVAL(self, s):
+        """Evaluate a BASIC expression held in a string, in the current
+        variable context (MMBasic 6.x EVAL)."""
+        from .lexer import Lexer
+        from .parser import Parser
+        from .tokens import Token, TokenType
+
+        s = str(s)
+        if not s.strip():
+            return 0
+        lexer = Lexer(s)
+        tokens = lexer.tokenize()
+        # A leading digit at the start of a "line" lexes as a LINE_NUMBER;
+        # EVAL takes an expression, so treat it as an ordinary NUMBER.
+        if tokens and tokens[0].type == TokenType.LINE_NUMBER:
+            t = tokens[0]
+            tokens[0] = Token(TokenType.NUMBER, t.value, t.line, t.column,
+                              literal_text=str(t.value))
+        parser = Parser(tokens)
+        node = parser.parse_expression()
+        io = self._io()
+        if io is not None and hasattr(io, "eval_expr"):
+            return io.eval_expr(node)
+        raise RuntimeError_("EVAL is unavailable", 5, 0)
+
+    def CHR(self, x):
+        return chr(int(self._num(x)) & 0xFF)
+
+    def HEX(self, x):
+        v = int(self._num(x)) & 0xFFFF
+        return format(v, "X")
+
+    def OCT(self, x):
+        v = int(self._num(x)) & 0xFFFF
+        return format(v, "o")
+
+    def INSTR(self, *args):
+        # INSTR([start,] s1, s2)
+        if len(args) == 3:
+            start = int(self._num(args[0]))
+            s1 = str(args[1])
+            s2 = str(args[2])
+        else:
+            start = 1
+            s1 = str(args[0])
+            s2 = str(args[1])
+        if start < 1:
+            start = 1
+        if start > len(s1):
+            return 0
+        idx = s1.find(s2, start - 1)
+        if idx < 0:
+            return 0
+        return idx + 1
+
+    def LEFT(self, s, n):
+        s = str(s)
+        n = max(int(self._num(n)), 0)
+        return s[:n]
+
+    def LEN(self, s):
+        return len(str(s))
+
+    def MID(self, *args):
+        s = str(args[0])
+        start = int(self._num(args[1]))
+        if start < 1:
+            start = 1
+        if len(args) > 2:
+            length = max(int(self._num(args[2])), 0)
+            return s[start - 1:start - 1 + length]
+        return s[start - 1:]
+
+    def RIGHT(self, s, n):
+        s = str(s)
+        n = max(int(self._num(n)), 0)
+        if n == 0:
+            return ""
+        return s[-n:]
+
+    def SPACE(self, n):
+        n = max(int(self._num(n)), 0)
+        return " " * n
+
+    def STR(self, x):
+        from .number import format_number, SINGLE_DIGITS
+        text = format_number(self._num(x), SINGLE_DIGITS)
+        if not text.startswith("-"):
+            text = " " + text
+        return text
+
+    def STRING(self, n, char):
+        n = max(int(self._num(n)), 0)
+        if isinstance(char, str):
+            c = char[0] if char else " "
+        else:
+            c = chr(int(self._num(char)) & 0xFF)
+        return c * n
+
+    def TIME(self):
+        """Return the local RTC time in MMBasic's HH:MM:SS form."""
+        import time
+
+        now = time.localtime()
+        return "%02d:%02d:%02d" % (now[3], now[4], now[5])
+
+    def NOW(self):
+        """Return the current Unix epoch (seconds)."""
+        import time
+
+        return int(time.time())
+
+    def EPOCH(self, n=0):
+        """Return the Unix epoch for a date (best effort: identity)."""
+        return int(self._num(n))
+
+    def TODAY(self):
+        """Return MMBasic's TODAY$ (DD/MM/YYYY HH:MM:SS) for month parsing."""
+        import time
+
+        now = time.localtime()
+        return "%02d/%02d/%04d %02d:%02d:%02d" % (
+            now[2], now[1], now[0], now[3], now[4], now[5])
+
+    def DATETIME(self, n=0):
+        """Return a human-readable date string for DAY$ to prefix."""
+        import time
+
+        weekdays = ("Monday", "Tuesday", "Wednesday", "Thursday",
+                    "Friday", "Saturday", "Sunday")
+        months = ("January", "February", "March", "April", "May", "June",
+                  "July", "August", "September", "October", "November",
+                  "December")
+        try:
+            t = time.localtime(int(self._num(n)))
+        except Exception:
+            t = time.localtime()
+        return "%s %d %s %d" % (weekdays[t[6] % 7], t[2], months[t[1] - 1],
+                                t[0])
+
+    def DAY(self, s):
+        """DAY$(date$): the leading day name of a DATETIME$ string."""
+        text = str(s).strip()
+        if text and text.split():
+            return text.split()[0]
+        return ""
+
+    def VAL(self, s):
+        s = str(s).strip()
+        if not s:
+            return 0
+        i = 0
+        n = len(s)
+        if s[0] in "+-":
+            i = 1
+        while i < n and (s[i].isdigit() or s[i] in ".eEdD"):
+            i += 1
+        token = s[:i]
+        if not token or token in ("+", "-", "."):
+            return 0
+        try:
+            if "D" in token or "d" in token:
+                token = token.replace("D", "E").replace("d", "e")
+            return float(token) if (any(c in token for c in ".eE")) else int(token)
+        except ValueError:
+            return 0
+
+
+    def MKI(self, x):
+        return struct.pack("<h", int(self._num(x)) & 0xFFFF)
+
+    def MKS(self, x):
+        return struct.pack("<f", self._num(x))
+
+    def MKD(self, x):
+        return struct.pack("<d", self._num(x))
+
+    def CVI(self, s):
+        s = self._as_bytes(s)
+        if len(s) < 2:
+            return 0
+        return struct.unpack("<h", s[:2])[0]
+
+    def CVS(self, s):
+        s = self._as_bytes(s)
+        if len(s) < 4:
+            return 0.0
+        return struct.unpack("<f", s[:4])[0]
+
+    def CVD(self, s):
+        s = self._as_bytes(s)
+        if len(s) < 8:
+            return 0.0
+        return struct.unpack("<d", s[:8])[0]
+
+    @staticmethod
+    def _as_bytes(s):
+        if isinstance(s, bytes):
+            return s
+        if isinstance(s, bytearray):
+            return bytes(s)
+        return bytes(ord(c) & 0xFF for c in str(s))
+
+
+    def TAB(self, n):
+        return TabMarker(max(int(self._num(n)), 1))
+
+    def SPC(self, n):
+        return SpcMarker(max(int(self._num(n)), 0))
+
+    def CHOICE(self, cond, a, b):
+        """Return a if cond is true (non-zero), else b."""
+        try:
+            truthy = float(cond) != 0
+        except (TypeError, ValueError):
+            truthy = bool(cond)
+        return a if truthy else b
+
+
+    def INKEY(self):
+        io = self._io()
+        if io is None or not hasattr(io, "read_key"):
+            return ""
+        return io.read_key()
+
+    def UCASE(self, s):
+        return str(s).upper()
+
+    def LCASE(self, s):
+        return str(s).lower()
+
+    def DIR(self, pattern, kind=0):
+        return ""
+
+    def INPUTSTRING(self, prompt=""):
+        """INPUTSTRING$(prompt): pop-up string input. Returns '' (no dialog)."""
+        return ""
+
+    def INPUT(self, num, file_num=None):
+        io = self._io()
+        if io is None or not hasattr(io, "key_input"):
+            raise KeyInputPending(int(self._num(num)))
+        return io.key_input(int(self._num(num)))
+
+
+    @staticmethod
+    def _num(x):
+        if isinstance(x, bool):
+            return int(x)
+        if isinstance(x, (int, float)):
+            return x
+        if isinstance(x, bytes):
+            try:
+                return float(x)
+            except Exception:
+                pass
+        raise TypeError("Type mismatch")

--- a/simulator/hardware/mmbasic_runtime/gfx.py
+++ b/simulator/hardware/mmbasic_runtime/gfx.py
@@ -1,0 +1,273 @@
+import math
+
+# Named colours for RGB(NAME) - 24-bit 0xRRGGBB values.
+NAMED_COLORS = {
+    "black": 0x000000,
+    "white": 0xFFFFFF,
+    "red": 0xFF0000,
+    "green": 0x00FF00,
+    "blue": 0x0000FF,
+    "yellow": 0xFFFF00,
+    "cyan": 0x00FFFF,
+    "magenta": 0xFF00FF,
+    "orange": 0xFF8000,
+    "pink": 0xFF0080,
+    "brown": 0xA52A2A,
+    "grey": 0x808080,
+    "gray": 0x808080,
+    "darkgrey": 0x404040,
+    "darkgray": 0x404040,
+    "lightgrey": 0xC0C0C0,
+    "lightgray": 0xC0C0C0,
+    "purple": 0x800080,
+    "myrtle": 0x21421E,
+    "maroon": 0x800000,
+    "navy": 0x000080,
+    "teal": 0x008080,
+    "olive": 0x808000,
+    "silver": 0xC0C0C0,
+    "lime": 0x00FF00,
+    "aqua": 0x00FFFF,
+    "fuchsia": 0xFF00FF,
+    "gold": 0xFFD700,
+    "violet": 0xEE82EE,
+}
+
+
+def rgb_to_565(color):
+    """Convert a 24-bit 0xRRGGBB colour to a 16-bit 565 value."""
+    color = int(color) & 0xFFFFFF
+    r = (color >> 16) & 0xFF
+    g = (color >> 8) & 0xFF
+    b = color & 0xFF
+    return ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3)
+
+
+class PicowareGraphics:
+    """Renders MMBasic graphics via the draw layer's C methods."""
+
+    __slots__ = (
+        "draw",
+        "vm",
+        "cur_color",
+        "pen_down",
+        "tx",
+        "ty",
+        "thead",
+        "_w",
+        "_h",
+        "_bg",
+        "_fs",
+        "display_active",
+        "has_drawn",
+    )
+
+    def __init__(self, view_manager):
+        """Bind the draw layer and capture screen, background and font."""
+        self.vm = view_manager
+        self.cur_color = 0xFFFFFF
+        self.pen_down = True
+        self.tx = 0.0
+        self.ty = 0.0
+        self.thead = 0.0
+        self._w = 320
+        self._h = 240
+        self._bg = 0
+        self._fs = 8
+        self.display_active = False
+        self.has_drawn = False
+        draw = view_manager.draw
+        if draw is not None:
+            self._w = draw.size.x
+            self._h = draw.size.y
+            self._bg = draw._background
+            self._fs = draw._font_default.size
+
+    def __del__(self):
+        """Cleanup"""
+        self.vm = None
+
+    def present(self):
+        """Present the back buffer so drawn graphics become visible."""
+        if self.vm.draw is not None and self.has_drawn:
+            self.vm.draw.swap()
+
+    def _c(self, color):
+        """Return the 565 colour for an MMBasic colour."""
+        if color is None:
+            return rgb_to_565(self.cur_color)
+        if isinstance(color, str):
+            color = NAMED_COLORS.get(color.lower().strip(), 0xFFFFFF)
+        return rgb_to_565(color)
+
+    def cls(self, color=None):
+        """Clear the screen with a colour, or the background."""
+        self.has_drawn = True
+        if color is not None:
+            self.vm.draw._clear(self._c(color))
+            return
+        self.vm.draw._clear(self._bg)
+
+    def pixel(self, x, y, color=None):
+        """Draw a single pixel."""
+        self.has_drawn = True
+        self.vm.draw._pixel(x, y, self._c(color))
+
+    def line(self, x1, y1, x2, y2, thickness=1, color=None):
+        """Draw a line, with optional thickness."""
+        self.has_drawn = True
+        col = self._c(color)
+        if thickness and (thickness) > 1:
+            self._thick_line(x1, y1, x2, y2,
+                             (thickness), col)
+        else:
+            self.vm.draw._line((x1), (y1), (x2), (y2), col)
+
+    def box(self, x, y, w, h, thickness=1, outline=None, fill=None):
+        """Draw a box outline and/or fill."""
+        self.has_drawn = True
+        if fill is not None:
+            self.vm.draw._fill_rectangle(x, y, w, h, self._c(fill))
+        if outline is not None:
+            self.vm.draw._rectangle(x, y, w, h, self._c(outline))
+        elif fill is None:
+            self.vm.draw._rectangle(x, y, w, h, self._c(None))
+
+    def circle(self, x, y, r, *extra):
+        """Draw a circle, treating trailing args as outline/fill."""
+        self.has_drawn = True
+        args = list(extra)
+        outline = None
+        fill = None
+        while args:
+            v = args.pop()
+            if isinstance(v, bool):
+                continue
+            if fill is None:
+                fill = v
+            elif outline is None:
+                outline = v
+        if fill is not None and fill != 0:
+            self.vm.draw._fill_circle(x, y, r, self._c(fill))
+        if outline is not None and outline != 0:
+            self.vm.draw._circle(x, y, r, self._c(outline))
+        elif fill is None:
+            self.vm.draw._circle(x, y, r, self._c(None))
+
+    def polygon(self, xs, ys, outline=None, fill=None):
+        """Draw a polygon outline and/or fill from coordinate arrays."""
+        self.has_drawn = True
+        pts = []
+        n = min(len(xs), len(ys))
+        for i in range(n):
+            pts.append((xs[i], ys[i]))
+        if len(pts) < 3:
+            return
+        if fill is not None and fill != 0:
+            col = self._c(fill)
+            x1, y1 = pts[0]
+            for i in range(1, len(pts) - 1):
+                x2, y2 = pts[i]
+                x3, y3 = pts[i + 1]
+                self.vm.draw._fill_triangle(x1, y1, x2, y2, x3, y3, col)
+        if outline is not None and outline != 0:
+            col = self._c(outline)
+            for i in range(len(pts)):
+                x1, y1 = pts[i]
+                x2, y2 = pts[(i + 1) % len(pts)]
+                self.vm.draw._line(x1, y1, x2, y2, col)
+
+    def color(self, fg, bg=None):
+        """Set the current MMBasic foreground (and optional background)."""
+        if fg is not None:
+            self.cur_color = fg
+        if bg is not None:
+            self._bg = bg
+
+    def set_font_size(self, size):
+        """MMBasic FONT n: 0-4 are font numbers; map to a pixel height."""
+        sizes = {0: 8, 1: 8, 2: 12, 3: 16, 4: 20}
+        try:
+            self._fs = sizes.get(int(size), 8)
+        except (TypeError, ValueError):
+            self._fs = 8
+
+    def text(self, x, y, s):
+        """Draw a string at the given position."""
+        self.has_drawn = True
+        self.vm.draw._text(x, y, s, self._c(None), self._fs)
+
+    def framebuffer(self, sub, args):
+        """Handle FRAMEBUFFER; the draw layer is already double-buffered."""
+        sub = str(sub).lower()
+        if sub == "create":
+            self.display_active = True
+            self.has_drawn = True
+            self.cls()
+        elif sub == "write":
+            self.display_active = True
+            self.has_drawn = True
+        elif sub == "copy":
+            self.display_active = True
+            self.has_drawn = True
+            self.swap()
+        elif sub == "close":
+            self.display_active = False
+        return True
+
+    def swap(self):
+        """Present the back buffer."""
+        self.vm.draw.swap()
+
+    def save_image(self, filename):
+        """Save the framebuffer; unsupported on the device for now."""
+        return True
+
+    def turtle(self, sub, args):
+        """Run a turtle command."""
+        sub = str(sub).lower()
+        if sub in ("reset", "home"):
+            self.cls()
+            self.pen_down = True
+            self.tx = self._w / 2.0
+            self.ty = self._h / 2.0
+            self.thead = 0.0
+        elif sub == "pen down":
+            self.pen_down = True
+        elif sub == "pen up":
+            self.pen_down = False
+        elif sub == "forward":
+            self._turtle_step(float(args[0]) if args else 0)
+        elif sub == "back":
+            self._turtle_step(-(float(args[0]) if args else 0))
+        elif sub == "right":
+            self.thead = (self.thead + float(args[0])) % 360
+        elif sub == "left":
+            self.thead = (self.thead - float(args[0])) % 360
+        elif sub in ("set xy", "setxy"):
+            self.tx = float(args[0])
+            self.ty = float(args[1])
+        elif sub in ("set heading", "setheading", "heading"):
+            self.thead = float(args[0]) % 360
+        return True
+
+    def _turtle_step(self, dist):
+        """Move the turtle and draw if the pen is down."""
+        rad = math.radians(self.thead)
+        nx = self.tx + dist * math.cos(rad)
+        ny = self.ty - dist * math.sin(rad)
+        if self.pen_down:
+            self.vm.draw._line(self.tx, self.ty, nx, ny, self._c(None))
+        self.tx = nx
+        self.ty = ny
+
+    def _thick_line(self, x1, y1, x2, y2, thick, col):
+        """Draw a thick line as a filled rectangle."""
+        if x1 == x2:
+            self.vm.draw._fill_rectangle(x1 - thick // 2, min(y1, y2),
+                                      thick, abs(y2 - y1) + 1, col)
+        elif y1 == y2:
+            self.vm.draw._fill_rectangle(min(x1, x2), y1 - thick // 2,
+                                      abs(x2 - x1) + 1, thick, col)
+        else:
+            self.vm.draw._line(x1, y1, x2, y2, col)

--- a/simulator/hardware/mmbasic_runtime/interpreter.py
+++ b/simulator/hardware/mmbasic_runtime/interpreter.py
@@ -1,0 +1,1883 @@
+from . import nodes as nodes
+import time
+from .runtime import RuntimeError_
+from .number import (
+    format_for_print, INTEGER_DIGITS, SINGLE_DIGITS, DOUBLE_DIGITS,
+)
+from .builtins import BuiltinFunctions, TabMarker, SpcMarker, KeyInputPending
+from .gfx import NAMED_COLORS
+
+
+class _FunctionReturn(Exception):
+    """Internal: a FUNCTION finished and its value is ready."""
+
+    def __init__(self, value):
+        super().__init__("function return")
+        self.value = value
+
+
+class _DoExit(Exception):
+    """Internal: EXIT DO fired inside an inline (clause-body) DO...LOOP."""
+
+
+#: Sentinel for "parameter was not bound before" in DEF FN.
+_UNBOUND = object()
+
+
+class InterpreterState:
+    """Result of one tick(), for the host app to inspect."""
+
+    __slots__ = ("status", "message", "line", "error_code")
+
+    def __init__(self, status="running", message="", line=0, error_code=0):
+        self.status = status      # running | ended | stopped | input | error
+        self.message = message
+        self.line = line
+        self.error_code = error_code
+
+    def __repr__(self):
+        return "<InterpreterState %s %r>" % (self.status, self.message)
+
+
+class Interpreter:
+    """Execute MBASIC AST with cooperative tick-based execution."""
+
+    __slots__ = ("runtime", "console", "gfx", "builtins",
+                 "_pending", "_key_buffer", "_key_want", "_input_vars",
+                 "_input_line", "_input_ready", "_input_line_mode",
+                 "_continuations", "_resume_index", "_fatal", "_tick_timers",
+                 "_in_function_call", "_inline_do_depth")
+
+    def __init__(self, runtime, console=None, builtins=None, gfx=None):
+        self.runtime = runtime
+        self.console = console
+        self.gfx = gfx
+        self.builtins = builtins or BuiltinFunctions(
+            runtime, io_provider=lambda: self)
+
+        # Input state
+        self._pending = None      # None | 'input' | 'key'
+        self._key_buffer = []     # chars for INKEY$/INPUT$
+        self._key_want = 0        # extra chars INPUT$ still needs
+        self._input_vars = []     # INPUT statement variables (nodes)
+        self._input_line = ""
+        self._input_ready = False
+        self._input_line_mode = False  # True for LINE INPUT
+        self._continuations = []  # clause continuations: (stmts, index, after_pc)
+        self._resume_index = None  # for RESUME (no arg)
+        self._fatal = None
+        self._tick_timers = {}     # SETTICK slot -> periodic SUB callback
+        self._in_function_call = 0  # nested FUNCTION body depth (for INPUT)
+        self._inline_do_depth = 0   # inline DO...LOOP nesting (for EXIT DO)
+
+        # Input state
+        self._pending = None      # None | 'input' | 'key'
+        self._key_buffer = []     # chars for INKEY$/INPUT$
+        self._key_want = 0        # extra chars INPUT$ still needs
+        self._input_vars = []     # INPUT statement variables (nodes)
+        self._input_line = ""
+        self._input_ready = False
+        self._continuations = []  # clause continuations: (stmts, index, after_pc)
+        self._resume_index = None  # for RESUME (no arg)
+        self._fatal = None
+
+
+    def start(self):
+        self.runtime.reset()
+        self.runtime.running = True
+        self._pending = None
+        self._key_buffer = []
+        self._key_want = 0
+        self._input_vars = []
+        self._input_line = ""
+        self._input_ready = False
+        self._continuations = []
+        self._resume_index = None
+        self._fatal = None
+        self._tick_timers = {}
+        self._in_function_call = 0
+        self._inline_do_depth = 0
+        return InterpreterState("running")
+
+    def tick(self, max_statements=0, max_time_ms=0):
+        """Execute the program cooperatively.
+
+        max_statements: statement budget per call. 0 (the default) means no
+        statement cap - execution runs until it yields naturally (END/STOP/
+        ERROR, an INPUT/INPUT$ park, a BREAK) or until `max_time_ms` elapses.
+
+        max_time_ms: wall-clock budget per call, in milliseconds. 0 (the
+        default) means no time cap. The MMBasic engine passes a small value so
+        interactive programs (INKEY$ polling, SETTICK timers, drawing) are
+        still serviced between ticks; a fixed *statement* count would throttle
+        fast programs for no reason, so the engine no longer uses one.
+        """
+        if not self.runtime.running:
+            return self._state("ended")
+
+        # Resolve pending input first.
+        if self._pending == "input":
+            if self._input_ready:
+                self._finish_input()
+            else:
+                return self._state("input")
+        elif self._pending == "key":
+            if len(self._key_buffer) >= self._key_want:
+                self._pending = None  # re-execute the INPUT$ statement
+            else:
+                return self._state("input")
+
+        # SETTICK callbacks are dispatched only at Picoware's cooperative
+        # frame boundary. Never interrupt a running SUB or inline clause.
+        self._dispatch_tick_timer()
+
+        count = 0
+        if max_statements <= 0:
+            max_statements = 1 << 30  # effectively unlimited
+        t0 = None
+        if max_time_ms > 0:
+            t0 = time.ticks_ms()
+        while count < max_statements and self.runtime.running:
+            if self.runtime.break_requested:
+                self.runtime.running = False
+                return self._state("stopped", "Break")
+            result = self._step()
+            if result == "INPUT_WAIT":
+                return self._state("input")
+            if result == "END":
+                self.runtime.running = False
+                return self._state("ended")
+            if result == "STOP":
+                self.runtime.running = False
+                return self._state("stopped",
+                                   "Break in line %d" % self.runtime.line_for_index(
+                                       self.runtime.pc))
+            if result == "ERROR":
+                return self._fatal_state()
+            count += 1
+            if t0 is not None and (count & 15) == 0 and \
+                    time.ticks_diff(time.ticks_ms(), t0) >= max_time_ms:
+                break
+        return self._state("running")
+
+
+    def _step(self):
+        # Resume a clause continuation (GOSUB inside THEN/ELSE).
+        if self._continuations:
+            stmts, i, after_pc = self._continuations.pop()
+            return self._run_statement_list(stmts, i, after_pc, is_resume=True)
+
+        if self.runtime.pc >= len(self.runtime.statements):
+            self.runtime.running = False
+            return "END"
+
+        line_num, stmt = self.runtime.statements[self.runtime.pc]
+        self.runtime.statement_count += 1
+        if self.runtime.tron and self.console is not None:
+            self.console.output("[%d]" % line_num)
+
+        try:
+            result = self._exec_statement(stmt)
+        except KeyInputPending as e:
+            self._key_want = e.remaining
+            self._pending = "key"
+            return "INPUT_WAIT"
+        except (RuntimeError_, ZeroDivisionError, OverflowError,
+                ValueError, TypeError, IndexError) as e:
+            return self._handle_error(e, line_num)
+
+        if result == "JUMP":
+            return "NORMAL"  # pc already set by the statement
+        if result in ("END", "STOP", "INPUT_WAIT", "ERROR"):
+            return result
+        self.runtime.pc += 1
+        return "NORMAL"
+
+    def _run_statement_list(self, statements, start=0, after_pc=None,
+                            is_resume=False):
+        """Execute a THEN/ELSE/block-IF/CASE clause inline.
+
+        A GOSUB inside a clause pushes a continuation frame so RETURN comes
+        back to the rest of the clause, then to `after_pc`.
+        """
+        i = start
+        local_for = []  # list of {'var','limit','step','body_i'} frames
+        while i < len(statements):
+            stmt = statements[i]
+            name = type(stmt).__name__
+            if name == "GosubStatementNode":
+                target = self.eval_expr(stmt.target)
+                idx = self.runtime.resolve_line(target)
+                if idx is None:
+                    raise RuntimeError_("Undefined line number", 8, stmt.line_num)
+                self.runtime.push_gosub(("clause", statements, i + 1, after_pc))
+                self.runtime.pc = idx
+                return "JUMP"
+            if name == "ForStatementNode":
+                frame = self._make_for_frame(stmt)
+                frame["body_i"] = i + 1
+                local_for.append(frame)
+                i += 1
+                continue
+            if name == "NextStatementNode":
+                if local_for:
+                    if self._exec_next_inline(stmt, local_for):
+                        i = local_for[-1]["body_i"]
+                        continue
+                    local_for.pop()
+                    i += 1
+                    continue
+            if name == "DoLoopStatementNode":
+                result = self._exec_do_inline(stmt, after_pc)
+                if result in ("JUMP", "END", "STOP", "ERROR", "INPUT_WAIT"):
+                    return result
+                i += 1
+                continue
+            if name == "ExitDoStatementNode" and self._inline_do_depth > 0:
+                # Inside a nested inline DO...LOOP: signal it to stop.
+                raise _DoExit()
+            result = self._exec_statement(stmt)
+            if result in ("JUMP", "END", "STOP", "ERROR", "INPUT_WAIT"):
+                return result
+            i += 1
+        if is_resume and after_pc is not None:
+            # Resumed after a GOSUB-in-clause returned: restore the flat pc so
+            # execution continues after the enclosing construct. pc is already
+            # positioned, so tell _step not to advance again.
+            self.runtime.pc = after_pc
+            return "JUMP"
+        return "NORMAL"
+
+    def _exec_do_inline(self, stmt, after_pc):
+        """Run an inline DO...LOOP (body is a nested statement list).
+
+        Returns "NORMAL" when the loop completes, or propagates a clause
+        result (JUMP/END/STOP/ERROR/INPUT_WAIT) out of the whole loop.
+        """
+        while True:
+            # Top condition (DO WHILE / DO UNTIL): exit before entering body.
+            if stmt.do_cond is not None:
+                truthy = self._truthy(self.eval_expr(stmt.do_cond))
+                if truthy if stmt.do_until else not truthy:
+                    return "NORMAL"
+            # Run the body once. _DoExit (from EXIT DO) stops the loop.
+            self._inline_do_depth += 1
+            try:
+                result = self._run_statement_list(stmt.body, after_pc=after_pc)
+            except _DoExit:
+                return "NORMAL"
+            finally:
+                self._inline_do_depth -= 1
+            if result in ("JUMP", "END", "STOP", "ERROR", "INPUT_WAIT"):
+                return result
+            # Bottom condition (LOOP WHILE / LOOP UNTIL).
+            if stmt.loop_cond is not None:
+                truthy = self._truthy(self.eval_expr(stmt.loop_cond))
+                if stmt.loop_until:
+                    if truthy:
+                        return "NORMAL"
+                else:
+                    if not truthy:
+                        return "NORMAL"
+            # Otherwise loop again (checks the top condition again too).
+            if stmt.do_cond is None and stmt.loop_cond is None:
+                # DO...LOOP with no condition: keep looping until EXIT DO.
+                continue
+
+    def _make_for_frame(self, stmt):
+        """Evaluate a FOR header and return its loop frame."""
+        var = stmt.variable
+        start = self.eval_expr(stmt.start)
+        end = self.eval_expr(stmt.end)
+        step = self.eval_expr(stmt.step)
+        self._assign_var(var, start)
+        return {
+            "var": var.name,
+            "limit": end,
+            "step": step,
+        }
+
+    def _exec_next_inline(self, stmt, local_for):
+        """Step an inline (clause) FOR loop; True = loop again, False = done."""
+        if not local_for:
+            return False
+        frame = local_for[-1]
+        varname = frame["var"]
+        if stmt.variables and stmt.variables[0].name != varname:
+            raise RuntimeError_("NEXT without FOR", 1, stmt.line_num)
+        var_node = nodes.VariableNode(varname)
+        cur = self.runtime.get_variable(var_node)
+        step = frame["step"]
+        limit = frame["limit"]
+        newval = cur + step
+        self.runtime.set_variable(var_node, newval)
+        return (step >= 0 and newval <= limit) or (step < 0 and newval >= limit)
+
+    def _handle_error(self, e, line_num):
+        if isinstance(e, RuntimeError_):
+            code = e.code
+            message = e.message
+        else:
+            code = 5
+            message = str(e)
+        self.runtime.last_error_code = code
+        self.runtime.last_error_line = line_num
+
+        handler = self.runtime.error_handler
+        if handler is not None and not self.runtime.error_active:
+            if handler == "IGNORE":
+                # Continue with the statement after the one that failed.
+                self.runtime.pc += 1
+                return "NORMAL"
+            if handler == "IGNORE1":
+                # Skip the rest of the offending line.
+                self._skip_line()
+                return "NORMAL"
+            idx = self.runtime.resolve_line(handler)
+            if idx is not None:
+                self.runtime.error_active = True
+                self._resume_index = self.runtime.pc
+                self.runtime.pc = idx
+                return "NORMAL"
+        self.runtime.running = False
+        self._fatal = RuntimeError_(message, code, line_num)
+        return "ERROR"
+
+    def _skip_line(self):
+        """Advance pc past the remainder of the current source line."""
+        if self.runtime.pc >= len(self.runtime.statements):
+            return
+        ln = self.runtime.line_for_index(self.runtime.pc)
+        while self.runtime.pc < len(self.runtime.statements) and \
+                self.runtime.line_for_index(self.runtime.pc) == ln:
+            self.runtime.pc += 1
+
+    def _fatal_state(self):
+        e = self._fatal
+        return InterpreterState("error", e.message, e.line, e.code)
+
+    def _state(self, status, message="", line=0):
+        if status == "error":
+            return self._fatal_state()
+        return InterpreterState(status, message, line)
+
+
+    def feed_char(self, ch):
+        """Feed one character from a button press."""
+        if ch == "\n":
+            if self._pending == "input":
+                self._input_ready = True
+                if self.console is not None:
+                    self.console.newline()
+            else:
+                if len(self._key_buffer) < 32:
+                    self._key_buffer.append("\n")
+            return
+        if ch == "\b":
+            if self._pending == "input" and self._input_line:
+                self._input_line = self._input_line[:-1]
+                if self.console is not None:
+                    self.console.backspace()
+            return
+        if self._pending == "input":
+            self._input_line += ch
+            if self.console is not None:
+                self.console.echo(ch)
+        else:
+            if len(self._key_buffer) < 32:
+                self._key_buffer.append(ch)
+
+    def is_input_pending(self):
+        return self._pending is not None
+
+    def current_input_line(self):
+        return self._input_line
+
+    # INKEY$ / INPUT$ read keys through these (the builtins' io provider).
+    def read_key(self):
+        if self._key_buffer:
+            return self._key_buffer.pop(0)
+        return ""
+
+    def key_input(self, n):
+        if len(self._key_buffer) >= n:
+            chars = self._key_buffer[:n]
+            del self._key_buffer[:n]
+            return "".join(chars)
+        raise KeyInputPending(n - len(self._key_buffer))
+
+    def _finish_input(self):
+        line = self._input_line
+        self._input_line = ""
+        self._input_ready = False
+        try:
+            self._assign_input_line(line)
+            self._pending = None
+            self.runtime.pc += 1  # skip the INPUT statement
+        except _InputValueError:
+            # MBASIC: "?Redo from start" and re-prompt.
+            self._input_line = ""
+            if self.console is not None:
+                self.console.output("?Redo from start")
+                self.console.output("? ")
+
+    def _assign_input_line(self, line):
+        # LINE INPUT: whole line to a single string variable.
+        if self._input_line_mode:
+            self.runtime.set_variable(self._input_vars[0], line)
+            return
+        # INPUT: comma-separated values.
+        if line.strip() == "":
+            return  # keep old values
+        tokens = line.split(",")
+        idx = 0
+        for var in self._input_vars:
+            if idx >= len(tokens):
+                tok = None
+            else:
+                tok = tokens[idx].strip()
+                idx += 1
+            suffix = self._var_suffix(var)
+            if suffix == "$":
+                if tok is None:
+                    continue  # keep old
+                self.runtime.set_variable(var, tok)
+            else:
+                if tok is None or tok == "":
+                    continue  # keep old
+                try:
+                    value = self._parse_number(tok)
+                except ValueError:
+                    raise _InputValueError()
+                self.runtime.set_variable(var, value)
+
+    def _var_suffix(self, var):
+        name = var.name
+        if name and name[-1] in "$%!#":
+            return name[-1]
+        return self.runtime._resolve_type(name)
+
+    @staticmethod
+    def _parse_number(text):
+        text = text.strip()
+        if not text:
+            return 0
+        i = 0
+        n = len(text)
+        if text[0] in "+-":
+            i = 1
+        while i < n and (text[i].isdigit() or text[i] in ".eEdD"):
+            i += 1
+        token = text[:i]
+        if not token or token in ("+", "-", "."):
+            raise ValueError()
+        if "D" in token or "d" in token:
+            token = token.replace("D", "E").replace("d", "e")
+        return float(token) if any(c in token for c in ".eE") else int(token)
+
+
+    def _exec_statement(self, stmt):
+        name = type(stmt).__name__
+        handler = _STATEMENT_HANDLERS.get(name)
+        if handler is None:
+            raise RuntimeError_("Unsupported statement %s" % name, 5, stmt.line_num)
+        return handler(self, stmt)
+
+
+    def _print_output(self, expressions, separators):
+        out = ""
+        for i, expr in enumerate(expressions):
+            value = self.eval_expr(expr)
+            if isinstance(value, TabMarker):
+                cur = len(out) + 1
+                if cur < value.column:
+                    out += " " * (value.column - cur)
+            elif isinstance(value, SpcMarker):
+                out += " " * value.count
+            elif isinstance(value, (int, float)) and not isinstance(value, bool):
+                out += format_for_print(value, self._numeric_digits(expr))
+            else:
+                out += str(value)
+            if i < len(separators):
+                sep = separators[i]
+                if sep == ",":
+                    cur = len(out)
+                    nz = ((cur // 14) + 1) * 14
+                    out += " " * (nz - cur)
+                elif sep == ";":
+                    pass
+                elif sep == "\n":
+                    out += "\n"
+        return out
+
+    def _numeric_digits(self, expr):
+        if isinstance(expr, nodes.NumberNode):
+            if expr.suffix == "%":
+                return INTEGER_DIGITS
+            if expr.suffix == "#":
+                return DOUBLE_DIGITS
+        return SINGLE_DIGITS
+
+    def execute_print(self, stmt):
+        if stmt.file_number is not None:
+            self._print_to_file(stmt)
+            return "NORMAL"
+        if stmt.position is not None and self.console is not None:
+            col_expr, row_expr, size_expr = stmt.position
+            col = int(self.eval_expr(col_expr))
+            row = int(self.eval_expr(row_expr))
+            size = None
+            if size_expr is not None:
+                size = int(self.eval_expr(size_expr))
+            self.console.goto(col, row, size)
+        out = self._print_output(stmt.expressions, stmt.separators)
+        if self.console is not None:
+            self.console.output(out)
+        return "NORMAL"
+
+    def execute_printusing(self, stmt):
+        fmt = str(self.eval_expr(stmt.format_string))
+        values = [self.eval_expr(e) for e in stmt.expressions]
+        if not fmt:
+            raise RuntimeError_("Illegal function call", 5, stmt.line_num)
+        from .builtins import UsingFormatter
+        formatter = UsingFormatter(fmt)
+        output = formatter.format_values(values)
+        if self.console is not None:
+            self.console.output(output)
+        return "NORMAL"
+
+    def execute_lprint(self, stmt):
+        out = self._print_output(stmt.expressions, stmt.separators)
+        if self.console is not None:
+            self.console.output(out)
+        return "NORMAL"
+
+    def execute_write(self, stmt):
+        if stmt.file_number is not None:
+            file_num = int(self.eval_expr(stmt.file_number))
+            f = self.runtime.files.get(file_num)
+            if f is None:
+                raise RuntimeError_("File not open", 54, stmt.line_num)
+            parts = []
+            for expr in stmt.expressions:
+                value = self.eval_expr(expr)
+                parts.append('"%s"' % value if isinstance(value, str)
+                             else str(value))
+            f["text"] += ",".join(parts) + "\n"
+            return "NORMAL"
+        parts = []
+        for expr in stmt.expressions:
+            value = self.eval_expr(expr)
+            if isinstance(value, str):
+                parts.append('"%s"' % value)
+            else:
+                parts.append(str(value))
+        out = ",".join(parts)
+        if self.console is not None:
+            self.console.output(out)
+        return "NORMAL"
+
+
+    def execute_input(self, stmt):
+        if stmt.file_number is not None:
+            self._input_from_file(stmt)
+            return "NORMAL"
+        prompt = ""
+        if stmt.prompt is not None:
+            prompt = str(self.eval_expr(stmt.prompt))
+        if self.console is not None:
+            self.console.output(prompt + "? ")
+        if self._in_function_call:
+            # INPUT inside a FUNCTION can't suspend in the cooperative model;
+            # complete it immediately with an empty line (best effort).
+            self._input_vars = list(stmt.variables)
+            self._input_line_mode = False
+            self._assign_input_line("")
+            return "NORMAL"
+        self._pending = "input"
+        self._input_vars = list(stmt.variables)
+        self._input_line_mode = False
+        self._input_line = ""
+        self._input_ready = False
+        return "INPUT_WAIT"
+
+    def execute_line_input(self, stmt):
+        if stmt.file_number is not None:
+            self._input_line_from_file(stmt)
+            return "NORMAL"
+        prompt = ""
+        if stmt.prompt is not None:
+            prompt = str(self.eval_expr(stmt.prompt))
+        if self.console is not None:
+            self.console.output(prompt)
+        if self._in_function_call:
+            self._input_vars = [stmt.variable]
+            self._input_line_mode = True
+            self._assign_input_line("")
+            return "NORMAL"
+        self._pending = "input"
+        self._input_vars = [stmt.variable]
+        self._input_line_mode = True
+        self._input_line = ""
+        self._input_ready = False
+        return "INPUT_WAIT"
+
+
+    def execute_let(self, stmt):
+        value = self.eval_expr(stmt.expression)
+        self._assign_var(stmt.variable, value)
+        return "NORMAL"
+
+    def execute_chained_assignment(self, stmt):
+        value = self.eval_expr(stmt.expression)
+        for var in stmt.variables:
+            self._assign_var(var, value)
+        return "NORMAL"
+
+    def execute_mid_assignment(self, stmt):
+        s = str(self.runtime.get_variable(stmt.target))
+        start = int(self.eval_expr(stmt.start))
+        repl = str(self.eval_expr(stmt.expression))
+        length = None
+        if stmt.length is not None:
+            length = int(self.eval_expr(stmt.length))
+        if length is None:
+            length = len(repl)
+        if start < 1:
+            start = 1
+        chars = list(s)
+        for k in range(length):
+            idx = start - 1 + k
+            if 0 <= idx < len(chars) and k < len(repl):
+                chars[idx] = repl[k]
+        self.runtime.set_variable(stmt.target, "".join(chars))
+        return "NORMAL"
+
+    def execute_swap(self, stmt):
+        v1 = self._read_var(stmt.variable1)
+        v2 = self._read_var(stmt.variable2)
+        self._assign_var(stmt.variable1, v2)
+        self._assign_var(stmt.variable2, v1)
+        return "NORMAL"
+
+
+    def execute_goto(self, stmt):
+        target = self.eval_expr(stmt.target)
+        idx = self.runtime.resolve_target(target)
+        if idx is None:
+            raise RuntimeError_("Undefined line number or label", 8, stmt.line_num)
+        self.runtime.pc = idx
+        return "JUMP"
+
+    def execute_gosub(self, stmt):
+        target = self.eval_expr(stmt.target)
+        idx = self.runtime.resolve_target(target)
+        if idx is None:
+            raise RuntimeError_("Undefined line number or label", 8, stmt.line_num)
+        self.runtime.push_gosub(self.runtime.pc + 1)
+        self.runtime.pc = idx
+        return "JUMP"
+
+    def execute_return(self, stmt):
+        frame = self.runtime.pop_gosub()
+        if isinstance(frame, tuple):
+            _, stmts, i, after_pc = frame
+            self._continuations.append((stmts, i, after_pc))
+            return "JUMP"
+        self.runtime.pc = frame
+        return "JUMP"
+
+    def execute_if(self, stmt):
+        cond = self.eval_expr(stmt.condition)
+        after_pc = self.runtime.pc + 1
+        if self._truthy(cond):
+            if stmt.then_line is not None:
+                return self._goto_line(stmt.then_line)
+            if stmt.then_statements:
+                return self._run_statement_list(stmt.then_statements,
+                                                after_pc=after_pc)
+            return "NORMAL"
+        if stmt.else_line is not None:
+            return self._goto_line(stmt.else_line)
+        if stmt.else_statements:
+            return self._run_statement_list(stmt.else_statements,
+                                            after_pc=after_pc)
+        return "NORMAL"
+
+    def _goto_line(self, target):
+        # `target` may be a raw line number (int, from `IF x THEN 100`) or an
+        # expression/label node (from `GOTO`/`ON GOTO`/`THEN GOTO`).
+        if isinstance(target, nodes._Node):
+            target = self.eval_expr(target)
+        idx = self.runtime.resolve_target(target)
+        if idx is None:
+            raise RuntimeError_("Undefined line number or label", 8, 0)
+        self.runtime.pc = idx
+        return "JUMP"
+
+    def execute_on_goto(self, stmt):
+        n = int(self.eval_expr(stmt.expression))
+        if n < 1 or n > len(stmt.targets):
+            return "NORMAL"
+        return self._goto_line(stmt.targets[n - 1])
+
+    def execute_on_gosub(self, stmt):
+        n = int(self.eval_expr(stmt.expression))
+        if n < 1 or n > len(stmt.targets):
+            return "NORMAL"
+        target = self.eval_expr(stmt.targets[n - 1])
+        idx = self.runtime.resolve_target(target)
+        if idx is None:
+            raise RuntimeError_("Undefined line number or label", 8, stmt.line_num)
+        self.runtime.push_gosub(self.runtime.pc + 1)
+        self.runtime.pc = idx
+        return "JUMP"
+
+    def execute_for(self, stmt):
+        frame = self._make_for_frame(stmt)
+        frame["body_pc"] = self.runtime.pc + 1
+        var = frame["var"]
+        start_val = self.runtime.get_variable(nodes.VariableNode(var))
+        step = frame["step"]
+        limit = frame["limit"]
+        # MMBasic: a FOR whose start is already past the limit runs zero times.
+        if (step >= 0 and start_val > limit) or (step < 0 and start_val < limit):
+            self.runtime.pc = self._skip_for_after(self.runtime.pc)
+            return "JUMP"
+        self.runtime._for_stack.append(frame)
+        return "NORMAL"
+
+    def execute_next(self, stmt):
+        if not self.runtime._for_stack:
+            raise RuntimeError_("NEXT without FOR", 1, stmt.line_num)
+        frame = self.runtime._for_stack[-1]
+        varname = frame["var"]
+        if stmt.variables and stmt.variables[0].name != varname:
+            raise RuntimeError_("NEXT without FOR", 1, stmt.line_num)
+        var_node = nodes.VariableNode(varname)
+        cur = self.runtime.get_variable(var_node)
+        step = frame["step"]
+        limit = frame["limit"]
+        newval = cur + step
+        self.runtime.set_variable(var_node, newval)
+        if (step >= 0 and newval <= limit) or (step < 0 and newval >= limit):
+            self.runtime.pc = frame["body_pc"]
+            return "JUMP"
+        self.runtime._for_stack.pop()
+        return "NORMAL"
+
+    def execute_while(self, stmt):
+        cond = self.eval_expr(stmt.condition)
+        if self._truthy(cond):
+            self.runtime._while_stack.append(self.runtime.pc)
+            return "NORMAL"
+        self._skip_to_wend()
+        return "JUMP"
+
+    def execute_wend(self, stmt):
+        if not self.runtime._while_stack:
+            raise RuntimeError_("WEND without WHILE", 1, stmt.line_num)
+        while_pc = self.runtime._while_stack.pop()
+        self.runtime.pc = while_pc
+        return "JUMP"
+
+    def _skip_to_wend(self):
+        depth = 1
+        i = self.runtime.pc + 1
+        while i < len(self.runtime.statements):
+            s = self.runtime.statements[i][1]
+            tn = type(s).__name__
+            if tn == "WhileStatementNode":
+                depth += 1
+            elif tn == "WendStatementNode":
+                depth -= 1
+                if depth == 0:
+                    self.runtime.pc = i + 1
+                    return
+            i += 1
+        raise RuntimeError_("WEND without WHILE", 1, 0)
+
+    def execute_end(self, stmt):
+        return "END"
+
+    def execute_stop(self, stmt):
+        return "STOP"
+
+    def execute_tron(self, stmt):
+        self.runtime.tron = True
+        return "NORMAL"
+
+    def execute_troff(self, stmt):
+        self.runtime.tron = False
+        return "NORMAL"
+
+
+    def execute_sub(self, stmt):
+        """A SUB definition encountered in normal flow: skip past its body."""
+        sub = self.runtime.sub_defs.get(stmt.name)
+        if sub is not None:
+            self.runtime.pc = sub["end"] + 1
+            return "JUMP"
+        return "NORMAL"
+
+    def execute_sub_call(self, stmt):
+        if stmt.name == "settick":
+            return self.execute_settick(stmt)
+        sub = self.runtime.sub_defs.get(stmt.name)
+        if sub is None:
+            raise RuntimeError_("Undefined SUB '%s'" % stmt.name, 18,
+                                stmt.line_num)
+        args = [self.eval_expr(a) for a in stmt.args]
+        params = sub["params"]
+        if len(args) != len(params):
+            raise RuntimeError_("Wrong number of arguments to '%s'" % stmt.name,
+                                5, stmt.line_num)
+        saved = {}
+        for p in params:
+            saved[p.name] = self.runtime._variables.get(p.name, _UNBOUND)
+        for p, a in zip(params, args):
+            self.runtime.set_variable(p, a)
+        frame = {"return_index": self.runtime.pc + 1, "saved": saved}
+        self.runtime.sub_stack.append(frame)
+        self.runtime.pc = sub["start"] + 1
+        return "JUMP"
+
+    def execute_settick(self, stmt):
+        """Configure `SETTICK period_ms, callback [, slot]`."""
+        if len(stmt.args) < 2 or len(stmt.args) > 3:
+            raise RuntimeError_("Wrong number of arguments to 'settick'", 5,
+                                stmt.line_num)
+        period = int(self.eval_expr(stmt.args[0]))
+        callback_node = stmt.args[1]
+        callback = getattr(callback_node, "name", "")
+        if not callback:
+            callback = str(self.eval_expr(callback_node)).lower()
+        slot = int(self.eval_expr(stmt.args[2])) if len(stmt.args) == 3 else 1
+
+        if period <= 0:
+            self._tick_timers.pop(slot, None)
+            return "NORMAL"
+        if callback not in self.runtime.sub_defs:
+            raise RuntimeError_("Undefined SUB '%s'" % callback, 18,
+                                stmt.line_num)
+        now = self._now_ms()
+        self._tick_timers[slot] = {
+            "period": period,
+            "callback": callback,
+            "due": self._ticks_add(now, period),
+        }
+        return "NORMAL"
+
+    def _dispatch_tick_timer(self):
+        if self.runtime.sub_stack or self._continuations or not self._tick_timers:
+            return False
+        now = self._now_ms()
+        for slot in sorted(self._tick_timers):
+            timer = self._tick_timers.get(slot)
+            if timer is None or self._ticks_diff(now, timer["due"]) < 0:
+                continue
+            sub = self.runtime.sub_defs.get(timer["callback"])
+            if sub is None:
+                self._tick_timers.pop(slot, None)
+                continue
+            timer["due"] = self._ticks_add(now, timer["period"])
+            self.runtime.sub_stack.append({
+                "return_index": self.runtime.pc,
+                "saved": {},
+                "tick_slot": slot,
+            })
+            self.runtime.pc = sub["start"] + 1
+            return True
+        return False
+
+    @staticmethod
+    def _now_ms():
+        import time
+
+        ticks_ms = getattr(time, "ticks_ms", None)
+        if ticks_ms is not None:
+            return ticks_ms()
+        monotonic = getattr(time, "monotonic", None)
+        if monotonic is not None:
+            return int(monotonic() * 1000)
+        return int(time.time() * 1000)
+
+    @staticmethod
+    def _ticks_add(value, delta):
+        import time
+
+        ticks_add = getattr(time, "ticks_add", None)
+        return ticks_add(value, delta) if ticks_add is not None else value + delta
+
+    @staticmethod
+    def _ticks_diff(value, reference):
+        import time
+
+        ticks_diff = getattr(time, "ticks_diff", None)
+        if ticks_diff is not None:
+            return ticks_diff(value, reference)
+        return value - reference
+
+    def _restore_sub_frame(self, frame):
+        for name, saved in frame["saved"].items():
+            if saved is _UNBOUND:
+                self.runtime._variables.pop(name, None)
+            else:
+                self.runtime._variables[name] = saved
+
+    def execute_endsub(self, stmt):
+        if self.runtime.sub_stack:
+            frame = self.runtime.sub_stack.pop()
+            self._restore_sub_frame(frame)
+            self.runtime.pc = frame["return_index"]
+            return "JUMP"
+        return "NORMAL"
+
+    def execute_exit_sub(self, stmt):
+        if self.runtime.sub_stack:
+            frame = self.runtime.sub_stack.pop()
+            self._restore_sub_frame(frame)
+            self.runtime.pc = frame["return_index"]
+            return "JUMP"
+        raise RuntimeError_("EXIT SUB outside a SUB", 5, stmt.line_num)
+
+    def execute_local(self, stmt):
+        if self.runtime.sub_stack:
+            frame = self.runtime.sub_stack[-1]
+            for idx, name in enumerate(stmt.names):
+                if name not in frame["saved"]:
+                    frame["saved"][name] = self.runtime._variables.get(
+                        name, _UNBOUND)
+                init = stmt.inits[idx] if idx < len(stmt.inits) else None
+                if init is not None:
+                    self.runtime.set_variable(nodes.VariableNode(name),
+                                              self.eval_expr(init))
+        return "NORMAL"
+
+
+    def execute_function(self, stmt):
+        """A FUNCTION definition in normal flow: skip past its body."""
+        fn = self.runtime.function_defs.get(stmt.name)
+        if fn is not None:
+            self.runtime.pc = fn["end"] + 1
+            return "JUMP"
+        return "NORMAL"
+
+    def _call_function(self, name, args):
+        fn = self.runtime.function_defs.get(name)
+        if fn is None:
+            raise RuntimeError_("Undefined FUNCTION '%s'" % name, 18, 0)
+        params = fn["params"]
+        if len(args) != len(params):
+            raise RuntimeError_("Wrong number of arguments to '%s'" % name,
+                                5, 0)
+        # Declared return type (e.g. `FUNCTION F$() AS STRING`): make the
+        # function-name variable string-typed so `F$ = "..."` works inside.
+        ret_type = fn.get("return_type")
+        if ret_type in ("string", "str"):
+            self.runtime.var_types[name] = "string"
+        saved_pc = self.runtime.pc
+        saved_fn = getattr(self.runtime, "_current_function", None)
+        saved = {}
+        for p in params:
+            saved[p.name] = self.runtime._variables.get(p.name, _UNBOUND)
+        for p, a in zip(params, args):
+            self.runtime.set_variable(p, a)
+        saved[name] = self.runtime._variables.get(name, _UNBOUND)
+        self.runtime._variables.pop(name, None)
+        self.runtime._current_function = name
+        self.runtime.pc = fn["start"] + 1
+        value = 0
+        self._in_function_call += 1
+        try:
+            for _ in range(500000):
+                if self.runtime.pc >= len(self.runtime.statements):
+                    break
+                try:
+                    result = self._step()
+                except _FunctionReturn as fr:
+                    value = fr.value
+                    break
+                if result in ("END", "ERROR", "INPUT_WAIT"):
+                    break
+            else:
+                value = self.runtime._variables.get(name, 0)
+        finally:
+            self._in_function_call -= 1
+            for p in params:
+                if saved[p.name] is _UNBOUND:
+                    self.runtime._variables.pop(p.name, None)
+                else:
+                    self.runtime._variables[p.name] = saved[p.name]
+            if saved[name] is _UNBOUND:
+                self.runtime._variables.pop(name, None)
+            else:
+                self.runtime._variables[name] = saved[name]
+            self.runtime._current_function = saved_fn
+            self.runtime.pc = saved_pc
+        return value
+
+    def execute_end_function(self, stmt):
+        raise _FunctionReturn(self.runtime._variables.get(stmt.name, 0))
+
+    def execute_exit_function(self, stmt):
+        name = getattr(self.runtime, "_current_function", None)
+        if name is None:
+            raise RuntimeError_("EXIT FUNCTION outside a FUNCTION", 5,
+                                stmt.line_num)
+        raise _FunctionReturn(self.runtime._variables.get(name, 0))
+
+
+    def execute_do(self, stmt):
+        if stmt.condition is not None:
+            val = self.eval_expr(stmt.condition)
+            truthy = self._truthy(val)
+            skip = truthy if stmt.until else not truthy
+            if skip:
+                self.runtime.pc = self._loop_after(self.runtime.pc)
+                return "JUMP"
+        return "NORMAL"
+
+    def _loop_after(self, do_idx):
+        loop_idx = self.runtime.do_loop_map.get(do_idx)
+        if loop_idx is None:
+            return do_idx + 1
+        return loop_idx + 1
+
+    def execute_loop(self, stmt):
+        do_idx = self.runtime.do_loop_map.get(self.runtime.pc)
+        if do_idx is None:
+            raise RuntimeError_("LOOP without DO", 1, stmt.line_num)
+        if stmt.condition is not None:
+            val = self.eval_expr(stmt.condition)
+            truthy = self._truthy(val)
+            continue_loop = (not truthy) if stmt.until else truthy
+            if not continue_loop:
+                return "NORMAL"
+        self.runtime.pc = do_idx
+        return "JUMP"
+
+    def execute_exit_do(self, stmt):
+        pc = self.runtime.pc
+        best = None
+        for do_i, loop_i in self.runtime.do_loop_map.items():
+            if do_i < loop_i and do_i < pc < loop_i:
+                if best is None or do_i > best[0]:
+                    best = (do_i, loop_i)
+        if best is not None:
+            self.runtime.pc = best[1] + 1
+            return "JUMP"
+        return "NORMAL"
+
+    def execute_exit_for(self, stmt):
+        if not self.runtime._for_stack:
+            return "NORMAL"
+        frame = self.runtime._for_stack.pop()
+        self.runtime.pc = self._skip_for_after(frame["body_pc"] - 1)
+        return "JUMP"
+
+    def _skip_for_after(self, for_idx):
+        """Jump to the statement after the NEXT that closes this FOR."""
+        depth = 1
+        i = for_idx + 1
+        statements = self.runtime.statements
+        while i < len(statements):
+            tn = type(statements[i][1]).__name__
+            if tn == "ForStatementNode":
+                depth += 1
+            elif tn == "NextStatementNode":
+                depth -= 1
+                if depth == 0:
+                    return i + 1
+            i += 1
+        return len(statements)
+
+
+    def execute_select(self, stmt):
+        expr_val = self.eval_expr(stmt.expression)
+        matched = None
+        for case in stmt.cases:
+            if case.is_else:
+                matched = case
+                break
+            for v in case.values:
+                if self._case_eq(expr_val, self.eval_expr(v)):
+                    matched = case
+                    break
+            if matched is not None:
+                break
+            for lo, hi in case.ranges:
+                try:
+                    if float(self.eval_expr(lo)) <= float(expr_val) <= float(self.eval_expr(hi)):
+                        matched = case
+                        break
+                except (TypeError, ValueError):
+                    pass
+            if matched is not None:
+                break
+        if matched is None:
+            return "NORMAL"
+        if matched.statements:
+            return self._run_statement_list(matched.statements,
+                                            after_pc=self.runtime.pc + 1)
+        return "NORMAL"
+
+    @staticmethod
+    def _case_eq(a, b):
+        if isinstance(a, str) or isinstance(b, str):
+            return str(a) == str(b)
+        try:
+            return float(a) == float(b)
+        except (TypeError, ValueError):
+            return a == b
+
+    def execute_block_if(self, stmt):
+        after_pc = self.runtime.pc + 1
+        for cond, body in stmt.branches:
+            if cond is None or self._truthy(self.eval_expr(cond)):
+                if body:
+                    return self._run_statement_list(body, after_pc=after_pc)
+                return "NORMAL"
+        return "NORMAL"
+
+    def execute_const(self, stmt):
+        for name, expr in stmt.entries:
+            self.runtime.set_constant(name, self.eval_expr(expr))
+        return "NORMAL"
+
+    def execute_option(self, stmt):
+        if stmt.kind == "base":
+            if stmt.value not in (0, 1):
+                raise RuntimeError_("Illegal function call", 5, stmt.line_num)
+            self.runtime.array_base = stmt.value
+        elif stmt.kind == "default":
+            self.runtime.default_type = stmt.value
+        elif stmt.kind == "angle":
+            self.runtime.angle_mode = stmt.value
+        elif stmt.kind == "explicit":
+            self.runtime.explicit = True
+        return "NORMAL"
+
+    def execute_label(self, stmt):
+        return "NORMAL"
+
+    def execute_end_if(self, stmt):
+        return "NORMAL"
+
+    def execute_end_select(self, stmt):
+        return "NORMAL"
+
+
+    def execute_pixel(self, stmt):
+        x = self.eval_expr(stmt.x)
+        y = self.eval_expr(stmt.y)
+        color = self.eval_expr(stmt.color) if stmt.color is not None else None
+        self.gfx.pixel(x, y, color)
+        return "NORMAL"
+
+    def execute_line(self, stmt):
+        x1 = self.eval_expr(stmt.x1)
+        y1 = self.eval_expr(stmt.y1)
+        x2 = self.eval_expr(stmt.x2)
+        y2 = self.eval_expr(stmt.y2)
+        thickness = self.eval_expr(stmt.thickness) if stmt.thickness else None
+        color = self.eval_expr(stmt.color) if stmt.color is not None else None
+        self.gfx.line(x1, y1, x2, y2, thickness, color)
+        return "NORMAL"
+
+    def execute_box(self, stmt):
+        x = self.eval_expr(stmt.x)
+        y = self.eval_expr(stmt.y)
+        w = self.eval_expr(stmt.w)
+        h = self.eval_expr(stmt.h)
+        thickness = self.eval_expr(stmt.thickness) if stmt.thickness else None
+        outline = self.eval_expr(stmt.outline) if stmt.outline is not None else None
+        fill = self.eval_expr(stmt.fill) if stmt.fill is not None else None
+        self.gfx.box(x, y, w, h, thickness, outline, fill)
+        return "NORMAL"
+
+    def _eval_args(self, args):
+        """Evaluate a list of arg expressions, preserving None (empty
+        comma-slots in Maximite graphics calls)."""
+        out = []
+        for a in args:
+            out.append(None if a is None else self.eval_expr(a))
+        return out
+
+    def execute_circle(self, stmt):
+        x = self.eval_expr(stmt.x)
+        y = self.eval_expr(stmt.y)
+        r = self.eval_expr(stmt.r)
+        args = self._eval_args(stmt.args)
+        self.gfx.circle(x, y, r, *args)
+        return "NORMAL"
+
+    def execute_polygon(self, stmt):
+        xs = self.eval_expr(stmt.xs)
+        ys = self.eval_expr(stmt.ys)
+        outline = self.eval_expr(stmt.outline) if stmt.outline is not None else None
+        fill = self.eval_expr(stmt.fill) if stmt.fill is not None else None
+        self.gfx.polygon(xs, ys, outline, fill)
+        return "NORMAL"
+
+    def execute_color(self, stmt):
+        bg = None
+        if stmt.background is not None:
+            bg = self.eval_expr(stmt.background)
+        self.gfx.color(self.eval_expr(stmt.color), bg)
+        return "NORMAL"
+
+    def execute_text(self, stmt):
+        x = self.eval_expr(stmt.x)
+        y = self.eval_expr(stmt.y)
+        text = str(self.eval_expr(stmt.text))
+        self.gfx.text(x, y, text)
+        return "NORMAL"
+
+    def execute_framebuffer(self, stmt):
+        args = self._eval_args(stmt.args)
+        self.gfx.framebuffer(stmt.sub, args)
+        return "NORMAL"
+
+    def execute_turtle(self, stmt):
+        args = self._eval_args(stmt.args)
+        self.gfx.turtle(stmt.sub, args)
+        return "NORMAL"
+
+    def execute_save_image(self, stmt):
+        self.gfx.save_image(str(self.eval_expr(stmt.filename)))
+        return "NORMAL"
+
+    def execute_layer(self, stmt):
+        return "NORMAL"
+
+
+    def execute_dim(self, stmt):
+        for decl in stmt.declarations:
+            type_name = decl.type_name
+            if decl.dims:
+                dims = [self.eval_expr(d) for d in decl.dims]
+                self.runtime.dim_array(decl.name, dims, stmt.line_num, type_name)
+                if decl.init_list is not None:
+                    base = self.runtime.array_base
+                    for k, val_expr in enumerate(decl.init_list):
+                        self.runtime.set_array(decl.name, [base + k],
+                                               self.eval_expr(val_expr))
+            else:
+                if type_name:
+                    self.runtime.declare_scalar(decl.name, type_name)
+                node = nodes.VariableNode(decl.name)
+                if decl.init is not None:
+                    self.runtime.set_variable(node, self.eval_expr(decl.init))
+                elif type_name:
+                    self.runtime.set_variable(
+                        node, "" if type_name == "string" else 0)
+        return "NORMAL"
+
+    def execute_erase(self, stmt):
+        for var in stmt.variables:
+            self.runtime.erase_array(var.name)
+        return "NORMAL"
+
+    def execute_def_type(self, stmt):
+        for lo, hi in stmt.letters:
+            for ch in range(ord(lo), ord(hi) + 1):
+                letter = chr(ch)
+                if letter.isalpha():
+                    self.runtime.def_type_map[letter.lower()] = stmt.type_name
+        return "NORMAL"
+
+    def execute_def_fn(self, stmt):
+        self.runtime.define_function(stmt.name, stmt.params, stmt.body)
+        return "NORMAL"
+
+    def execute_data(self, stmt):
+        return "NORMAL"  # collected at startup
+
+    def execute_read(self, stmt):
+        for var in stmt.variables:
+            value, _is_string = self.runtime.next_data()
+            self._assign_var(var, value)
+        return "NORMAL"
+
+    def execute_restore(self, stmt):
+        self.runtime.restore_data(stmt.target)
+        return "NORMAL"
+
+    def execute_clear(self, stmt):
+        self.runtime.clear_variables()
+        self.runtime._for_stack = []
+        self.runtime._while_stack = []
+        self.runtime._gosub_stack = []
+        self.runtime.def_functions = {}
+        return "NORMAL"
+
+    def execute_cls(self, stmt):
+        color = self.eval_expr(stmt.color) if stmt.color is not None else None
+        if self.gfx is not None:
+            self.gfx.cls(color)
+        if self.console is not None and hasattr(self.console, "clear"):
+            self.console.clear()
+        return "NORMAL"
+
+    def execute_font(self, stmt):
+        if stmt.size is not None:
+            size = int(self.eval_expr(stmt.size))
+            if self.gfx is not None:
+                self.gfx.set_font_size(size)
+        return "NORMAL"
+
+    def execute_center(self, stmt):
+        if self.console is None:
+            return "NORMAL"
+        text = ""
+        if stmt.text is not None:
+            text = str(self.eval_expr(stmt.text))
+        cols = getattr(self.console, "columns", 60)
+        pad = max((cols - len(text)) // 2, 0)
+        self.console.output(" " * pad + text + "\n")
+        return "NORMAL"
+
+    def execute_drive(self, stmt):
+        # Drive selection is a no-op on Picoware (single storage volume).
+        return "NORMAL"
+
+    def execute_common(self, stmt):
+        return "NORMAL"
+
+
+    def execute_error(self, stmt):
+        if stmt.code is None:
+            code = getattr(self.runtime, "last_error_code", 0) or 0
+        else:
+            code = int(self.eval_expr(stmt.code))
+        raise RuntimeError_("User error %d" % code, code, stmt.line_num)
+
+    def execute_on_error(self, stmt):
+        target = stmt.target
+        if target in ("IGNORE", "IGNORE1"):
+            self.runtime.error_handler = target
+            return "NORMAL"
+        if isinstance(target, nodes.NumberNode) and target.value == 0:
+            self.runtime.error_handler = None
+        else:
+            self.runtime.error_handler = int(self.eval_expr(target))
+        return "NORMAL"
+
+    def execute_resume(self, stmt):
+        self.runtime.error_active = False
+        if stmt.target is None:
+            if self._resume_index is not None:
+                self.runtime.pc = self._resume_index
+            else:
+                self.runtime.pc += 1
+            return "JUMP"
+        if stmt.target == "NEXT":
+            self.runtime.pc += 1
+            return "JUMP"
+        target = self.eval_expr(stmt.target)
+        idx = self.runtime.resolve_line(target)
+        if idx is None:
+            raise RuntimeError_("Undefined line number", 8, stmt.line_num)
+        self.runtime.pc = idx
+        return "JUMP"
+
+
+    def execute_randomize(self, stmt):
+        if stmt.seed is not None and \
+                not (isinstance(stmt.seed, nodes.VariableNode) and
+                     stmt.seed.name == "timer"):
+            seed = self.eval_expr(stmt.seed)
+        else:
+            # RANDOMIZE or RANDOMIZE TIMER: seed from the millisecond timer
+            try:
+                from time import ticks_ms
+                seed = ticks_ms()
+            except Exception:
+                seed = 1
+        self.runtime.rnd.randomize(seed)
+        return "NORMAL"
+
+    def execute_poke(self, stmt):
+        addr = int(self.eval_expr(stmt.address)) & 0xFFFF
+        value = int(self.eval_expr(stmt.value)) & 0xFF
+        self.runtime.memory[addr] = value
+        return "NORMAL"
+
+    def execute_out(self, stmt):
+        return "NORMAL"
+
+    def execute_wait(self, stmt):
+        return "NORMAL"
+
+    def execute_call(self, stmt):
+        raise RuntimeError_("CALL is not supported on Picoware", 5, stmt.line_num)
+
+    def execute_width(self, stmt):
+        return "NORMAL"
+
+    def execute_remark(self, stmt):
+        return "NORMAL"
+
+    def execute_unsupported(self, stmt):
+        raise RuntimeError_("Statement %s is not supported on Picoware"
+                            % stmt.statement_type, 5, stmt.line_num)
+
+    # Files (minimal in-memory sequential support)
+
+    def execute_open(self, stmt):
+        filename = str(self.eval_expr(stmt.filename))
+        file_num = int(self.eval_expr(stmt.file_number))
+        mode = (stmt.mode or "I").upper()[:1]
+        if mode not in ("I", "O", "A", "R"):
+            mode = "I"
+        if mode in ("O",):
+            self.runtime.file_store[filename] = ""   # truncate
+        text = self.runtime.file_store.get(filename, "")
+        self.runtime.files[file_num] = {
+            "mode": mode, "name": filename,
+            "text": text, "pos": 0, "eof": False,
+        }
+        return "NORMAL"
+
+    def execute_close(self, stmt):
+        def _close_one(fn):
+            f = self.runtime.files.pop(fn, None)
+            if f is not None:
+                self.runtime.file_store[f["name"]] = f["text"]
+        if not stmt.file_numbers:
+            for fn in list(self.runtime.files.keys()):
+                _close_one(fn)
+        else:
+            for expr in stmt.file_numbers:
+                _close_one(int(self.eval_expr(expr)))
+        return "NORMAL"
+
+    def execute_kill(self, stmt):
+        filename = str(self.eval_expr(stmt.filename))
+        self.runtime.file_store.pop(filename, None)
+        for fn in list(self.runtime.files.keys()):
+            if self.runtime.files[fn]["name"] == filename:
+                del self.runtime.files[fn]
+        return "NORMAL"
+
+    def execute_reset_file(self, stmt):
+        for f in self.runtime.files.values():
+            self.runtime.file_store[f["name"]] = f["text"]
+        self.runtime.files.clear()
+        return "NORMAL"
+
+    def _print_to_file(self, stmt):
+        file_num = int(self.eval_expr(stmt.file_number))
+        f = self.runtime.files.get(file_num)
+        if f is None:
+            raise RuntimeError_("File not open", 54, stmt.line_num)
+        if f["mode"] not in ("O", "A"):
+            raise RuntimeError_("File not open for output", 54, stmt.line_num)
+        out = self._print_output(stmt.expressions, stmt.separators)
+        f["text"] += out
+        if not stmt.separators or stmt.separators[-1] in (";", ","):
+            f["text"] += " "
+        else:
+            f["text"] += "\n"
+
+    def _input_from_file(self, stmt):
+        file_num = int(self.eval_expr(stmt.file_number))
+        f = self.runtime.files.get(file_num)
+        if f is None:
+            raise RuntimeError_("File not open", 54, stmt.line_num)
+        for var in stmt.variables:
+            value = self._file_read_value(f, var, stmt.line_num)
+            self.runtime.set_variable(var, value)
+
+    def _input_line_from_file(self, stmt):
+        file_num = int(self.eval_expr(stmt.file_number))
+        f = self.runtime.files.get(file_num)
+        if f is None:
+            raise RuntimeError_("File not open", 54, stmt.line_num)
+        rest = f["text"][f["pos"]:]
+        nl = rest.find("\n")
+        if nl < 0:
+            line = rest
+            f["pos"] = len(f["text"])
+        else:
+            line = rest[:nl]
+            f["pos"] += nl + 1
+        f["eof"] = f["pos"] >= len(f["text"]) and not f["text"][f["pos"]:]
+        self.runtime.set_variable(stmt.variable, line)
+
+    def _file_read_value(self, f, var, line_num):
+        rest = f["text"][f["pos"]:]
+        if rest == "":
+            raise RuntimeError_("Input past end of file", 62, line_num)
+        i = 0
+        n = len(rest)
+        while i < n and rest[i] in (" ", "\t", "\r", "\n"):
+            i += 1
+        if i >= n:
+            f["eof"] = True
+            raise RuntimeError_("Input past end of file", 62, line_num)
+        suffix = self._var_suffix(var)
+        if suffix == "$":
+            # string fields are comma-delimited; strip surrounding quotes
+            start = i
+            while i < n and rest[i] not in (",", "\r", "\n"):
+                i += 1
+            token = rest[start:i].strip()
+            if len(token) >= 2 and token[0] == '"' and token[-1] == '"':
+                token = token[1:-1]
+        else:
+            # numeric fields are whitespace- or comma-delimited
+            start = i
+            while i < n and rest[i] not in (",", "\r", "\n", " ", "\t"):
+                i += 1
+            token = rest[start:i].strip()
+        f["pos"] += i
+        if i < n and rest[i] == ",":
+            f["pos"] += 1
+        f["eof"] = f["text"][f["pos"]:].strip(" \t\r\n") == ""
+        if suffix == "$":
+            return token
+        try:
+            return self._parse_number(token)
+        except ValueError:
+            raise RuntimeError_("Type mismatch", 13, line_num)
+
+
+    # Variable access (evaluates array indices before touching the runtime)
+
+    def _read_var(self, node):
+        if node.indices:
+            # A parenthesised name that matches a FUNCTION is a function call.
+            if node.name.startswith("mm."):
+                # MMBasic system values (MM.Info(...), MM.HRES()...) are not
+                # fully supported on Picoware; return benign defaults so
+                # programs can load and run without hard-crashing.
+                if node.name[3:].startswith("info"):
+                    arg = node.indices[0] if node.indices else None
+                    argname = ""
+                    if isinstance(arg, nodes.VariableNode):
+                        argname = arg.name.lower()
+                    # MM.Info(DRIVE) is a string ("A:" / "B:").
+                    if argname in ("drive", "drives"):
+                        return "A:"
+                    # MM.Info(VERSION) is a string.
+                    if argname in ("version", "ver"):
+                        return "6.03"
+                    return 100  # MM.Info(BATTERY) reports 100%
+                if node.name[3:].startswith("hres"):
+                    return self.runtime.screen_w
+                if node.name[3:].startswith("vres"):
+                    return self.runtime.screen_h
+                return 0
+            if node.name in self.runtime.function_defs:
+                args = [self.eval_expr(d) for d in node.indices]
+                return self._call_function(node.name, args)
+            idx = [self.eval_expr(d) for d in node.indices]
+            return self.runtime.get_array(node.name, idx)
+        return self.runtime.get_variable(node)
+
+    def _assign_var(self, node, value):
+        if node.indices:
+            idx = [self.eval_expr(d) for d in node.indices]
+            self.runtime.set_array(node.name, idx, value)
+            return
+        self.runtime.set_variable(node, value)
+
+    def eval_expr(self, node):
+        if isinstance(node, nodes.NumberNode):
+            return node.value
+        if isinstance(node, nodes.StringNode):
+            return node.value
+        if isinstance(node, nodes.VariableNode):
+            return self._read_var(node)
+        if isinstance(node, nodes.ArrayRefNode):
+            return self.runtime.get_whole_array(node.name)
+        if isinstance(node, nodes.LabelRefNode):
+            return node.name
+        if isinstance(node, nodes.BinaryOpNode):
+            return self._eval_binary(node)
+        if isinstance(node, nodes.UnaryOpNode):
+            return self._eval_unary(node)
+        if isinstance(node, nodes.FunctionCallNode):
+            return self._eval_function(node)
+        raise RuntimeError_("Bad expression", 2, getattr(node, "line_num", 0))
+
+    def _eval_binary(self, node):
+        op = node.op
+        opu = op.upper() if isinstance(op, str) else op
+        left = self.eval_expr(node.left)
+        right = self.eval_expr(node.right)
+
+        if op in ("=", "<>", "><", "<", ">", "<=", ">=", "=<", "=>"):
+            if op == "=<":
+                op = "<="
+            elif op == "=>":
+                op = ">="
+            return -1 if self._compare(op, left, right) else 0
+
+        if isinstance(left, str) or isinstance(right, str):
+            if op == "+":
+                return str(left) + str(right)
+            raise RuntimeError_("Type mismatch", 13, node.line_num)
+
+        if op == "+":
+            return left + right
+        if op == "-":
+            return left - right
+        if op == "*":
+            return left * right
+        if op == "/":
+            if right == 0:
+                return 0.0  # MMBasic-tolerant: x/0 -> 0, not a hard crash
+            return left / right
+        if op == "\\":
+            if right == 0:
+                return 0
+            return int(left) // int(right)
+        if opu == "MOD":
+            if right == 0:
+                return 0
+            return int(left) % int(right)
+        if op == "^":
+            return left ** right
+        if op == ">>":
+            return int(left) >> int(right)
+        if op == "<<":
+            return int(left) << int(right)
+        if opu in ("AND", "OR", "XOR", "EQV", "IMP"):
+            return self._logical(opu, left, right)
+        raise RuntimeError_("Illegal function call", 5, node.line_num)
+
+    def _eval_unary(self, node):
+        v = self.eval_expr(node.operand)
+        op = node.op
+        opu = op.upper() if isinstance(op, str) else op
+        if op == "-":
+            return -v
+        if op == "+":
+            return v
+        if opu == "NOT":
+            return self._logical("NOT", v, 0)
+        raise RuntimeError_("Illegal function call", 5, node.line_num)
+
+    def _compare(self, op, a, b):
+        if isinstance(a, str) or isinstance(b, str):
+            a = str(a)
+            b = str(b)
+        if op == "=":
+            return a == b
+        if op in ("<>", "><"):
+            return a != b
+        if op == "<":
+            return a < b
+        if op == ">":
+            return a > b
+        if op == "<=":
+            return a <= b
+        if op == ">=":
+            return a >= b
+        return False
+
+    @staticmethod
+    def _logical(op, a, b):
+        """32-bit bitwise operations (MMBasic integer width)."""
+        a32 = int(a) & 0xFFFFFFFF
+        if op == "NOT":
+            r = (~a32) & 0xFFFFFFFF
+        else:
+            b32 = int(b) & 0xFFFFFFFF
+            if op == "AND":
+                r = a32 & b32
+            elif op == "OR":
+                r = a32 | b32
+            elif op == "XOR":
+                r = a32 ^ b32
+            elif op == "EQV":
+                r = (~(a32 ^ b32)) & 0xFFFFFFFF
+            elif op == "IMP":
+                r = ((~a32) | b32) & 0xFFFFFFFF
+            else:
+                r = 0
+        return r
+
+    def _eval_rgb(self, node):
+        """RGB(r,g,b) or RGB(colourname)."""
+        args = node.args
+        if len(args) == 1:
+            a0 = args[0]
+            if isinstance(a0, nodes.VariableNode) and a0.name in NAMED_COLORS:
+                return NAMED_COLORS[a0.name]
+            return int(self.eval_expr(a0)) & 0xFFFFFF
+        vals = [self.eval_expr(a) for a in args]
+        r = int(vals[0]) & 0xFF
+        g = int(vals[1]) & 0xFF
+        b = int(vals[2]) & 0xFF
+        return (r << 16) | (g << 8) | b
+
+    def _eval_function(self, node):
+        name = node.name
+        if name.startswith("fn"):
+            # A name like `fnr` (lexed lowercase) may be a FUNCTION defined
+            # with `FUNCTION FNR(...)` rather than a DEF FN. FUNCTION wins;
+            # fall back to DEF FN (def_functions) if it's not one.
+            if name in self.runtime.function_defs:
+                args = [self.eval_expr(a) for a in node.args]
+                return self._call_function(name, args)
+            return self._call_user_fn(node)
+        if name == "rgb":
+            return self._eval_rgb(node)
+        args = [self.eval_expr(a) for a in node.args]
+        method_name = name.rstrip("$").upper()
+        method = getattr(self.builtins, method_name, None)
+        if method is None:
+            raise RuntimeError_("Undefined function %s" % name, 18, node.line_num)
+        try:
+            return method(*args)
+        except TypeError:
+            raise RuntimeError_("Wrong number of arguments for %s" % name,
+                                5, node.line_num)
+
+    def _call_user_fn(self, node):
+        name = node.name
+        fn = self.runtime.def_functions.get(name)
+        if fn is None:
+            raise RuntimeError_("Undefined user function %s" % name, 18, node.line_num)
+        params = fn["params"]
+        body = fn["body"]
+        args = [self.eval_expr(a) for a in node.args]
+        if len(args) != len(params):
+            raise RuntimeError_("Wrong number of arguments", 5, node.line_num)
+        saved = {}
+        for p, a in zip(params, args):
+            saved[p.name] = self.runtime._variables.get(p.name, _UNBOUND)
+            self.runtime.set_variable(p, a)
+        try:
+            return self.eval_expr(body)
+        finally:
+            for p in params:
+                if saved[p.name] is _UNBOUND:
+                    self.runtime._variables.pop(p.name, None)
+                else:
+                    self.runtime._variables[p.name] = saved[p.name]
+
+    @staticmethod
+    def _truthy(v):
+        if isinstance(v, str):
+            raise RuntimeError_("Type mismatch", 13, 0)
+        return v != 0
+
+
+class _InputValueError(Exception):
+    pass
+
+
+
+def _noop(*_a):
+    return "NORMAL"
+
+
+def _make_handlers():
+    table = {
+        "PrintStatementNode": Interpreter.execute_print,
+        "PrintUsingStatementNode": Interpreter.execute_printusing,
+        "LprintStatementNode": Interpreter.execute_lprint,
+        "WriteStatementNode": Interpreter.execute_write,
+        "InputStatementNode": Interpreter.execute_input,
+        "LineInputStatementNode": Interpreter.execute_line_input,
+        "LetStatementNode": Interpreter.execute_let,
+        "ChainedAssignmentStatementNode": Interpreter.execute_chained_assignment,
+        "MidAssignmentStatementNode": Interpreter.execute_mid_assignment,
+        "SwapStatementNode": Interpreter.execute_swap,
+        "GotoStatementNode": Interpreter.execute_goto,
+        "GosubStatementNode": Interpreter.execute_gosub,
+        "ReturnStatementNode": Interpreter.execute_return,
+        "IfStatementNode": Interpreter.execute_if,
+        "OnGotoStatementNode": Interpreter.execute_on_goto,
+        "OnGosubStatementNode": Interpreter.execute_on_gosub,
+        "ForStatementNode": Interpreter.execute_for,
+        "NextStatementNode": Interpreter.execute_next,
+        "WhileStatementNode": Interpreter.execute_while,
+        "WendStatementNode": Interpreter.execute_wend,
+        "EndStatementNode": Interpreter.execute_end,
+        "StopStatementNode": Interpreter.execute_stop,
+        "TronStatementNode": Interpreter.execute_tron,
+        "TroffStatementNode": Interpreter.execute_troff,
+        "DimStatementNode": Interpreter.execute_dim,
+        "EraseStatementNode": Interpreter.execute_erase,
+        "DefTypeStatementNode": Interpreter.execute_def_type,
+        "DefFnStatementNode": Interpreter.execute_def_fn,
+        "DataStatementNode": Interpreter.execute_data,
+        "ReadStatementNode": Interpreter.execute_read,
+        "RestoreStatementNode": Interpreter.execute_restore,
+        "ClearStatementNode": Interpreter.execute_clear,
+        "ClsStatementNode": Interpreter.execute_cls,
+        "FontStatementNode": Interpreter.execute_font,
+        "CenterStatementNode": Interpreter.execute_center,
+        "DriveStatementNode": Interpreter.execute_drive,
+        "CommonStatementNode": Interpreter.execute_common,
+        "ErrorStatementNode": Interpreter.execute_error,
+        "OnErrorStatementNode": Interpreter.execute_on_error,
+        "ResumeStatementNode": Interpreter.execute_resume,
+        "RandomizeStatementNode": Interpreter.execute_randomize,
+        "PokeStatementNode": Interpreter.execute_poke,
+        "OutStatementNode": Interpreter.execute_out,
+        "WaitStatementNode": Interpreter.execute_wait,
+        "CallStatementNode": Interpreter.execute_call,
+        "WidthStatementNode": Interpreter.execute_width,
+        "RemarkStatementNode": Interpreter.execute_remark,
+        "OpenStatementNode": Interpreter.execute_open,
+        "CloseStatementNode": Interpreter.execute_close,
+        "KillStatementNode": Interpreter.execute_kill,
+        "ResetStatementNode": Interpreter.execute_reset_file,
+        "SystemStatementNode": Interpreter.execute_end,
+        "UnsupportedStatementNode": Interpreter.execute_unsupported,
+        "SubStatementNode": Interpreter.execute_sub,
+        "EndSubStatementNode": Interpreter.execute_endsub,
+        "ExitSubStatementNode": Interpreter.execute_exit_sub,
+        "FunctionStatementNode": Interpreter.execute_function,
+        "EndFunctionStatementNode": Interpreter.execute_end_function,
+        "ExitFunctionStatementNode": Interpreter.execute_exit_function,
+        "SubCallStatementNode": Interpreter.execute_sub_call,
+        "LocalStatementNode": Interpreter.execute_local,
+        "DoStatementNode": Interpreter.execute_do,
+        "LoopStatementNode": Interpreter.execute_loop,
+        "ExitDoStatementNode": Interpreter.execute_exit_do,
+        "ExitForStatementNode": Interpreter.execute_exit_for,
+        "SelectStatementNode": Interpreter.execute_select,
+        "ConstStatementNode": Interpreter.execute_const,
+        "OptionStatementNode": Interpreter.execute_option,
+        "BlockIfStatementNode": Interpreter.execute_block_if,
+        "LabelNode": Interpreter.execute_label,
+        "EndIfStatementNode": Interpreter.execute_end_if,
+        "EndSelectStatementNode": Interpreter.execute_end_select,
+        "PixelStatementNode": Interpreter.execute_pixel,
+        "LineStatementNode": Interpreter.execute_line,
+        "BoxStatementNode": Interpreter.execute_box,
+        "CircleStatementNode": Interpreter.execute_circle,
+        "PolygonStatementNode": Interpreter.execute_polygon,
+        "ColorStatementNode": Interpreter.execute_color,
+        "TextStatementNode": Interpreter.execute_text,
+        "FrameBufferStatementNode": Interpreter.execute_framebuffer,
+        "TurtleStatementNode": Interpreter.execute_turtle,
+        "SaveImageStatementNode": Interpreter.execute_save_image,
+        "LayerStatementNode": Interpreter.execute_layer,
+        "CopyStatementNode": _noop,
+        "SortStatementNode": _noop,
+        "MkdirStatementNode": _noop,
+        "ChdirStatementNode": _noop,
+        # Statements that parse but do nothing meaningful on a handheld.
+        "LsetStatementNode": _noop,
+        "RsetStatementNode": _noop,
+        "FieldStatementNode": _noop,
+        "GetStatementNode": _noop,
+        "PutStatementNode": _noop,
+        "NameStatementNode": _noop,
+        "ContStatementNode": _noop,
+        "RunStatementNode": _noop,
+    }
+    return table
+
+
+_STATEMENT_HANDLERS = _make_handlers()

--- a/simulator/hardware/mmbasic_runtime/io.py
+++ b/simulator/hardware/mmbasic_runtime/io.py
@@ -1,0 +1,143 @@
+class PicowareConsole:
+    def __init__(self, view_manager):
+        self.vm = view_manager
+        self.draw = view_manager.draw
+        self.fg = view_manager.foreground_color
+        self.bg = view_manager.background_color
+
+        self.font_w = self.draw.font_size.x
+        self.font_h = self.draw.font_size.y
+        self.screen_w = self.draw.size.x
+        self.screen_h = self.draw.size.y
+        self.columns = max(self.screen_w // max(self.font_w, 1), 8)
+        self.rows = max(self.screen_h // max(self.font_h, 1), 4)
+
+        # Scroll-back buffer
+        self.lines = []      # completed lines
+        self.cur = ""        # current in-progress line
+        self.max_lines = 400
+        self.footer = "BACK=exit"
+        self.dirty = True
+        self._input_active = False
+        self._pos = None     # (row, col) from PRINT @(col,row[,size])
+        self._fs = 8         # font size for PRINT @(col,row,size)
+
+    def goto(self, col, row, size=None):
+        """Position the text cursor at a character cell for PRINT @(...)."""
+        self._pos = [max(int(row), 0), max(int(col), 0)]
+        if size is not None and int(size) > 0:
+            self._fs = int(size)
+        self.dirty = True
+
+    def output(self, text):
+        """Append text; '\\n' flushes lines, a trailing newline opens a fresh
+        line, and no trailing newline leaves the line open (PRINT ...;)."""
+        if self._pos is not None:
+            self._output_at(text)
+            return
+        parts = text.split("\n")
+        for i, part in enumerate(parts):
+            self.cur += part
+            if i < len(parts) - 1:
+                self._flush_line()
+            else:
+                self._wrap_cur()
+        self.dirty = True
+
+    def _output_at(self, text):
+        """Write text at the current PRINT @(col,row) position, then advance
+        the cursor past what was written (so trailing `;` prints continue)."""
+        row, col = self._pos
+        while len(self.lines) <= row:
+            self.lines.append("")
+        i = 0
+        n = len(text)
+        while i < n:
+            ch = text[i]
+            if ch == "\n":
+                row += 1
+                col = 0
+                while len(self.lines) <= row:
+                    self.lines.append("")
+                i += 1
+                continue
+            line = self.lines[row]
+            if len(line) < col:
+                line = line + " " * (col - len(line))
+            line = line[:col] + ch + line[col + 1:]
+            self.lines[row] = line
+            col += 1
+            i += 1
+        self._pos = [row, col]
+        self._trim()
+        self.dirty = True
+
+    def newline(self):
+        self._flush_line()
+        self.dirty = True
+
+    def echo(self, ch):
+        self.cur += ch
+        self._wrap_cur()
+        self.dirty = True
+
+    def backspace(self):
+        if self.cur:
+            self.cur = self.cur[:-1]
+            self.dirty = True
+
+    def clear(self):
+        self.lines = []
+        self.cur = ""
+        self.dirty = True
+
+    def pos(self):
+        """Current print column (for POS())."""
+        return len(self.cur)
+
+    def set_input_active(self, active):
+        self._input_active = bool(active)
+
+    def _flush_line(self):
+        self.lines.append(self.cur)
+        self.cur = ""
+        self._trim()
+
+    def _wrap_cur(self):
+        while len(self.cur) > self.columns:
+            self.lines.append(self.cur[:self.columns])
+            self.cur = self.cur[self.columns:]
+            self._trim()
+
+    def _trim(self):
+        if len(self.lines) > self.max_lines:
+            del self.lines[:len(self.lines) - self.max_lines]
+
+
+    def render(self):
+        if not self.dirty:
+            return
+        draw = self.draw
+        try:
+            draw.erase()
+        except Exception:
+            draw.fill_screen(self.bg)
+
+        display = list(self.lines) + [self.cur]
+        text_rows = self.rows - (1 if self.footer else 0)
+        text_rows = max(text_rows, 1)
+        tail = display[-text_rows:]
+
+        y = 0
+        for line in tail:
+            draw._text(0, y, line, self.fg)
+            y += self.font_h
+        if self.footer:
+            draw._text(0, self.screen_h - self.font_h, self.footer,
+                       self.vm.selected_color)
+        draw.swap()
+        self.dirty = False
+
+
+    def log(self, message, level=-1):
+        self.vm.log(message, level)

--- a/simulator/hardware/mmbasic_runtime/lexer.py
+++ b/simulator/hardware/mmbasic_runtime/lexer.py
@@ -1,0 +1,531 @@
+from .tokens import Token, TokenType, KEYWORDS, FILE_IO_KEYWORDS
+
+
+class SimpleKeywordCase:
+    """Minimal keyword-case handler. """
+
+    def __init__(self, policy="force_lower"):
+        self.policy = policy
+
+    def register_keyword(self, keyword, display, line, column):
+        return display
+
+
+def create_keyword_case_manager():
+    return SimpleKeywordCase(policy="force_lower")
+
+
+class LexerError(Exception):
+    """Exception raised for lexer errors."""
+
+    def __init__(self, message, line, column):
+        super().__init__("Lexer error at %d:%d: %s" % (line, column, message))
+        self.line = line
+        self.column = column
+
+
+class Lexer:
+    """Tokenizes MBASIC 5.21 source code."""
+
+    __slots__ = (
+        "source",
+        "_b",
+        "_n",
+        "pos",
+        "line",
+        "column",
+        "tokens",
+        "_font_data",
+        "keyword_case_manager",
+    )
+
+    def __init__(self, source, keyword_case_manager=None):
+        if source[:1] == "\ufeff":
+            source = source[1:]
+        self.source = source
+        try:
+            self._b = source.encode("latin-1")
+        except Exception:
+            self._b = source.encode("utf-8")
+        self._n = len(self._b)
+        self.pos = 0
+        self.line = 1
+        self.column = 1
+        self.tokens = []
+        self._font_data = False
+        self.keyword_case_manager = keyword_case_manager or SimpleKeywordCase(policy="force_lower")
+
+
+    def current_char(self):
+        if self.pos >= self._n:
+            return None
+        return chr(self._b[self.pos])
+
+    def peek_char(self, offset=1):
+        pos = self.pos + offset
+        if pos >= self._n:
+            return None
+        return chr(self._b[pos])
+
+    def advance(self):
+        if self.pos >= self._n:
+            return None
+        char = chr(self._b[self.pos])
+        self.pos += 1
+        if char == "\n":
+            self.line += 1
+            self.column = 1
+        else:
+            self.column += 1
+        return char
+
+    def skip_whitespace(self, skip_newlines=False):
+        while self.current_char() is not None:
+            char = self.current_char()
+            if char == " " or char == "\t":
+                self.advance()
+            elif skip_newlines and (char == "\n" or char == "\r"):
+                self.advance()
+            else:
+                break
+
+
+    def read_number(self):
+        """Read a number literal.
+
+        - Integer: -32768 to 32767
+        - Fixed point: with decimal point
+        - Floating point: with E or D exponent notation
+        - Octal: &O or & prefix
+        - Hexadecimal: &H prefix
+        """
+        start_line = self.line
+        start_column = self.column
+        num_str = ""
+
+        # Octal/hex prefix
+        if self.current_char() == "&":
+            num_str += self.advance()
+            next_char = self.current_char()
+
+            if next_char and next_char.upper() == "H":
+                # Hexadecimal
+                num_str += self.advance()
+                while self.current_char() and self.current_char() in "0123456789ABCDEFabcdef":
+                    num_str += self.advance()
+                try:
+                    value = int(num_str[2:], 16) if len(num_str) > 2 else 0
+                except ValueError:
+                    raise LexerError("Invalid hex number: %s" % num_str,
+                                     start_line, start_column)
+                return Token(TokenType.NUMBER, value, start_line, start_column,
+                             literal_text=num_str)
+
+            elif next_char and next_char.upper() == "O":
+                # Octal with &O prefix
+                num_str += self.advance()
+                while self.current_char() and self.current_char() in "01234567":
+                    num_str += self.advance()
+                try:
+                    value = int(num_str[2:], 8) if len(num_str) > 2 else 0
+                except ValueError:
+                    raise LexerError("Invalid octal number: %s" % num_str,
+                                     start_line, start_column)
+                return Token(TokenType.NUMBER, value, start_line, start_column,
+                             literal_text=num_str)
+
+            elif next_char and next_char in "01234567":
+                # Octal with just & prefix
+                while self.current_char() and self.current_char() in "01234567":
+                    num_str += self.advance()
+                try:
+                    value = int(num_str[1:], 8) if len(num_str) > 1 else 0
+                except ValueError:
+                    raise LexerError("Invalid octal number: %s" % num_str,
+                                     start_line, start_column)
+                return Token(TokenType.NUMBER, value, start_line, start_column,
+                             literal_text=num_str)
+
+        # Leading decimal point (.5 syntax)
+        if self.current_char() == "." and self.peek_char() and self.peek_char().isdigit():
+            num_str += self.advance()
+            while self.current_char() is not None and self.current_char().isdigit():
+                num_str += self.advance()
+        else:
+            while self.current_char() is not None and self.current_char().isdigit():
+                num_str += self.advance()
+
+            # Decimal point (MBASIC allows trailing dot: 100.)
+            if self.current_char() == ".":
+                next_char = self.peek_char()
+                if next_char is None or next_char.isdigit() or \
+                        not (next_char.isalpha() or next_char.isdigit()):
+                    num_str += self.advance()
+                    while self.current_char() is not None and self.current_char().isdigit():
+                        num_str += self.advance()
+
+        # Scientific notation (E or D)
+        if self.current_char() and self.current_char().upper() in ["E", "D"]:
+            num_str += self.advance()
+            if self.current_char() in ["+", "-"]:
+                num_str += self.advance()
+            if not (self.current_char() and self.current_char().isdigit()):
+                raise LexerError("Invalid number format: %s" % num_str,
+                                 start_line, start_column)
+            while self.current_char() is not None and self.current_char().isdigit():
+                num_str += self.advance()
+
+        # Type suffix (! # %)
+        type_suffix = None
+        if self.current_char() in ["!", "#", "%"]:
+            type_suffix = self.advance()
+
+        try:
+            if "." in num_str or "E" in num_str.upper() or "D" in num_str.upper():
+                value = float(num_str.replace("D", "E").replace("d", "e"))
+            else:
+                value = int(num_str)
+        except ValueError:
+            raise LexerError("Invalid number: %s" % num_str, start_line, start_column)
+
+        return Token(TokenType.NUMBER, value, start_line, start_column,
+                     literal_text=num_str + (type_suffix or ""))
+
+    def read_string(self):
+        """Read a string literal enclosed in double quotes."""
+        start_line = self.line
+        start_column = self.column
+        self.advance()  # Skip opening quote
+        string_val = []
+
+        while self.current_char() is not None:
+            char = self.current_char()
+            if char == '"':
+                self.advance()
+                break
+            if char == "\n" or char == "\r":
+                break  # unclosed string runs to end of line
+            string_val.append(self.advance())
+
+        return Token(TokenType.STRING, "".join(string_val),
+                     start_line, start_column)
+
+    def read_identifier(self):
+        """Read an identifier or keyword.
+
+        Identifiers can contain letters, digits and periods, and end with a
+        type suffix ($ % ! #), which is part of the identifier.
+        """
+        start_line = self.line
+        start_column = self.column
+        ident = ""
+
+        if self.current_char() and self.current_char().isalpha():
+            ident += self.advance()
+        else:
+            raise LexerError("Invalid identifier", start_line, start_column)
+
+        while self.current_char() is not None:
+            char = self.current_char()
+            if (char.isalpha() or char.isdigit()) or char == "." or char == "_":
+                ident += self.advance()
+            elif char in ["$", "%", "!", "#"]:
+                ident += self.advance()
+                break
+            else:
+                break
+
+        ident_lower = ident.lower()
+        if ident_lower in KEYWORDS:
+            self.keyword_case_manager.register_keyword(
+                ident_lower, ident, start_line, start_column)
+            return Token(KEYWORDS[ident_lower], ident_lower, start_line,
+                         start_column)
+
+        # File I/O keywords followed by # with no space (PRINT#1, INPUT#1, ...)
+        if ident_lower.endswith("#") and ident_lower[:-1] in KEYWORDS:
+            keyword_part = ident_lower[:-1]
+            if keyword_part in FILE_IO_KEYWORDS:
+                # Put the # back so it is tokenized separately
+                self.pos -= 1
+                self.column -= 1
+                self.keyword_case_manager.register_keyword(
+                    keyword_part, ident[:-1], start_line, start_column)
+                return Token(KEYWORDS[keyword_part], keyword_part,
+                             start_line, start_column)
+
+        return Token(TokenType.IDENTIFIER, ident_lower, start_line, start_column)
+
+    def read_line_number(self):
+        """Read a line number at the start of a line (0-65529)."""
+        start_line = self.line
+        start_column = self.column
+        num_str = ""
+        while self.current_char() is not None and self.current_char().isdigit():
+            num_str += self.advance()
+        line_num = int(num_str)
+        if line_num > 65529:
+            raise LexerError("Line number %d exceeds maximum of 65529" % line_num,
+                             start_line, start_column)
+        return Token(TokenType.LINE_NUMBER, line_num, start_line, start_column)
+
+    def read_comment(self):
+        """Read comment text until end of line."""
+        comment_text = []
+        while self.current_char() is not None and self.current_char() != "\n":
+            comment_text.append(self.current_char())
+            self.advance()
+        return "".join(comment_text).strip()
+
+
+    def _line_starts_with(self, word):
+        """True if the current line (from `self.pos`, leading whitespace
+        already skipped) begins with `word` as a whole identifier
+        (case-insensitive)."""
+        b = self._b
+        n = self._n
+        i = self.pos
+        wlen = len(word)
+        if i + wlen > n:
+            return False
+        for k in range(wlen):
+            c = b[i + k]
+            if not (65 <= c <= 90 or 97 <= c <= 122):
+                return False
+            wc = word[k]
+            if c != ord(wc) and c != ord(wc) - 32:
+                return False
+        # word boundary: the next char must not be a letter
+        if i + wlen < n and (65 <= b[i + wlen] <= 90 or 97 <= b[i + wlen] <= 122):
+            return False
+        return True
+
+    def _skip_line(self):
+        """Consume the rest of the current line (leading whitespace already
+        skipped) including its trailing newline, updating line/column."""
+        while self.pos < self._n:
+            c = self._b[self.pos]
+            if c == 0x0A or c == 0x0D:
+                self.advance()
+                if self.pos < self._n and (self._b[self.pos] == 0x0A or
+                                           self._b[self.pos] == 0x0D):
+                    if self._b[self.pos] != c:
+                        self.advance()
+                return
+            self.advance()
+
+    def tokenize(self):
+        self.tokens = []
+        at_line_start = True
+
+        while self.pos < self._n:
+            self.skip_whitespace(skip_newlines=False)
+
+            char = self.current_char()
+            if char is None:
+                break
+
+            start_line = self.line
+            start_column = self.column
+
+            # DefineFont ... End DefineFont blocks carry raw bitmap data on
+            # the following lines (hex words that would otherwise look like
+            # huge line numbers). Skip the whole block.
+            if at_line_start:
+                if self._font_data:
+                    if self._line_starts_with("end"):
+                        self._font_data = False
+                    self._skip_line()
+                    at_line_start = True
+                    continue
+                if self._line_starts_with("definefont"):
+                    self._font_data = True
+                    self._skip_line()
+                    at_line_start = True
+                    continue
+
+            # Line number at start of line
+            if at_line_start and char.isdigit():
+                self.tokens.append(self.read_line_number())
+                at_line_start = False
+                continue
+
+            # Newline (\n and \r both work as statement separators)
+            if char == "\n":
+                self.tokens.append(Token(TokenType.NEWLINE, "\n", start_line, start_column))
+                self.advance()
+                if self.current_char() == "\r":
+                    self.advance()
+                at_line_start = True
+                continue
+
+            if char == "\r":
+                self.tokens.append(Token(TokenType.NEWLINE, "\r", start_line, start_column))
+                self.advance()
+                if self.current_char() == "\n":
+                    self.advance()
+                at_line_start = True
+                continue
+
+            # Apostrophe comment
+            if char == "'":
+                self.advance()
+                comment_text = self.read_comment()
+                self.tokens.append(Token(TokenType.APOSTROPHE, comment_text,
+                                         start_line, start_column))
+                continue
+
+            # Numbers (including &H hex, &O octal, and .5 leading decimal)
+            if char.isdigit() or \
+               (char == "&" and self.peek_char() and
+                (self.peek_char().upper() in ["H", "O"] or self.peek_char().isdigit())) or \
+               (char == "." and self.peek_char() and self.peek_char().isdigit()):
+                self.tokens.append(self.read_number())
+                continue
+
+            if char == '"':
+                self.tokens.append(self.read_string())
+                continue
+
+            if char.isalpha():
+                token = self.read_identifier()
+                if token.type in (TokenType.REM, TokenType.REMARK):
+                    comment_text = self.read_comment()
+                    token = Token(token.type, comment_text, token.line, token.column)
+                    self.tokens.append(token)
+                else:
+                    self.tokens.append(token)
+                at_line_start = False
+                continue
+
+            if char == "+":
+                self.advance()
+                if self.current_char() == "=":
+                    self.advance()
+                    self.tokens.append(Token(TokenType.PLUS_EQUAL, "+=",
+                                             start_line, start_column))
+                else:
+                    self.tokens.append(Token(TokenType.PLUS, "+",
+                                             start_line, start_column))
+            elif char == "-":
+                self.advance()
+                if self.current_char() == "=":
+                    self.advance()
+                    self.tokens.append(Token(TokenType.MINUS_EQUAL, "-=",
+                                             start_line, start_column))
+                else:
+                    self.tokens.append(Token(TokenType.MINUS, "-",
+                                             start_line, start_column))
+            elif char == "*":
+                self.tokens.append(Token(TokenType.MULTIPLY, "*", start_line, start_column))
+                self.advance()
+            elif char == "/":
+                self.tokens.append(Token(TokenType.DIVIDE, "/", start_line, start_column))
+                self.advance()
+            elif char == "^":
+                self.tokens.append(Token(TokenType.POWER, "^", start_line, start_column))
+                self.advance()
+            elif char == "\\":
+                self.tokens.append(Token(TokenType.BACKSLASH, "\\", start_line, start_column))
+                self.advance()
+            elif char == "=":
+                self.advance()
+                next_char = self.current_char()
+                if next_char == "<":
+                    self.tokens.append(Token(TokenType.LESS_EQUAL, "=<",
+                                             start_line, start_column))
+                    self.advance()
+                elif next_char == ">":
+                    self.tokens.append(Token(TokenType.GREATER_EQUAL, "=>",
+                                             start_line, start_column))
+                    self.advance()
+                else:
+                    self.tokens.append(Token(TokenType.EQUAL, "=",
+                                             start_line, start_column))
+            elif char == "<":
+                self.advance()
+                next_char = self.current_char()
+                if next_char == ">":
+                    self.tokens.append(Token(TokenType.NOT_EQUAL, "<>", start_line, start_column))
+                    self.advance()
+                elif next_char == "=":
+                    self.tokens.append(Token(TokenType.LESS_EQUAL, "<=", start_line, start_column))
+                    self.advance()
+                elif next_char == "<":
+                    self.tokens.append(Token(TokenType.SHL, "<<", start_line, start_column))
+                    self.advance()
+                else:
+                    # tolerate `< >` (spaced) as NOT_EQUAL (PicoCalc files)
+                    while self.current_char() in (" ", "\t"):
+                        self.advance()
+                    if self.current_char() == ">":
+                        self.tokens.append(Token(TokenType.NOT_EQUAL, "<>", start_line, start_column))
+                        self.advance()
+                    else:
+                        self.tokens.append(Token(TokenType.LESS_THAN, "<", start_line, start_column))
+            elif char == ">":
+                self.advance()
+                next_char = self.current_char()
+                if next_char == "<":
+                    self.tokens.append(Token(TokenType.NOT_EQUAL, "><", start_line, start_column))
+                    self.advance()
+                elif next_char == "=":
+                    self.tokens.append(Token(TokenType.GREATER_EQUAL, ">=", start_line, start_column))
+                    self.advance()
+                elif next_char == ">":
+                    self.tokens.append(Token(TokenType.SHR, ">>", start_line, start_column))
+                    self.advance()
+                else:
+                    # tolerate `> <` (spaced) as NOT_EQUAL (PicoCalc files)
+                    while self.current_char() in (" ", "\t"):
+                        self.advance()
+                    if self.current_char() == "<":
+                        self.tokens.append(Token(TokenType.NOT_EQUAL, "><", start_line, start_column))
+                        self.advance()
+                    else:
+                        self.tokens.append(Token(TokenType.GREATER_THAN, ">", start_line, start_column))
+            elif char == "(":
+                self.tokens.append(Token(TokenType.LPAREN, "(", start_line, start_column))
+                self.advance()
+            elif char == ")":
+                self.tokens.append(Token(TokenType.RPAREN, ")", start_line, start_column))
+                self.advance()
+            elif char == ",":
+                self.tokens.append(Token(TokenType.COMMA, ",", start_line, start_column))
+                self.advance()
+            elif char == ";":
+                self.tokens.append(Token(TokenType.SEMICOLON, ";", start_line, start_column))
+                self.advance()
+            elif char == ":":
+                self.tokens.append(Token(TokenType.COLON, ":", start_line, start_column))
+                self.advance()
+                at_line_start = False
+            elif char == "?":
+                self.tokens.append(Token(TokenType.QUESTION, "?", start_line, start_column))
+                self.advance()
+            elif char == "#":
+                self.tokens.append(Token(TokenType.HASH, "#", start_line, start_column))
+                self.advance()
+            elif char == "&":
+                self.tokens.append(Token(TokenType.AMPERSAND, "&", start_line, start_column))
+                self.advance()
+            elif char == "@":
+                self.tokens.append(Token(TokenType.AT, "@", start_line, start_column))
+                self.advance()
+            else:
+                # Skip control characters gracefully
+                if ord(char) < 32 and char not in ["\t", "\n", "\r"]:
+                    self.advance()
+                    continue
+                raise LexerError("Unexpected character: '%s' (0x%02x)" %
+                                 (char, ord(char)), start_line, start_column)
+
+            at_line_start = False
+
+        self.tokens.append(Token(TokenType.EOF, None, self.line, self.column))
+        return self.tokens
+
+
+def tokenize(source):
+    """Convenience function to tokenize source code."""
+    return Lexer(source).tokenize()

--- a/simulator/hardware/mmbasic_runtime/nodes.py
+++ b/simulator/hardware/mmbasic_runtime/nodes.py
@@ -1,0 +1,1032 @@
+class _Node:
+    """Base class: carries source position."""
+
+    __slots__ = ("line_num", "column", "char_start", "char_end")
+
+    def __init__(self, token=None, line_num=None, column=None):
+        if token is not None:
+            self.line_num = getattr(token, "line", 0)
+            self.column = getattr(token, "column", 0)
+        else:
+            self.line_num = line_num if line_num is not None else 0
+            self.column = column if column is not None else 0
+        self.char_start = 0
+        self.char_end = 0
+
+    def __repr__(self):
+        return "<%s at %d:%d>" % (type(self).__name__, self.line_num, self.column)
+
+
+
+class ProgramNode(_Node):
+    """The whole program: {line_num: LineNode}."""
+
+    __slots__ = ("lines", "order")
+
+    def __init__(self, lines=None):
+        super().__init__(line_num=0, column=0)
+        self.lines = lines if lines is not None else {}
+        self.order = sorted(self.lines.keys())
+
+    def add_line(self, line_node):
+        self.lines[line_node.line_num] = line_node
+        self.order = sorted(self.lines.keys())
+
+    def highest_line(self):
+        """Highest numbered line in the program (0 if empty)."""
+        if self.order:
+            return self.order[-1]
+        return 0
+
+
+class LineNode(_Node):
+    """One numbered source line: a list of statements."""
+
+    __slots__ = ("statements", "text")
+
+    def __init__(self, line_num, statements=None, text=""):
+        super().__init__(line_num=line_num, column=0)
+        self.line_num = line_num
+        self.statements = statements if statements is not None else []
+        self.text = text
+
+
+class StatementNode(_Node):
+    """Base class for all statements."""
+
+    __slots__ = ()
+
+
+
+class PrintStatementNode(StatementNode):
+    __slots__ = ("expressions", "separators", "file_number", "using_format",
+                 "position")
+
+    def __init__(self, expressions, separators, file_number=None,
+                 position=None, using_format=None, token=None):
+        super().__init__(token=token)
+        self.expressions = expressions
+        self.separators = separators
+        self.file_number = file_number
+        self.using_format = using_format
+        self.position = position  # (col, row, size) from PRINT @(col,row[,size])
+
+
+class PrintUsingStatementNode(StatementNode):
+    __slots__ = ("format_string", "expressions", "file_number")
+
+    def __init__(self, format_string, expressions, file_number=None, token=None):
+        super().__init__(token=token)
+        self.format_string = format_string
+        self.expressions = expressions
+        self.file_number = file_number
+
+
+class LprintStatementNode(StatementNode):
+    __slots__ = ("expressions", "separators")
+
+    def __init__(self, expressions, separators, token=None):
+        super().__init__(token=token)
+        self.expressions = expressions
+        self.separators = separators
+
+
+class WriteStatementNode(StatementNode):
+    __slots__ = ("expressions", "file_number")
+
+    def __init__(self, expressions, file_number=None, token=None):
+        super().__init__(token=token)
+        self.expressions = expressions
+        self.file_number = file_number
+
+
+class InputStatementNode(StatementNode):
+    __slots__ = ("variables", "prompt", "file_number", "is_line")
+
+    def __init__(self, variables, prompt=None, file_number=None,
+                 is_line=False, token=None):
+        super().__init__(token=token)
+        self.variables = variables
+        self.prompt = prompt
+        self.file_number = file_number
+        self.is_line = is_line
+
+
+class LineInputStatementNode(StatementNode):
+    __slots__ = ("variable", "prompt", "file_number")
+
+    def __init__(self, variable, prompt=None, file_number=None, token=None):
+        super().__init__(token=token)
+        self.variable = variable
+        self.prompt = prompt
+        self.file_number = file_number
+
+
+
+class LetStatementNode(StatementNode):
+    __slots__ = ("variable", "expression")
+
+    def __init__(self, variable, expression, token=None):
+        super().__init__(token=token)
+        self.variable = variable
+        self.expression = expression
+
+
+class ChainedAssignmentStatementNode(StatementNode):
+    """`A = B = C = expr` - assign expr to every listed variable."""
+
+    __slots__ = ("variables", "expression")
+
+    def __init__(self, variables, expression, token=None):
+        super().__init__(token=token)
+        self.variables = variables
+        self.expression = expression
+
+
+class MidAssignmentStatementNode(StatementNode):
+    __slots__ = ("target", "start", "length", "expression")
+
+    def __init__(self, target, start, length, expression, token=None):
+        super().__init__(token=token)
+        self.target = target      # VariableNode (string)
+        self.start = start
+        self.length = length
+        self.expression = expression
+
+
+class SwapStatementNode(StatementNode):
+    __slots__ = ("variable1", "variable2")
+
+    def __init__(self, variable1, variable2, token=None):
+        super().__init__(token=token)
+        self.variable1 = variable1
+        self.variable2 = variable2
+
+
+
+class IfStatementNode(StatementNode):
+    __slots__ = ("condition", "then_statements", "else_statements",
+                 "then_line", "else_line")
+
+    def __init__(self, condition, then_statements=None, else_statements=None,
+                 then_line=None, else_line=None, token=None):
+        super().__init__(token=token)
+        self.condition = condition
+        self.then_statements = then_statements if then_statements is not None else []
+        self.else_statements = else_statements if else_statements is not None else []
+        self.then_line = then_line
+        self.else_line = else_line
+
+
+class ForStatementNode(StatementNode):
+    __slots__ = ("variable", "start", "end", "step")
+
+    def __init__(self, variable, start, end, step, token=None):
+        super().__init__(token=token)
+        self.variable = variable
+        self.start = start
+        self.end = end
+        self.step = step
+
+
+class NextStatementNode(StatementNode):
+    __slots__ = ("variables",)
+
+    def __init__(self, variables=None, token=None):
+        super().__init__(token=token)
+        self.variables = variables if variables is not None else []
+
+
+class WhileStatementNode(StatementNode):
+    __slots__ = ("condition",)
+
+    def __init__(self, condition, token=None):
+        super().__init__(token=token)
+        self.condition = condition
+
+
+class WendStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class GotoStatementNode(StatementNode):
+    __slots__ = ("target",)
+
+    def __init__(self, target, token=None):
+        super().__init__(token=token)
+        self.target = target
+
+
+class GosubStatementNode(StatementNode):
+    __slots__ = ("target",)
+
+    def __init__(self, target, token=None):
+        super().__init__(token=token)
+        self.target = target
+
+
+class ReturnStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class OnGotoStatementNode(StatementNode):
+    __slots__ = ("expression", "targets")
+
+    def __init__(self, expression, targets, token=None):
+        super().__init__(token=token)
+        self.expression = expression
+        self.targets = targets
+
+
+class OnGosubStatementNode(StatementNode):
+    __slots__ = ("expression", "targets")
+
+    def __init__(self, expression, targets, token=None):
+        super().__init__(token=token)
+        self.expression = expression
+        self.targets = targets
+
+
+class EndStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class StopStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class ContStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class TronStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class TroffStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class SystemStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class RunStatementNode(StatementNode):
+    __slots__ = ("target", "filename")
+
+    def __init__(self, target=None, filename=None, token=None):
+        super().__init__(token=token)
+        self.target = target
+        self.filename = filename
+
+
+
+class DimStatementNode(StatementNode):
+    __slots__ = ("declarations",)
+
+    def __init__(self, declarations, token=None):
+        super().__init__(token=token)
+        self.declarations = declarations
+
+
+class ArrayDeclNode(_Node):
+    __slots__ = ("name", "dimensions")
+
+    def __init__(self, name, dimensions, token=None):
+        super().__init__(token=token)
+        self.name = name
+        self.dimensions = dimensions
+
+
+class EraseStatementNode(StatementNode):
+    __slots__ = ("variables",)
+
+    def __init__(self, variables, token=None):
+        super().__init__(token=token)
+        self.variables = variables
+
+
+class DataStatementNode(StatementNode):
+    __slots__ = ("values",)
+
+    def __init__(self, values, token=None):
+        super().__init__(token=token)
+        # values: list of (value, is_string)
+        self.values = values
+
+
+class ReadStatementNode(StatementNode):
+    __slots__ = ("variables",)
+
+    def __init__(self, variables, token=None):
+        super().__init__(token=token)
+        self.variables = variables
+
+
+class RestoreStatementNode(StatementNode):
+    __slots__ = ("target",)
+
+    def __init__(self, target=None, token=None):
+        super().__init__(token=token)
+        self.target = target  # int line number or str label name or None
+
+
+class DefTypeStatementNode(StatementNode):
+    __slots__ = ("letters", "type_name")
+
+    def __init__(self, letters, type_name, token=None):
+        super().__init__(token=token)
+        self.letters = letters
+        self.type_name = type_name
+
+
+class DefFnStatementNode(StatementNode):
+    __slots__ = ("name", "params", "body")
+
+    def __init__(self, name, params, body, token=None):
+        super().__init__(token=token)
+        self.name = name
+        self.params = params
+        self.body = body
+
+
+class ClearStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class FontStatementNode(StatementNode):
+    __slots__ = ("size",)
+
+    def __init__(self, size, token=None):
+        super().__init__(token=token)
+        self.size = size
+
+
+class ClsStatementNode(StatementNode):
+    """CLS [colour]: clear the text console, or (Maximite) clear the
+    graphics screen with an optional colour."""
+
+    __slots__ = ("color",)
+
+    def __init__(self, color=None, token=None):
+        super().__init__(token=token)
+        self.color = color
+
+
+class CenterStatementNode(StatementNode):
+    """CENTER text$: print text centred on the text console."""
+
+    __slots__ = ("text",)
+
+    def __init__(self, text, token=None):
+        super().__init__(token=token)
+        self.text = text
+
+
+class DriveStatementNode(StatementNode):
+    """DRIVE "A:"...: select the default drive. No-op on Picoware."""
+
+    __slots__ = ("path",)
+
+    def __init__(self, path=None, token=None):
+        super().__init__(token=token)
+        self.path = path
+
+
+class OptionBaseStatementNode(StatementNode):
+    __slots__ = ("base",)
+
+    def __init__(self, base, token=None):
+        super().__init__(token=token)
+        self.base = base
+
+
+class CommonStatementNode(StatementNode):
+    __slots__ = ("variables",)
+
+    def __init__(self, variables, token=None):
+        super().__init__(token=token)
+        self.variables = variables
+
+
+
+class ErrorStatementNode(StatementNode):
+    __slots__ = ("code",)
+
+    def __init__(self, code, token=None):
+        super().__init__(token=token)
+        self.code = code
+
+
+class OnErrorStatementNode(StatementNode):
+    __slots__ = ("target",)
+
+    def __init__(self, target, token=None):
+        super().__init__(token=token)
+        self.target = target
+
+
+class ResumeStatementNode(StatementNode):
+    __slots__ = ("target",)
+
+    def __init__(self, target=None, token=None):
+        super().__init__(token=token)
+        self.target = target
+
+
+
+class OpenStatementNode(StatementNode):
+    __slots__ = ("file_number", "mode", "filename", "rec_length")
+
+    def __init__(self, file_number, mode, filename, rec_length=None, token=None):
+        super().__init__(token=token)
+        self.file_number = file_number
+        self.mode = mode
+        self.filename = filename
+        self.rec_length = rec_length
+
+
+class CloseStatementNode(StatementNode):
+    __slots__ = ("file_numbers",)
+
+    def __init__(self, file_numbers, token=None):
+        super().__init__(token=token)
+        self.file_numbers = file_numbers
+
+
+class ResetStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class KillStatementNode(StatementNode):
+    __slots__ = ("filename",)
+
+    def __init__(self, filename, token=None):
+        super().__init__(token=token)
+        self.filename = filename
+
+
+class NameStatementNode(StatementNode):
+    __slots__ = ("old_name", "new_name")
+
+    def __init__(self, old_name, new_name, token=None):
+        super().__init__(token=token)
+        self.old_name = old_name
+        self.new_name = new_name
+
+
+class LsetStatementNode(StatementNode):
+    __slots__ = ("variable", "expression")
+
+    def __init__(self, variable, expression, token=None):
+        super().__init__(token=token)
+        self.variable = variable
+        self.expression = expression
+
+
+class RsetStatementNode(StatementNode):
+    __slots__ = ("variable", "expression")
+
+    def __init__(self, variable, expression, token=None):
+        super().__init__(token=token)
+        self.variable = variable
+        self.expression = expression
+
+
+class FieldStatementNode(StatementNode):
+    __slots__ = ("file_number", "fields")
+
+    def __init__(self, file_number, fields, token=None):
+        super().__init__(token=token)
+        self.file_number = file_number
+        self.fields = fields
+
+
+class GetStatementNode(StatementNode):
+    __slots__ = ("file_number", "record_number", "variables")
+
+    def __init__(self, file_number, record_number, variables, token=None):
+        super().__init__(token=token)
+        self.file_number = file_number
+        self.record_number = record_number
+        self.variables = variables
+
+
+class PutStatementNode(StatementNode):
+    __slots__ = ("file_number", "record_number", "variables")
+
+    def __init__(self, file_number, record_number, variables, token=None):
+        super().__init__(token=token)
+        self.file_number = file_number
+        self.record_number = record_number
+        self.variables = variables
+
+
+
+class PokeStatementNode(StatementNode):
+    __slots__ = ("address", "value")
+
+    def __init__(self, address, value, token=None):
+        super().__init__(token=token)
+        self.address = address
+        self.value = value
+
+
+class OutStatementNode(StatementNode):
+    __slots__ = ("port", "value")
+
+    def __init__(self, port, value, token=None):
+        super().__init__(token=token)
+        self.port = port
+        self.value = value
+
+
+class WaitStatementNode(StatementNode):
+    __slots__ = ("port", "and_value", "xor_value")
+
+    def __init__(self, port, and_value, xor_value, token=None):
+        super().__init__(token=token)
+        self.port = port
+        self.and_value = and_value
+        self.xor_value = xor_value
+
+
+class CallStatementNode(StatementNode):
+    __slots__ = ("address", "args")
+
+    def __init__(self, address, args, token=None):
+        super().__init__(token=token)
+        self.address = address
+        self.args = args
+
+
+class WidthStatementNode(StatementNode):
+    __slots__ = ("width",)
+
+    def __init__(self, width, token=None):
+        super().__init__(token=token)
+        self.width = width
+
+
+class RandomizeStatementNode(StatementNode):
+    __slots__ = ("seed",)
+
+    def __init__(self, seed=None, token=None):
+        super().__init__(token=token)
+        self.seed = seed
+
+
+class RemarkStatementNode(StatementNode):
+    __slots__ = ("text",)
+
+    def __init__(self, text, token=None):
+        super().__init__(token=token)
+        self.text = text
+
+
+class UnsupportedStatementNode(StatementNode):
+    """A statement that parsed but this port cannot execute (e.g. CHAIN)."""
+
+    __slots__ = ("statement_type", "text")
+
+    def __init__(self, statement_type, text="", token=None):
+        super().__init__(token=token)
+        self.statement_type = statement_type
+        self.text = text
+
+
+
+class SubStatementNode(StatementNode):
+    """A SUB definition; its body is flattened into the program by the runtime.
+    In the flat statement list this node is the start marker."""
+
+    __slots__ = ("name", "params", "body")
+
+    def __init__(self, name, params, body=None, token=None):
+        super().__init__(token=token)
+        self.name = name
+        self.params = params
+        self.body = body if body is not None else []
+
+
+class EndSubStatementNode(StatementNode):
+    __slots__ = ("name",)
+
+    def __init__(self, name="", token=None):
+        super().__init__(token=token)
+        self.name = name
+
+class FunctionStatementNode(StatementNode):
+    """A FUNCTION definition; body is flattened into the program."""
+
+    __slots__ = ("name", "params", "body", "return_type")
+
+    def __init__(self, name, params, body=None, token=None,
+                 return_type=None):
+        super().__init__(token=token)
+        self.name = name
+        self.params = params
+        self.body = body if body is not None else []
+        self.return_type = return_type
+
+
+class EndFunctionStatementNode(StatementNode):
+    __slots__ = ("name",)
+
+    def __init__(self, name="", token=None):
+        super().__init__(token=token)
+        self.name = name
+
+
+class ExitSubStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class SubCallStatementNode(StatementNode):
+    __slots__ = ("name", "args")
+
+    def __init__(self, name, args, token=None):
+        super().__init__(token=token)
+        self.name = name
+        self.args = args
+
+
+class LocalStatementNode(StatementNode):
+    __slots__ = ("names", "inits")
+
+    def __init__(self, names, inits=None, token=None):
+        super().__init__(token=token)
+        self.names = names
+        self.inits = inits if inits is not None else [None] * len(names)
+
+
+class DoLoopStatementNode(StatementNode):
+    """DO ... LOOP container; the runtime flattens it into a Do marker,
+    the body and a Loop marker."""
+
+    __slots__ = ("do_cond", "do_until", "loop_cond", "loop_until", "body")
+
+    def __init__(self, do_cond, do_until, loop_cond, loop_until, body,
+                 token=None):
+        super().__init__(token=token)
+        self.do_cond = do_cond
+        self.do_until = do_until
+        self.loop_cond = loop_cond
+        self.loop_until = loop_until
+        self.body = body if body is not None else []
+
+
+class DoStatementNode(StatementNode):
+    """DO marker in the flattened statement list."""
+
+    __slots__ = ("condition", "until")
+
+    def __init__(self, condition=None, until=False, token=None):
+        super().__init__(token=token)
+        self.condition = condition
+        self.until = until
+
+
+class LoopStatementNode(StatementNode):
+    """LOOP marker in the flattened statement list."""
+
+    __slots__ = ("condition", "until")
+
+    def __init__(self, condition=None, until=False, token=None):
+        super().__init__(token=token)
+        self.condition = condition
+        self.until = until
+
+
+class ExitDoStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class ExitForStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class ExitFunctionStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class SelectStatementNode(StatementNode):
+    """SELECT CASE expr ... END SELECT. cases is a list of CaseClauseNode."""
+
+    __slots__ = ("expression", "cases")
+
+    def __init__(self, expression, cases, token=None):
+        super().__init__(token=token)
+        self.expression = expression
+        self.cases = cases
+
+
+class CaseClauseNode(_Node):
+    __slots__ = ("values", "ranges", "is_else", "statements")
+
+    def __init__(self, values, is_else, statements, ranges=None, token=None):
+        super().__init__(token=token)
+        self.values = values
+        self.ranges = ranges if ranges is not None else []
+        self.is_else = is_else
+        self.statements = statements
+
+
+class ConstStatementNode(StatementNode):
+    """CONST name = expr [, name = expr] ... entries is [(name, expr)]."""
+
+    __slots__ = ("entries",)
+
+    def __init__(self, entries, token=None):
+        super().__init__(token=token)
+        self.entries = entries
+
+
+class OptionStatementNode(StatementNode):
+    __slots__ = ("kind", "value")
+
+    def __init__(self, kind, value, token=None):
+        super().__init__(token=token)
+        self.kind = kind      # 'base' | 'default' | 'angle' | 'explicit'
+        self.value = value
+
+
+class LabelNode(StatementNode):
+    """A named label (BRUSH:, putd:, l1:) or bare-number label."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name, token=None):
+        super().__init__(token=token)
+        self.name = name
+
+
+class BlockIfStatementNode(StatementNode):
+    """Multi-line IF ... THEN ... [ELSEIF cond THEN ...] [ELSE ...] END IF.
+    branches is a list of (condition_or_None, statements)."""
+
+    __slots__ = ("branches",)
+
+    def __init__(self, branches, token=None):
+        super().__init__(token=token)
+        self.branches = branches
+
+
+class EndIfStatementNode(StatementNode):
+    __slots__ = ()
+
+
+class EndSelectStatementNode(StatementNode):
+    __slots__ = ()
+
+
+
+class PixelStatementNode(StatementNode):
+    __slots__ = ("x", "y", "color")
+
+    def __init__(self, x, y, color=None, token=None):
+        super().__init__(token=token)
+        self.x = x
+        self.y = y
+        self.color = color
+
+
+class LineStatementNode(StatementNode):
+    __slots__ = ("x1", "y1", "x2", "y2", "thickness", "color")
+
+    def __init__(self, x1, y1, x2, y2, thickness=None, color=None, token=None):
+        super().__init__(token=token)
+        self.x1 = x1
+        self.y1 = y1
+        self.x2 = x2
+        self.y2 = y2
+        self.thickness = thickness
+        self.color = color
+
+
+class BoxStatementNode(StatementNode):
+    __slots__ = ("x", "y", "w", "h", "thickness", "outline", "fill")
+
+    def __init__(self, x, y, w, h, thickness=None, outline=None, fill=None,
+                 token=None):
+        super().__init__(token=token)
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+        self.thickness = thickness
+        self.outline = outline
+        self.fill = fill
+
+
+class CircleStatementNode(StatementNode):
+    __slots__ = ("x", "y", "r", "args")
+
+    def __init__(self, x, y, r, args, token=None):
+        super().__init__(token=token)
+        self.x = x
+        self.y = y
+        self.r = r
+        self.args = args
+
+
+class PolygonStatementNode(StatementNode):
+    __slots__ = ("xs", "ys", "outline", "fill")
+
+    def __init__(self, xs, ys, outline=None, fill=None, token=None):
+        super().__init__(token=token)
+        self.xs = xs
+        self.ys = ys
+        self.outline = outline
+        self.fill = fill
+
+
+class CopyStatementNode(StatementNode):
+    __slots__ = ("source", "dest")
+
+    def __init__(self, source, dest, token=None):
+        super().__init__(token=token)
+        self.source = source
+        self.dest = dest
+
+
+class SortStatementNode(StatementNode):
+    __slots__ = ("array", "args")
+
+    def __init__(self, array, args=None, token=None):
+        super().__init__(token=token)
+        self.array = array
+        self.args = args if args is not None else []
+
+
+class MkdirStatementNode(StatementNode):
+    __slots__ = ("path",)
+
+    def __init__(self, path, token=None):
+        super().__init__(token=token)
+        self.path = path
+
+
+class ChdirStatementNode(StatementNode):
+    __slots__ = ("path",)
+
+    def __init__(self, path, token=None):
+        super().__init__(token=token)
+        self.path = path
+
+
+class ColorStatementNode(StatementNode):
+    __slots__ = ("color", "background")
+
+    def __init__(self, color, background=None, token=None):
+        super().__init__(token=token)
+        self.color = color
+        self.background = background
+
+
+class TextStatementNode(StatementNode):
+    __slots__ = ("x", "y", "text")
+
+    def __init__(self, x, y, text, token=None):
+        super().__init__(token=token)
+        self.x = x
+        self.y = y
+        self.text = text
+
+
+class FrameBufferStatementNode(StatementNode):
+    __slots__ = ("sub", "args")
+
+    def __init__(self, sub, args, token=None):
+        super().__init__(token=token)
+        self.sub = sub
+        self.args = args
+
+
+class TurtleStatementNode(StatementNode):
+    __slots__ = ("sub", "args")
+
+    def __init__(self, sub, args, token=None):
+        super().__init__(token=token)
+        self.sub = sub
+        self.args = args
+
+
+class SaveImageStatementNode(StatementNode):
+    __slots__ = ("filename",)
+
+    def __init__(self, filename, token=None):
+        super().__init__(token=token)
+        self.filename = filename
+
+
+class LayerStatementNode(StatementNode):
+    __slots__ = ("args",)
+
+    def __init__(self, args, token=None):
+        super().__init__(token=token)
+        self.args = args
+
+
+
+class DimDeclNode(_Node):
+    __slots__ = ("name", "dims", "init", "init_list", "type_name")
+
+    def __init__(self, name, dims=None, init=None, init_list=None,
+                 type_name=None, token=None):
+        super().__init__(token=token)
+        self.name = name
+        self.dims = dims if dims is not None else []
+        self.init = init
+        self.init_list = init_list
+        self.type_name = type_name
+
+
+
+class ExpressionNode(_Node):
+    __slots__ = ()
+
+
+class NumberNode(ExpressionNode):
+    __slots__ = ("value", "literal_text", "suffix")
+
+    def __init__(self, value, token=None, literal_text=None, suffix=None):
+        super().__init__(token=token)
+        self.value = value
+        self.literal_text = literal_text if literal_text is not None else ""
+        self.suffix = suffix
+
+
+class StringNode(ExpressionNode):
+    __slots__ = ("value",)
+
+    def __init__(self, value, token=None):
+        super().__init__(token=token)
+        self.value = value
+
+
+class VariableNode(ExpressionNode):
+    """A variable reference; `indices` is a list of dimension expressions."""
+
+    __slots__ = ("name", "indices", "is_array")
+
+    def __init__(self, name, indices=None, token=None):
+        super().__init__(token=token)
+        self.name = name
+        self.indices = indices if indices is not None else []
+        self.is_array = len(self.indices) > 0
+
+    @property
+    def type_suffix(self):
+        if self.name and self.name[-1] in "$%!#":
+            return self.name[-1]
+        return None
+
+
+class BinaryOpNode(ExpressionNode):
+    __slots__ = ("left", "op", "right")
+
+    def __init__(self, left, op, right, token=None):
+        super().__init__(token=token)
+        self.left = left
+        self.op = op
+        self.right = right
+
+
+class UnaryOpNode(ExpressionNode):
+    __slots__ = ("op", "operand")
+
+    def __init__(self, op, operand, token=None):
+        super().__init__(token=token)
+        self.op = op
+        self.operand = operand
+
+
+class FunctionCallNode(ExpressionNode):
+    __slots__ = ("name", "args", "is_string")
+
+    def __init__(self, name, args, is_string=False, token=None):
+        super().__init__(token=token)
+        self.name = name
+        self.args = args
+        self.is_string = is_string
+
+
+class LabelRefNode(ExpressionNode):
+    """A GOTO/GOSUB target that is a label name rather than a line number."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name, token=None):
+        super().__init__(token=token)
+        self.name = name
+
+
+class ArrayRefNode(ExpressionNode):
+    """A whole-array reference `name()` (used by POLYGON and SUB args)."""
+
+    __slots__ = ("name",)
+
+    def __init__(self, name, token=None):
+        super().__init__(token=token)
+        self.name = name

--- a/simulator/hardware/mmbasic_runtime/number.py
+++ b/simulator/hardware/mmbasic_runtime/number.py
@@ -1,0 +1,158 @@
+from micropython import const
+import math
+import struct
+
+#: Significant figures MBASIC keeps for each precision. None means the value
+#: is INTEGER-typed and prints as a plain whole number.
+INTEGER_DIGITS = const(None)
+SINGLE_DIGITS = const(6)
+DOUBLE_DIGITS = const(16)
+
+def _round_half_away(x):
+    """Round a float to the nearest integer, halves away from zero."""
+    if x >= 0:
+        return math.floor(x + 0.5)
+    return -math.floor(-x + 0.5)
+
+
+def _round_to_digits(value, digits):
+    """Round a positive value to `digits` significant figures (half away)."""
+    if value == 0:
+        return 0.0
+    exp = math.floor(math.log10(value))
+    factor = 10.0 ** (digits - 1 - exp)
+    r = _round_half_away(value * factor) / factor
+    # Rounding may carry into the next power of ten (999 -> 1000).
+    if r > 0 and math.floor(math.log10(r)) != exp:
+        exp2 = math.floor(math.log10(r))
+        factor2 = 10.0 ** (digits - 1 - exp2)
+        r = _round_half_away(value * factor2) / factor2
+    return r
+
+
+def _significant_digits(rounded, exponent, digits):
+    """How many significant figures a rounded value actually carries."""
+    ndec = max(digits - 1 - exponent, 0)
+    text = ("%.*f" % (ndec, rounded)).rstrip("0").rstrip(".")
+    s = text.lstrip("-")
+    if "." in s:
+        s = s.replace(".", "")
+    return len(s.lstrip("0")) if s.lstrip("0") else 1
+
+
+def _unscaled(rounded, ndec):
+    """Plain decimal notation: no leading zero, no trailing zeros."""
+    text = ("%.*f" % (ndec, rounded)).rstrip("0").rstrip(".")
+    if text.startswith("0."):
+        text = text[1:]  # .5, not 0.5
+    return text or "0"
+
+
+def _scaled(rounded, digits):
+    """Exponential notation, MBASIC style: 1E+06, 1.23457E+06, 1.5D-08."""
+    exponent = math.floor(math.log10(rounded))
+    mantissa = rounded / (10.0 ** exponent)
+    text = ("%.*f" % (digits - 1, mantissa)).rstrip("0").rstrip(".")
+    letter = "D" if digits > SINGLE_DIGITS else "E"
+    sign = "+" if exponent >= 0 else "-"
+    return "%s%c%s%02d" % (text, letter, sign, abs(exponent))
+
+
+def format_number(value, digits=SINGLE_DIGITS):
+    """The characters MBASIC prints for a number, without the padding spaces.
+
+    Args:
+        value: an int or float.
+        digits: significant figures - SINGLE_DIGITS or DOUBLE_DIGITS, or None
+            for an INTEGER-typed value.
+
+    Returns:
+        str, e.g. "3934.03", ".333333", "1E+06", "-1.23457E+06".
+    """
+    if isinstance(value, bool):
+        value = int(value)
+
+    if digits is None:
+        return str(int(value))
+
+    try:
+        if value in (float("inf"), float("-inf")):
+            return str(value)
+    except (TypeError, ValueError):
+        return str(value)
+
+    if value == 0:
+        return "0"
+
+    negative = value < 0
+    rounded = _round_to_digits(abs(value), digits)
+    exponent = math.floor(math.log10(rounded))
+    significant = _significant_digits(rounded, exponent, digits)
+
+    if exponent >= 0:
+        unscaled = (exponent + 1) <= digits
+    else:
+        unscaled = (-exponent - 1) + significant <= digits + 1
+
+    if unscaled:
+        ndec = max(digits - 1 - exponent, 0)
+        text = _unscaled(rounded, ndec)
+    else:
+        text = _scaled(rounded, digits)
+    return "-" + text if negative else text
+
+
+def format_for_print(value, digits=SINGLE_DIGITS):
+    """As printed in a PRINT list: a leading space unless negative, and a
+    trailing space always.
+
+        PRINT 1;2;-3      ->  " 1  2 -3 "
+    """
+    text = format_number(value, digits)
+    if not text.startswith("-"):
+        text = " " + text
+    return text + " "
+
+
+def to_single(value):
+    """Round to MBASIC single precision (a round trip through float32)."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return value
+    try:
+        return struct.unpack("f", struct.pack("f", value))[0]
+    except (OverflowError, struct.error, ValueError):
+        return value
+
+
+def to_integer(value):
+    """Round to MBASIC's integer type: nearest, with halves away from zero.
+
+    A% = 3.7 is 4 and A% = -3.7 is -4. A% = 2.5 is 3, so it is not Python's
+    banker's rounding either.
+    """
+    if isinstance(value, str):
+        raise TypeError("Type mismatch")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return value
+    if isinstance(value, int):
+        return value
+    return _round_half_away(value)
+
+
+def coerce_to_type(value, suffix):
+    """Store a value the way a variable of this type would hold it."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        if suffix in ("%", "!", "#", None):
+            raise TypeError("Type mismatch")
+        return value
+    if not isinstance(value, (int, float)):
+        return value
+    if suffix == "%":
+        return to_integer(value)
+    if suffix == "#":
+        return float(value)
+    if suffix in ("!", None):
+        return to_single(value)
+    return value

--- a/simulator/hardware/mmbasic_runtime/parser.py
+++ b/simulator/hardware/mmbasic_runtime/parser.py
@@ -1,0 +1,1990 @@
+import math
+from .tokens import TokenType
+from . import nodes as nodes
+
+
+class ParseError(Exception):
+    """Exception raised for parse errors."""
+
+    def __init__(self, message, token=None):
+        if token is not None:
+            super().__init__("Parse error at %d:%d: %s" %
+                             (token.line, token.column, message))
+            self.line = token.line
+            self.column = token.column
+        else:
+            super().__init__("Parse error: %s" % message)
+            self.line = 0
+            self.column = 0
+
+
+#: TokenType -> (function name, is_string_return)
+BUILTIN_FUNCTIONS = {
+    TokenType.ABS: ("abs", False), TokenType.ATN: ("atn", False),
+    TokenType.ATAN2: ("atan2", False),
+    TokenType.CDBL: ("cdbl", False), TokenType.CINT: ("cint", False),
+    TokenType.COS: ("cos", False), TokenType.CSNG: ("csng", False),
+    TokenType.CVD: ("cvd", False), TokenType.CVI: ("cvi", False),
+    TokenType.CVS: ("cvs", False), TokenType.EXP: ("exp", False),
+    TokenType.FIX: ("fix", False), TokenType.INT: ("int", False),
+    TokenType.LOG: ("log", False), TokenType.RND: ("rnd", False),
+    TokenType.SGN: ("sgn", False), TokenType.SIN: ("sin", False),
+    TokenType.SQR: ("sqr", False), TokenType.TAN: ("tan", False),
+    TokenType.PEEK: ("peek", False), TokenType.POS: ("pos", False),
+    TokenType.FRE: ("fre", False), TokenType.ERR: ("err", False),
+    TokenType.ERL: ("erl", False), TokenType.INP: ("inp", False),
+    TokenType.LOC: ("loc", False), TokenType.LOF: ("lof", False),
+    TokenType.EOF_FUNC: ("eof", False), TokenType.USR: ("usr", False),
+    TokenType.VARPTR: ("varptr", False),
+    TokenType.ASC: ("asc", False), TokenType.CHR: ("chr$", True),
+    TokenType.EVAL: ("eval", False),
+    TokenType.HEX: ("hex$", True), TokenType.INKEY: ("inkey$", True),
+    TokenType.INPUT_FUNC: ("input$", True), TokenType.INSTR: ("instr", False),
+    TokenType.LEFT: ("left$", True), TokenType.LEN: ("len", False),
+    TokenType.MID: ("mid$", True), TokenType.MKD: ("mkd$", True),
+    TokenType.MKI: ("mki$", True), TokenType.MKS: ("mks$", True),
+    TokenType.OCT: ("oct$", True), TokenType.RIGHT: ("right$", True),
+    TokenType.SPACE: ("space$", True), TokenType.STR: ("str$", True),
+    TokenType.STRING_FUNC: ("string$", True), TokenType.TIME: ("time$", True),
+    TokenType.VAL: ("val", False),
+    TokenType.TAB: ("tab", False), TokenType.SPC: ("spc", False),
+    TokenType.RGB: ("rgb", False), TokenType.CHOICE: ("choice", False),
+}
+
+#: Function keywords that may be called without parentheses (INKEY$, RND...).
+_ZERO_ARG_FUNCS = frozenset((
+    TokenType.INKEY, TokenType.RND, TokenType.ERR, TokenType.ERL,
+    TokenType.FRE, TokenType.POS, TokenType.USR, TokenType.EOF_FUNC,
+    TokenType.TIME,
+))
+
+
+#: Builtin functions that lex as plain IDENTIFIERs (not keyword tokens).
+#: key = identifier (lowercase, without a trailing '$'); value = call name.
+IDENTIFIER_FUNCTIONS = {
+    "ucase": "ucase$",
+    "lcase": "lcase$",
+    "dir": "dir$",
+    "inputstring": "inputstring$",
+    "epoch": "epoch",
+    "datetime": "datetime$",
+    "day": "day$",
+    "now": "now",
+    "today": "today$",
+}
+
+
+#: Editor/immediate-mode commands that make no sense on a handheld, but which
+#: the parser still consumes gracefully so real MBASIC programs never crash it.
+UNSUPPORTED_STATEMENTS = {
+    TokenType.AUTO: "AUTO", TokenType.CONT: "CONT", TokenType.DELETE: "DELETE",
+    TokenType.EDIT: "EDIT", TokenType.FILES: "FILES", TokenType.LIST: "LIST",
+    TokenType.LLIST: "LLIST", TokenType.LOAD: "LOAD", TokenType.MERGE: "MERGE",
+    TokenType.NEW: "NEW", TokenType.RENUM: "RENUM", TokenType.RUN: "RUN",
+    TokenType.SAVE: "SAVE", TokenType.CHAIN: "CHAIN", TokenType.HELP: "HELP",
+    TokenType.SYSTEM: "SYSTEM",
+}
+
+
+def create_default_def_type_map():
+    """Default DEF type map (all SINGLE precision)."""
+    return {letter: "single" for letter in "abcdefghijklmnopqrstuvwxyz"}
+
+
+class Parser:
+    """Parses a token stream into a ProgramNode AST."""
+
+    __slots__ = ("tokens", "pos", "source", "def_type_map", "keyword_case_manager",
+                 "line_index", "_source_lines", "_in_print_items",
+                 "_user_functions")
+
+    def __init__(self, tokens, def_type_map=None, source="", keyword_case_manager=None):
+        self.tokens = tokens
+        self.pos = 0
+        self.source = source
+        self.def_type_map = def_type_map or create_default_def_type_map()
+        self.keyword_case_manager = keyword_case_manager
+        self.line_index = {}  # line_num -> LineNode (filled by parse_program)
+        self._source_lines = None
+        self._in_print_items = False  # suppresses implicit multiplication in PRINT
+        self._user_functions = set()
+        for i, t in enumerate(tokens):
+            if t.type == TokenType.FUNCTION:
+                j = i + 1
+                while j < len(tokens) and tokens[j].type in (
+                        TokenType.NEWLINE, TokenType.COLON, TokenType.EOF):
+                    j += 1
+                if j < len(tokens) and isinstance(tokens[j].value, str):
+                    self._user_functions.add(tokens[j].value.lower())
+
+
+    def current(self):
+        return self.tokens[self.pos]
+
+    def peek(self, offset=1):
+        idx = self.pos + offset
+        if idx >= len(self.tokens):
+            return self.tokens[-1]
+        return self.tokens[idx]
+
+    def advance(self):
+        token = self.tokens[self.pos]
+        if self.pos < len(self.tokens) - 1:
+            self.pos += 1
+        return token
+
+    def at(self, type_):
+        return self.current().type == type_
+
+    def at_any(self, types):
+        return self.current().type in types
+
+    def match(self, type_):
+        if self.at(type_):
+            return self.advance()
+        return None
+
+    def expect(self, type_, message=None):
+        if self.at(type_):
+            return self.advance()
+        if message is None:
+            message = "Expected %s but found %s" % (type_, self.current().type)
+        raise ParseError(message, self.current())
+
+    def at_statement_end(self):
+        # APOSTROPHE: a comment always extends to end of line, so it ends the
+        # current statement (e.g. `FRAMEBUFFER LAYER RGB(BLACK) ' note`).
+        return self.at_any((TokenType.NEWLINE, TokenType.COLON,
+                            TokenType.ELSE, TokenType.APOSTROPHE,
+                            TokenType.EOF))
+
+
+    def parse_program(self):
+        program = nodes.ProgramNode()
+        while not self.at(TokenType.EOF):
+            line = self.parse_line()
+            if line is not None:
+                if line.line_num is not None and line.line_num >= 0:
+                    program.add_line(line)
+                else:
+                    # Unnumbered line (no explicit line number): give it the
+                    # next sequential number so it participates in the program.
+                    program.lines[program.highest_line() + 1] = line
+                    program.order = sorted(program.lines.keys())
+        return program
+
+    def parse_line(self):
+        line_num = None
+        if self.at(TokenType.LINE_NUMBER):
+            line_num = self.advance().value
+        elif self.at(TokenType.NEWLINE) or self.at(TokenType.EOF):
+            self.match(TokenType.NEWLINE)
+            return None
+
+        statements = []
+        # Skip empty statements (e.g. a stray ':').
+        while self.at(TokenType.COLON):
+            self.advance()
+        while not self.at_any((TokenType.NEWLINE, TokenType.EOF)):
+            stmt = self.parse_statement()
+            if stmt is not None:
+                statements.append(stmt)
+            if self.match(TokenType.COLON):
+                while self.at(TokenType.COLON):
+                    self.advance()
+                continue
+            break
+
+        self.match(TokenType.NEWLINE)
+
+        text = self._line_text(line_num)
+        return nodes.LineNode(line_num if line_num is not None else -1,
+                              statements, text)
+
+    def _line_text(self, line_num):
+        if not self.source:
+            return ""
+        try:
+            if self._source_lines is None:
+                self._source_lines = self.source.split("\n")
+            if 1 <= line_num <= len(self._source_lines):
+                return self._source_lines[line_num - 1].strip()
+        except Exception:
+            pass
+        return ""
+
+
+    def parse_statement(self):
+        token = self.current()
+        type_ = token.type
+
+        if type_ in (TokenType.NEWLINE, TokenType.EOF, TokenType.ELSE,
+                     TokenType.THEN):
+            raise ParseError("Unexpected %s" % type_, token)
+
+        if type_ == TokenType.PRINT:
+            return self.parse_print(self.advance())
+        if type_ == TokenType.QUESTION:
+            return self.parse_print(self.advance())
+        if type_ == TokenType.LPRINT:
+            return self.parse_lprint(self.advance())
+        if type_ == TokenType.INPUT:
+            return self.parse_input(self.advance())
+        if type_ == TokenType.LINE_INPUT:
+            if self.peek().type == TokenType.INPUT:
+                return self.parse_line_input(self.advance())
+            if self.peek().type == TokenType.EQUAL:
+                # `line` used as a variable name (PicoCalc BASIC files)
+                return self.parse_assignment(self.advance())
+            return self.parse_draw_line(self.advance())
+        if type_ == TokenType.SORT:
+            return self.parse_sort(self.advance())
+        if type_ == TokenType.LET:
+            return self.parse_assignment(self.advance())
+        if type_ == TokenType.IDENTIFIER:
+            return self.parse_identifier_statement(token)
+        if type_ == TokenType.MID:
+            return self.parse_assignment(token)
+        if type_ in (TokenType.ANGLE, TokenType.BASE) and \
+                self.peek().type == TokenType.EQUAL:
+            # `angle = ...` / `base = ...` (keywords used as variables)
+            return self.parse_assignment(token)
+        if type_ == TokenType.ENDIF:
+            # stray terminator (some programs have unbalanced EndIf): no-op
+            self.advance()
+            return nodes.EndIfStatementNode(token=token)
+        if type_ in BUILTIN_FUNCTIONS and self.peek().type == TokenType.EQUAL:
+            # A function keyword used as a variable name: `len = 80`
+            return self.parse_assignment(token)
+        if type_ == TokenType.IF:
+            return self.parse_if(self.advance())
+        if type_ == TokenType.FOR:
+            return self.parse_for(self.advance())
+        if type_ == TokenType.NEXT:
+            return self.parse_next(self.advance())
+        if type_ == TokenType.WHILE:
+            return self.parse_while(self.advance())
+        if type_ == TokenType.WEND:
+            self.advance()
+            return nodes.WendStatementNode(token=token)
+        if type_ == TokenType.GOTO:
+            return self.parse_goto(self.advance())
+        if type_ == TokenType.GOSUB:
+            return self.parse_gosub(self.advance())
+        if type_ == TokenType.RETURN:
+            self.advance()
+            return nodes.ReturnStatementNode(token=token)
+        if type_ == TokenType.ON:
+            return self.parse_on(self.advance())
+        if type_ == TokenType.DIM:
+            return self.parse_dim(self.advance())
+        if type_ == TokenType.ERASE:
+            return self.parse_erase(self.advance())
+        if type_ == TokenType.DEF:
+            return self.parse_def(self.advance())
+        if type_ == TokenType.DATA:
+            return self.parse_data(self.advance())
+        if type_ == TokenType.READ:
+            return self.parse_read(self.advance())
+        if type_ == TokenType.RESTORE:
+            return self.parse_restore(self.advance())
+        if type_ == TokenType.END:
+            # Handle END IF / END SELECT / END SUB / END FUNCTION before plain
+            # END so `End If` isn't split into END + IF.
+            nxt = self.peek().type
+            if nxt in (TokenType.IF, TokenType.SELECT, TokenType.SUB,
+                       TokenType.FUNCTION):
+                self.advance()
+                self.advance()
+                if nxt == TokenType.IF:
+                    return nodes.EndIfStatementNode(token=token)
+                if nxt == TokenType.SELECT:
+                    return nodes.EndSelectStatementNode(token=token)
+                if nxt == TokenType.SUB:
+                    return nodes.EndSubStatementNode(token=token)
+                return nodes.EndFunctionStatementNode(token=token)
+            self.advance()
+            return nodes.EndStatementNode(token=token)
+        if type_ == TokenType.STOP:
+            self.advance()
+            return nodes.StopStatementNode(token=token)
+        if type_ == TokenType.TRON:
+            self.advance()
+            return nodes.TronStatementNode(token=token)
+        if type_ == TokenType.TROFF:
+            self.advance()
+            return nodes.TroffStatementNode(token=token)
+        if type_ == TokenType.RANDOMIZE:
+            return self.parse_randomize(self.advance())
+        if type_ in (TokenType.REM, TokenType.REMARK):
+            return self.parse_remark(self.advance())
+        if type_ == TokenType.APOSTROPHE:
+            return self.parse_remark(self.advance())
+        if type_ == TokenType.SWAP:
+            return self.parse_swap(self.advance())
+        if type_ == TokenType.CLEAR:
+            self.advance()
+            return nodes.ClearStatementNode(token=token)
+        if type_ == TokenType.CLS:
+            self.advance()
+            color = None
+            if not self.at_statement_end():
+                color = self.parse_expression()
+                if self.match(TokenType.COMMA):
+                    # tolerate `CLS fg, bg` (some adapted programs)
+                    self.parse_expression()
+            return nodes.ClsStatementNode(color=color, token=token)
+        if type_ == TokenType.FONT:
+            self.advance()
+            size = self.parse_expression() if not self.at_statement_end() else None
+            return nodes.FontStatementNode(size, token=token)
+        if type_ == TokenType.OPTION:
+            return self.parse_option(self.advance())
+        if type_ == TokenType.WIDTH:
+            return self.parse_width(self.advance())
+        if type_ == TokenType.ERROR:
+            return self.parse_error(self.advance())
+        if type_ == TokenType.RESUME:
+            return self.parse_resume(self.advance())
+        if type_ == TokenType.COMMON:
+            return self.parse_common(self.advance())
+        if type_ == TokenType.POKE:
+            return self.parse_poke(self.advance())
+        if type_ == TokenType.OUT:
+            return self.parse_out(self.advance())
+        if type_ == TokenType.WAIT:
+            return self.parse_wait(self.advance())
+        if type_ == TokenType.CALL:
+            return self.parse_call(self.advance())
+        if type_ == TokenType.OPEN:
+            return self.parse_open(self.advance())
+        if type_ == TokenType.CLOSE:
+            return self.parse_close(self.advance())
+        if type_ == TokenType.KILL:
+            return self.parse_kill(self.advance())
+        if type_ == TokenType.MKDIR:
+            return self.parse_mkdir(self.advance())
+        if type_ == TokenType.CHDIR:
+            return self.parse_chdir(self.advance())
+        if type_ == TokenType.NAME:
+            return self.parse_name(self.advance())
+        if type_ == TokenType.RESET:
+            self.advance()
+            return nodes.ResetStatementNode(token=token)
+        if type_ == TokenType.LSET:
+            return self.parse_lset(self.advance())
+        if type_ == TokenType.RSET:
+            return self.parse_rset(self.advance())
+        if type_ == TokenType.FIELD:
+            return self.parse_field(self.advance())
+        if type_ == TokenType.GET:
+            return self.parse_get(self.advance())
+        if type_ == TokenType.PUT:
+            return self.parse_put(self.advance())
+        if type_ == TokenType.WRITE:
+            return self.parse_write(self.advance())
+
+        if type_ == TokenType.SUB:
+            return self.parse_sub(self.advance())
+        if type_ == TokenType.FUNCTION:
+            return self.parse_function(self.advance())
+        if type_ == TokenType.LOCAL:
+            return self.parse_local(self.advance())
+        if type_ == TokenType.CONST:
+            return self.parse_const(self.advance())
+        if type_ == TokenType.SELECT:
+            return self.parse_select(self.advance())
+        if type_ == TokenType.EXIT:
+            return self.parse_exit(self.advance())
+        if type_ == TokenType.DO:
+            return self.parse_do(self.advance())
+        if type_ == TokenType.PLAY:
+            return self.parse_play(self.advance())
+        if type_ == TokenType.PAUSE:
+            return self.parse_pause(self.advance())
+        if type_ == TokenType.OPTION:
+            return self.parse_option(self.advance())
+        if type_ == TokenType.DIM:
+            return self.parse_dim(self.advance())
+        if type_ == TokenType.FRAMEBUFFER:
+            return self.parse_framebuffer(self.advance())
+        if type_ == TokenType.LAYER:
+            return self.parse_layer(self.advance())
+        if type_ == TokenType.TURTLE:
+            return self.parse_turtle(self.advance())
+        if type_ == TokenType.COPY:
+            return self.parse_copy(self.advance())
+        if type_ == TokenType.PIXEL:
+            return self.parse_pixel(self.advance())
+        if type_ == TokenType.BOX:
+            return self.parse_box(self.advance())
+        if type_ == TokenType.CIRCLE:
+            return self.parse_circle(self.advance())
+        if type_ == TokenType.POLYGON:
+            return self.parse_polygon(self.advance())
+        if type_ == TokenType.COLOR:
+            return self.parse_color(self.advance())
+        if type_ == TokenType.TEXT:
+            return self.parse_text(self.advance())
+        if type_ == TokenType.SAVE:
+            if self.peek().type == TokenType.IMAGE:
+                self.advance()
+                self.advance()
+                filename = self.parse_expression()
+                # SAVE IMAGE file$ [, x1, y1, x2, y2]
+                while self.match(TokenType.COMMA):
+                    self.parse_expression()
+                return nodes.SaveImageStatementNode(filename, token=token)
+            self.advance()
+            text = self._consume_rest_of_statement()
+            return nodes.UnsupportedStatementNode("SAVE", text, token=token)
+
+        # END IF / END SELECT / END SUB terminators (no-op if seen stray)
+        if type_ == TokenType.END:
+            if self.peek().type == TokenType.IF:
+                self.advance()
+                self.advance()
+                return nodes.EndIfStatementNode(token=token)
+            if self.peek().type == TokenType.SELECT:
+                self.advance()
+                self.advance()
+                return nodes.EndSelectStatementNode(token=token)
+
+        # LOAD IMAGE/JPG/BMP "file" [,x,y] is a graphics command; no-op.
+        if type_ == TokenType.LOAD:
+            nxt = self.peek()
+            if nxt.type == TokenType.IMAGE or (
+                    nxt.type == TokenType.IDENTIFIER and
+                    nxt.value.lower() in ("jpg", "bmp", "png", "gif")):
+                self.advance()
+                self.advance()
+                while not self.at_statement_end():
+                    self.parse_expression()
+                    if not self.match(TokenType.COMMA):
+                        break
+                return nodes.RemarkStatementNode("", token=token)
+
+        if type_ in UNSUPPORTED_STATEMENTS:
+            name = UNSUPPORTED_STATEMENTS[type_]
+            self.advance()
+            text = self._consume_rest_of_statement()
+            return nodes.UnsupportedStatementNode(name, text, token=token)
+
+        raise ParseError("Unexpected token %s (%r)" % (type_, token.value), token)
+
+    def _consume_rest_of_statement(self):
+        """Consume tokens up to (not including) the next statement separator."""
+        parts = []
+        while not self.at_statement_end():
+            parts.append(self.advance().value)
+        return " ".join(str(p) for p in parts if p is not None)
+
+
+    def parse_print(self, print_token):
+        """PRINT [@(col,row[,size])] [USING fmt;] [expr {;|, expr}...]"""
+        file_number = None
+        position = None
+        if self.match(TokenType.HASH):
+            file_number = self.parse_expression()
+            self.match(TokenType.COMMA)
+
+        # MMBasic 6.x: PRINT @(col, row[, size]) positions the text cursor
+        # (in character cells) before the output.
+        if self.match(TokenType.AT):
+            self.expect(TokenType.LPAREN)
+            col = self.parse_expression()
+            self.expect(TokenType.COMMA)
+            row = self.parse_expression()
+            size = None
+            if self.match(TokenType.COMMA):
+                size = self.parse_expression()
+            self.expect(TokenType.RPAREN)
+            position = (col, row, size)
+
+        if self.match(TokenType.USING):
+            format_expr = self.parse_expression()
+            self.match(TokenType.SEMICOLON)
+            expressions, separators = self._parse_print_items()
+            return nodes.PrintUsingStatementNode(
+                format_expr, expressions, file_number, token=print_token)
+
+        expressions, separators = self._parse_print_items()
+        return nodes.PrintStatementNode(expressions, separators, file_number,
+                                        position, token=print_token)
+
+    def parse_play(self, play_token):
+        # PLAY TONE / PLAY STOP / PAUSE: audio is not wired up yet; no-op.
+        text = self._consume_rest_of_statement()
+        return nodes.RemarkStatementNode(text, token=play_token)
+
+    def parse_pause(self, pause_token):
+        text = self._consume_rest_of_statement()
+        return nodes.RemarkStatementNode(text, token=pause_token)
+
+    def _parse_print_items(self):
+        expressions = []
+        separators = []
+        # Tolerate a leading separator: `PRINT @(x,y);`  /  `PRINT ;`  just
+        # position the cursor with no output.
+        while self.at_any((TokenType.SEMICOLON, TokenType.COMMA)):
+            self.advance()
+        if self.at_statement_end():
+            return expressions, separators
+        # In a PRINT list an adjacent value means an implicit `;` separator,
+        # NOT multiplication, so disable implicit `*` while parsing items
+        # (`PRINT TAB(5) X$` must not become TAB(5)*X$).
+        saved = self._in_print_items
+        self._in_print_items = True
+        try:
+            while True:
+                expressions.append(self.parse_expression())
+                if self.at(TokenType.SEMICOLON):
+                    sep = ";"
+                    self.advance()
+                elif self.at(TokenType.COMMA):
+                    sep = ","
+                    self.advance()
+                elif self._implicit_print_sep():
+                    sep = ";"
+                else:
+                    sep = "\n"
+                separators.append(sep)
+                if sep == "\n":
+                    break
+                # Tolerate doubled separators: `PRINT a;;b`
+                while self.at_any((TokenType.SEMICOLON, TokenType.COMMA)):
+                    self.advance()
+                if self.at_statement_end():
+                    break
+        finally:
+            self._in_print_items = saved
+        return expressions, separators
+
+    def _implicit_print_sep(self):
+        t = self.current().type
+        return (t in (TokenType.STRING, TokenType.NUMBER, TokenType.IDENTIFIER,
+                      TokenType.PI, TokenType.LPAREN, TokenType.AT) or
+                t in BUILTIN_FUNCTIONS)
+
+    def parse_lprint(self, lprint_token):
+        expressions, separators = self._parse_print_items()
+        return nodes.LprintStatementNode(expressions, separators, token=lprint_token)
+
+    def parse_input(self, input_token):
+        """INPUT [;] [prompt {;|,}] var[, var...]   or   INPUT# file, var..."""
+        file_number = None
+        if self.match(TokenType.HASH):
+            file_number = self.parse_expression()
+            self.expect(TokenType.COMMA)
+
+        self.match(TokenType.SEMICOLON)  # suppress newline after prompt
+
+        prompt = None
+        if self.at(TokenType.STRING):
+            p = self.advance()
+            prompt = nodes.StringNode(p.value, token=p)
+            self.match(TokenType.SEMICOLON)
+            self.match(TokenType.COMMA)
+
+        variables = []
+        if not self.at_statement_end():
+            variables.append(self.parse_variable_reference())
+            while self.match(TokenType.COMMA):
+                variables.append(self.parse_variable_reference())
+        return nodes.InputStatementNode(variables, prompt, file_number,
+                                        is_line=False, token=input_token)
+
+    def parse_line_input(self, line_token):
+        """LINE INPUT [;] [prompt;] var$   or   LINE INPUT# file, var$"""
+        # The caller consumed the LINE keyword; consume the INPUT keyword.
+        self.match(TokenType.INPUT)
+        file_number = None
+        if self.match(TokenType.HASH):
+            file_number = self.parse_expression()
+            self.expect(TokenType.COMMA)
+        self.match(TokenType.SEMICOLON)
+        prompt = None
+        if self.at(TokenType.STRING):
+            p = self.advance()
+            prompt = nodes.StringNode(p.value, token=p)
+            self.match(TokenType.SEMICOLON)
+            self.match(TokenType.COMMA)
+        var = self.parse_variable_reference()
+        return nodes.LineInputStatementNode(var, prompt, file_number,
+                                            token=line_token)
+
+    def parse_assignment(self, start_token):
+        """LET var = expr | var(i) = expr | MID$(s, p[, n]) = expr"""
+        if self.at(TokenType.MID):
+            # MID$(stringvar, start[, len]) = expr
+            self.advance()
+            self.expect(TokenType.LPAREN)
+            target = self.parse_variable_reference()
+            self.expect(TokenType.COMMA)
+            start = self.parse_expression()
+            length = None
+            if self.match(TokenType.COMMA):
+                length = self.parse_expression()
+            self.expect(TokenType.RPAREN)
+            self.expect(TokenType.EQUAL)
+            expr = self.parse_expression()
+            return nodes.MidAssignmentStatementNode(
+                target, start, length, expr, token=start_token)
+
+        var = self.parse_variable_reference()
+        self.expect(TokenType.EQUAL, "Expected '=' in assignment")
+        chain = [var]
+        # Chained assignment: `A = B = C = expr` (PicoCalc BASIC sets all).
+        while self._at_chained_var():
+            chain.append(self.parse_variable_reference())
+            self.expect(TokenType.EQUAL)
+        expr = self.parse_expression()
+        if len(chain) > 1:
+            return nodes.ChainedAssignmentStatementNode(chain, expr,
+                                                        token=start_token)
+        return nodes.LetStatementNode(var, expr, token=start_token)
+
+    def _at_chained_var(self):
+        """True when the current token is a variable name followed by '='."""
+        t = self.current().type
+        if t not in (TokenType.IDENTIFIER, TokenType.FN, TokenType.LINE_INPUT,
+                     TokenType.BASE, TokenType.ANGLE):
+            return False
+        return self.peek().type == TokenType.EQUAL
+
+    def parse_if(self, if_token):
+        condition = self.parse_expression()
+
+        # tolerate a stray trailing ')' in some adapted programs
+        while self.at(TokenType.RPAREN):
+            self.advance()
+
+        if not self.at(TokenType.THEN):
+            if self.match(TokenType.GOTO):
+                return nodes.IfStatementNode(condition, [], [],
+                                             self._parse_line_target(), None,
+                                             token=if_token)
+            raise ParseError("Expected THEN or GOTO in IF statement",
+                             self.current())
+        self.advance()  # THEN
+
+        # `IF cond THEN 'comment` starts a block; skip trailing comments.
+        while self.at(TokenType.APOSTROPHE):
+            self.advance()
+
+        if self.at_statement_end():
+            # Block IF: IF cond THEN ... [ELSEIF ...] [ELSE ...] END IF
+            return self._parse_if_block(if_token, condition)
+
+        then_line = None
+        then_statements = []
+        if self.at(TokenType.NUMBER):
+            then_line = self.advance().value
+        elif self.at(TokenType.GOTO):
+            self.advance()
+            then_line = self._parse_line_target()
+        elif not self.at_statement_end():
+            then_statements = self._parse_statement_list()
+
+        else_line = None
+        else_statements = []
+        if self.match(TokenType.ELSE):
+            if self.at(TokenType.GOTO):
+                self.advance()
+                else_line = self._parse_line_target()
+            elif self.at(TokenType.NUMBER):
+                else_line = self.advance().value
+            elif not self.at_statement_end():
+                else_statements = self._parse_statement_list()
+
+        return nodes.IfStatementNode(condition, then_statements, else_statements,
+                                     then_line, else_line, token=if_token)
+
+    def _parse_if_block(self, if_token, first_cond):
+        def _at_end_if():
+            return (self.at(TokenType.END) and
+                    self.peek().type == TokenType.IF) or \
+                   self.at(TokenType.ENDIF)
+
+        stops = (TokenType.ELSEIF, TokenType.ELSE, TokenType.ENDIF,
+                 TokenType.LOOP)
+        branches = [(first_cond, self._collect_block(stops, _at_end_if))]
+        while True:
+            if self.at(TokenType.ELSEIF):
+                self.advance()
+                # tolerate a duplicated keyword: `ELSEIF if cond THEN`
+                while self.at(TokenType.IF):
+                    self.advance()
+                cond = self.parse_expression()
+                self.expect(TokenType.THEN)
+                body = self._collect_block(stops, _at_end_if)
+                branches.append((cond, body))
+                continue
+            if self.at(TokenType.ELSE):
+                # `ELSE IF cond THEN` means ELSEIF (Maximite/MMBasic
+                # convention, written with a space between the keywords).
+                if self.peek().type == TokenType.IF:
+                    self.advance()  # ELSE
+                    self.advance()  # IF
+                    # tolerate a duplicated keyword: `ELSE IF if cond THEN`
+                    while self.at(TokenType.IF):
+                        self.advance()
+                    cond = self.parse_expression()
+                    self.expect(TokenType.THEN)
+                    body = self._collect_block(stops, _at_end_if)
+                    branches.append((cond, body))
+                    continue
+                self.advance()
+                body = self._collect_block(stops, _at_end_if)
+                branches.append((None, body))
+                continue
+            if self.at(TokenType.LOOP):
+                break  # implicitly closed by the enclosing DO's Loop
+            if self.at(TokenType.END):
+                self.advance()
+                self.expect(TokenType.IF)
+            else:
+                self.advance()  # ENDIF
+            break
+        return nodes.BlockIfStatementNode(branches, token=if_token)
+
+    def _parse_line_target(self):
+        """A GOTO/GOSUB target: a line number, a label name, or an expression."""
+        while self.at_any((TokenType.GOTO, TokenType.GOSUB)):
+            self.advance()
+        if self.at(TokenType.IDENTIFIER):
+            tok = self.advance()
+            return nodes.LabelRefNode(tok.value, token=tok)
+        return self.parse_expression()
+
+    def _parse_statement_list(self):
+        """Collect statements until ELSE / NEWLINE / EOF, consuming ':'."""
+        statements = []
+        while not self.at_statement_end():
+            stmt = self.parse_statement()
+            if stmt is not None:
+                statements.append(stmt)
+            if self.match(TokenType.COLON):
+                while self.at(TokenType.COLON):
+                    self.advance()
+                continue
+            break
+        return statements
+
+    def parse_for(self, for_token):
+        var = self.parse_variable_reference()
+        # MMBasic 6.x: FOR var AS type = start TO end
+        if self.match(TokenType.AS):
+            self._take_name("type name")
+        self.expect(TokenType.EQUAL)
+        start = self.parse_expression()
+        self.expect(TokenType.TO)
+        end = self.parse_expression()
+        step = None
+        if self.match(TokenType.STEP):
+            step = self.parse_expression()
+        if step is None:
+            step = nodes.NumberNode(1)
+        return nodes.ForStatementNode(var, start, end, step, token=for_token)
+
+    def parse_next(self, next_token):
+        variables = []
+        if not self.at_statement_end():
+            variables.append(self.parse_variable_reference())
+            while self.match(TokenType.COMMA):
+                variables.append(self.parse_variable_reference())
+        return nodes.NextStatementNode(variables, token=next_token)
+
+    def parse_while(self, while_token):
+        condition = self.parse_expression()
+        return nodes.WhileStatementNode(condition, token=while_token)
+
+    def parse_goto(self, goto_token):
+        target = self._parse_line_target()
+        return nodes.GotoStatementNode(target, token=goto_token)
+
+    def parse_gosub(self, gosub_token):
+        target = self._parse_line_target()
+        return nodes.GosubStatementNode(target, token=gosub_token)
+
+    def parse_on(self, on_token):
+        if self.match(TokenType.ERROR):
+            if self.match(TokenType.GOTO):
+                target = self._parse_line_target()
+                return nodes.OnErrorStatementNode(target, token=on_token)
+            # MMBasic 6.x: ON ERROR IGNORE [n] / SKIP [n] / FIXED / CRITICAL
+            # / ABORT
+            if self.at(TokenType.IDENTIFIER) and \
+                    self.current().value in ("ignore", "skip", "fixed",
+                                             "critical", "abort"):
+                mode = self.advance().value
+                count = None
+                if mode in ("ignore", "skip") and self.at(TokenType.NUMBER):
+                    count = self.advance().value
+                if mode in ("ignore", "skip"):
+                    target = "IGNORE1" if count else "IGNORE"
+                else:
+                    target = None  # FIXED / CRITICAL / ABORT reset to default
+                return nodes.OnErrorStatementNode(target, token=on_token)
+            raise ParseError("Expected GOTO or IGNORE after ON ERROR",
+                             self.current())
+        expr = self.parse_expression()
+        if self.match(TokenType.GOTO):
+            targets = self._parse_line_number_list()
+            return nodes.OnGotoStatementNode(expr, targets, token=on_token)
+        if self.match(TokenType.GOSUB):
+            targets = self._parse_line_number_list()
+            return nodes.OnGosubStatementNode(expr, targets, token=on_token)
+        raise ParseError("Expected GOTO or GOSUB after ON expression",
+                         self.current())
+
+    def _parse_line_number_list(self):
+        targets = [self._parse_line_target()]
+        while self.match(TokenType.COMMA):
+            targets.append(self._parse_line_target())
+        return targets
+
+    def parse_dim(self, dim_token):
+        declarations = []
+        if self.at_statement_end():
+            raise ParseError("DIM requires at least one declaration",
+                             self.current())
+        stmt_type = None
+        if self.at(TokenType.IDENTIFIER) and \
+                self.current().value.lower() in self._TYPE_WORDS:
+            stmt_type = self.advance().value.lower()
+        # MMBasic 6.x: DIM AS <type> var, var
+        if self.match(TokenType.AS):
+            if self.at(TokenType.IDENTIFIER):
+                stmt_type = self.advance().value.lower()
+            else:
+                stmt_type = "single"
+        while True:
+            name_tok = self.expect(TokenType.IDENTIFIER)
+            dims = None
+            init = None
+            init_list = None
+            decl_type = stmt_type
+            if self.match(TokenType.LPAREN):
+                dims = [self.parse_expression()]
+                while self.match(TokenType.COMMA):
+                    dims.append(self.parse_expression())
+                self.expect(TokenType.RPAREN)
+            # MMBasic 6.x: per-variable `AS <type>` (each decl may have its own).
+            if self.match(TokenType.AS):
+                if self.at(TokenType.IDENTIFIER):
+                    decl_type = self.advance().value.lower()
+                else:
+                    decl_type = "single"
+            if self.match(TokenType.EQUAL):
+                if dims is not None and self.at(TokenType.LPAREN):
+                    # array initializer list: DIM a(5) = (1,2,3,4,5)
+                    self.advance()
+                    init_list = [self.parse_expression()]
+                    while self.match(TokenType.COMMA):
+                        init_list.append(self.parse_expression())
+                    self.expect(TokenType.RPAREN)
+                else:
+                    init = self.parse_expression()
+            declarations.append(nodes.DimDeclNode(name_tok.value, dims, init,
+                                                  init_list, decl_type,
+                                                  token=name_tok))
+            # MMBasic 6.x: `DIM a(10) LENGTH n` (fixed-length string arrays).
+            # `length` lexes as an IDENTIFIER; consume the clause and ignore.
+            if self.at(TokenType.IDENTIFIER) and \
+                    self.current().value.lower() == "length":
+                self.advance()
+                if not self.at_statement_end():
+                    self.parse_expression()
+            # tolerate a stray trailing ')' in some adapted programs
+            self.match(TokenType.RPAREN)
+            if not self.match(TokenType.COMMA):
+                break
+        return nodes.DimStatementNode(declarations, token=dim_token)
+
+    def parse_erase(self, erase_token):
+        variables = []
+        if not self.at_statement_end():
+            variables.append(self.parse_variable_reference())
+            while self.match(TokenType.COMMA):
+                variables.append(self.parse_variable_reference())
+        return nodes.EraseStatementNode(variables, token=erase_token)
+
+    @staticmethod
+    def _fn_canonical(name):
+        """Canonical user-function key: FNX and FN X are the same function."""
+        if name.startswith("fn"):
+            return "fn" + name[2:]
+        return "fn" + name
+
+    def parse_def(self, def_token):
+        # DEF FN name(params) = expr  |  DEFSNG/INT/DBL/STR letter[-letter], ...
+        if self.at(TokenType.FN):
+            self.advance()
+            return self._parse_deffn_body(def_token)
+        if self.at(TokenType.IDENTIFIER) and self.current().value.startswith("fn"):
+            # DEF FNX(...) - FN glued to the name
+            return self._parse_deffn_body(def_token)
+        if self.at(TokenType.DEFINT):
+            self.advance()
+            return self._parse_deftype_body(def_token, "integer")
+        if self.at(TokenType.DEFSNG):
+            self.advance()
+            return self._parse_deftype_body(def_token, "single")
+        if self.at(TokenType.DEFDBL):
+            self.advance()
+            return self._parse_deftype_body(def_token, "double")
+        if self.at(TokenType.DEFSTR):
+            self.advance()
+            return self._parse_deftype_body(def_token, "string")
+        raise ParseError("Expected DEF FN or DEF type statement", self.current())
+
+    def _parse_deffn_body(self, def_token):
+        name_token = self.expect(TokenType.IDENTIFIER)
+        name = self._fn_canonical(name_token.value)
+        params = []
+        if self.match(TokenType.LPAREN):
+            if not self.at(TokenType.RPAREN):
+                params.append(self.parse_variable_reference())
+                while self.match(TokenType.COMMA):
+                    params.append(self.parse_variable_reference())
+            self.expect(TokenType.RPAREN)
+        self.expect(TokenType.EQUAL)
+        body = self.parse_expression()
+        return nodes.DefFnStatementNode(name, params, body, token=def_token)
+
+    def _parse_deftype_body(self, def_token, type_name):
+        letters = []
+        if self.at_statement_end():
+            raise ParseError("DEF type requires letter range", self.current())
+        while True:
+            tok = self.expect(TokenType.IDENTIFIER)
+            if self.match(TokenType.MINUS):
+                tok2 = self.expect(TokenType.IDENTIFIER)
+                letters.append((tok.value, tok2.value))
+            else:
+                letters.append((tok.value, tok.value))
+            if not self.match(TokenType.COMMA):
+                break
+        return nodes.DefTypeStatementNode(letters, type_name, token=def_token)
+
+    def parse_data(self, data_token):
+        values = []
+        while not self.at_statement_end():
+            if self.at(TokenType.STRING):
+                tok = self.advance()
+                values.append((tok.value, True))
+            elif self.at(TokenType.NUMBER):
+                tok = self.advance()
+                values.append((tok.value, False))
+            elif self.at(TokenType.MINUS):
+                self.advance()
+                tok = self.expect(TokenType.NUMBER)
+                values.append((-tok.value, False))
+            elif self.at(TokenType.PLUS):
+                self.advance()
+                tok = self.expect(TokenType.NUMBER)
+                values.append((tok.value, False))
+            else:
+                # Unquoted string data (e.g. `bucket of water`): collect the
+                # words up to the next comma / end of statement as a string.
+                parts = [str(self.advance().value)]
+                while not self.at(TokenType.COMMA) and not self.at_statement_end():
+                    parts.append(str(self.advance().value))
+                values.append((" ".join(parts), True))
+            if not self.match(TokenType.COMMA):
+                break
+        return nodes.DataStatementNode(values, token=data_token)
+
+    def parse_read(self, read_token):
+        variables = []
+        if not self.at_statement_end():
+            variables.append(self.parse_variable_reference())
+            while self.match(TokenType.COMMA):
+                variables.append(self.parse_variable_reference())
+        return nodes.ReadStatementNode(variables, token=read_token)
+
+    def parse_restore(self, restore_token):
+        target = None
+        if self.at(TokenType.NUMBER):
+            target = self.advance().value
+        elif self.at(TokenType.IDENTIFIER):
+            target = self.advance().value  # label name (e.g. Restore BRUSH)
+        return nodes.RestoreStatementNode(target, token=restore_token)
+
+    def parse_randomize(self, rnd_token):
+        seed = None
+        if not self.at_statement_end():
+            seed = self.parse_expression()
+        return nodes.RandomizeStatementNode(seed, token=rnd_token)
+
+    def parse_remark(self, remark_token):
+        return nodes.RemarkStatementNode(remark_token.value, token=remark_token)
+
+    def parse_swap(self, swap_token):
+        v1 = self.parse_variable_reference()
+        self.expect(TokenType.COMMA)
+        v2 = self.parse_variable_reference()
+        return nodes.SwapStatementNode(v1, v2, token=swap_token)
+
+    _TYPE_WORDS = ("integer", "int", "single", "float", "double", "string",
+                   "long", "byte")
+
+    def parse_option(self, option_token):
+        if self.match(TokenType.BASE):
+            tok = self.expect(TokenType.NUMBER)
+            return nodes.OptionStatementNode("base", int(tok.value),
+                                             token=option_token)
+        if self.match(TokenType.DEFAULT):
+            if self.at(TokenType.IDENTIFIER):
+                type_name = self.advance().value.lower()
+            else:
+                type_name = "single"
+            return nodes.OptionStatementNode("default", type_name,
+                                             token=option_token)
+        if self.match(TokenType.ANGLE):
+            if self.match(TokenType.RADIANS):
+                return nodes.OptionStatementNode("angle", "radians",
+                                                 token=option_token)
+            if self.match(TokenType.DEGREES):
+                return nodes.OptionStatementNode("angle", "degrees",
+                                                 token=option_token)
+            if self.at(TokenType.IDENTIFIER):
+                return nodes.OptionStatementNode("angle",
+                                                 self.advance().value.lower(),
+                                                 token=option_token)
+            return nodes.OptionStatementNode("angle", "radians",
+                                             token=option_token)
+        if self.match(TokenType.EXPLICIT):
+            return nodes.OptionStatementNode("explicit", True,
+                                             token=option_token)
+        raise ParseError("Unknown OPTION", self.current())
+
+    def parse_width(self, width_token):
+        w = self.parse_expression()
+        return nodes.WidthStatementNode(w, token=width_token)
+
+    def parse_error(self, error_token):
+        code = None
+        if not self.at_statement_end():
+            code = self.parse_expression()
+        return nodes.ErrorStatementNode(code, token=error_token)
+
+    def parse_resume(self, resume_token):
+        target = None
+        if self.match(TokenType.NEXT):
+            target = "NEXT"
+        elif not self.at_statement_end():
+            target = self._parse_line_target()
+        return nodes.ResumeStatementNode(target, token=resume_token)
+
+    def parse_common(self, common_token):
+        variables = []
+        if not self.at_statement_end():
+            variables.append(self.parse_variable_reference())
+            while self.match(TokenType.COMMA):
+                variables.append(self.parse_variable_reference())
+        return nodes.CommonStatementNode(variables, token=common_token)
+
+    def parse_poke(self, poke_token):
+        address = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        value = self.parse_expression()
+        return nodes.PokeStatementNode(address, value, token=poke_token)
+
+    def parse_out(self, out_token):
+        port = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        value = self.parse_expression()
+        return nodes.OutStatementNode(port, value, token=out_token)
+
+    def parse_wait(self, wait_token):
+        port = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        and_value = self.parse_expression()
+        xor_value = None
+        if self.match(TokenType.COMMA):
+            xor_value = self.parse_expression()
+        return nodes.WaitStatementNode(port, and_value, xor_value,
+                                       token=wait_token)
+
+    def parse_call(self, call_token):
+        address = self.parse_expression()
+        args = []
+        if self.match(TokenType.LPAREN):
+            if not self.at(TokenType.RPAREN):
+                args.append(self.parse_expression())
+                while self.match(TokenType.COMMA):
+                    args.append(self.parse_expression())
+            self.expect(TokenType.RPAREN)
+        return nodes.CallStatementNode(address, args, token=call_token)
+
+
+    def parse_open(self, open_token):
+        # OPEN mode$, #fn, name$       (old style)
+        # OPEN name$ FOR INPUT|OUTPUT|APPEND|RANDOM AS #fn [LEN = n]
+        file_number = None
+        mode = None
+        filename = None
+        rec_length = None
+
+        if self.at(TokenType.STRING) and self.peek().type == TokenType.COMMA:
+            # old style: OPEN "O", #1, "FILE"
+            mode_tok = self.advance()
+            mode = mode_tok.value.strip().upper()[:1] or "I"
+            self.expect(TokenType.COMMA)
+            if self.match(TokenType.HASH):
+                file_number = self.parse_expression()
+            self.expect(TokenType.COMMA)
+            filename = self.parse_expression()
+        else:
+            filename = self.parse_expression()
+            self.expect(TokenType.FOR)
+            # FOR INPUT / OUTPUT are keywords; APPEND/RANDOM/BINARY arrive
+            # as bare identifiers in this tokenizer.
+            if self.match(TokenType.INPUT):
+                mode = "I"
+            elif self.match(TokenType.OUTPUT):
+                mode = "O"
+            elif self.at(TokenType.IDENTIFIER) and \
+                    self.current().value in ("append", "random", "binary"):
+                mode = {"append": "A", "random": "R", "binary": "B"}[
+                    self.advance().value]
+            else:
+                raise ParseError("Expected FOR INPUT/OUTPUT in OPEN",
+                                 self.current())
+            self.expect(TokenType.AS)
+            self.match(TokenType.HASH)
+            file_number = self.parse_expression()
+            if self.match(TokenType.LEN):
+                self.expect(TokenType.EQUAL)
+                rec_length = self.parse_expression()
+
+        return nodes.OpenStatementNode(file_number, mode, filename,
+                                       rec_length, token=open_token)
+
+    def parse_close(self, close_token):
+        file_numbers = []
+        if self.match(TokenType.HASH):
+            file_numbers.append(self.parse_expression())
+            while self.match(TokenType.COMMA):
+                self.match(TokenType.HASH)
+                file_numbers.append(self.parse_expression())
+        return nodes.CloseStatementNode(file_numbers, token=close_token)
+
+    def parse_kill(self, kill_token):
+        filename = self.parse_expression()
+        return nodes.KillStatementNode(filename, token=kill_token)
+
+    def parse_mkdir(self, mkdir_token):
+        path = self.parse_expression()
+        return nodes.MkdirStatementNode(path, token=mkdir_token)
+
+    def parse_chdir(self, chdir_token):
+        path = self.parse_expression()
+        return nodes.ChdirStatementNode(path, token=chdir_token)
+
+    def parse_name(self, name_token):
+        old_name = self.parse_expression()
+        self.expect(TokenType.AS)
+        new_name = self.parse_expression()
+        return nodes.NameStatementNode(old_name, new_name, token=name_token)
+
+    def parse_lset(self, lset_token):
+        var = self.parse_variable_reference()
+        self.expect(TokenType.EQUAL)
+        expr = self.parse_expression()
+        return nodes.LsetStatementNode(var, expr, token=lset_token)
+
+    def parse_rset(self, rset_token):
+        var = self.parse_variable_reference()
+        self.expect(TokenType.EQUAL)
+        expr = self.parse_expression()
+        return nodes.RsetStatementNode(var, expr, token=rset_token)
+
+    def parse_field(self, field_token):
+        self.match(TokenType.HASH)
+        file_number = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        fields = []
+        while True:
+            width = self.parse_expression()
+            self.expect(TokenType.AS)
+            var = self.parse_variable_reference()
+            fields.append((width, var))
+            if not self.match(TokenType.COMMA):
+                break
+        return nodes.FieldStatementNode(file_number, fields, token=field_token)
+
+    def parse_get(self, get_token):
+        self.match(TokenType.HASH)
+        file_number = self.parse_expression()
+        record_number = None
+        variables = []
+        if self.match(TokenType.COMMA):
+            if not self.at_statement_end():
+                record_number = self.parse_expression()
+                while self.match(TokenType.COMMA):
+                    variables.append(self.parse_variable_reference())
+        return nodes.GetStatementNode(file_number, record_number, variables,
+                                      token=get_token)
+
+    def parse_put(self, put_token):
+        self.match(TokenType.HASH)
+        file_number = self.parse_expression()
+        record_number = None
+        variables = []
+        if self.match(TokenType.COMMA):
+            if not self.at_statement_end():
+                record_number = self.parse_expression()
+                while self.match(TokenType.COMMA):
+                    variables.append(self.parse_variable_reference())
+        return nodes.PutStatementNode(file_number, record_number, variables,
+                                      token=put_token)
+
+    def parse_write(self, write_token):
+        file_number = None
+        if self.match(TokenType.HASH):
+            file_number = self.parse_expression()
+            self.match(TokenType.COMMA)
+        expressions = []
+        separators = []
+        if not self.at_statement_end():
+            while True:
+                expressions.append(self.parse_expression())
+                if self.at(TokenType.COMMA):
+                    sep = ","
+                elif self.at(TokenType.SEMICOLON):
+                    sep = ";"
+                else:
+                    sep = "\n"
+                separators.append(sep)
+                if sep == "\n":
+                    break
+                self.advance()
+                if self.at_statement_end():
+                    break
+        return nodes.WriteStatementNode(expressions, file_number, token=write_token)
+
+
+    def parse_identifier_statement(self, token):
+        """A statement that begins with an identifier."""
+        name = token.value
+
+        # CENTER / DRIVE commands (PicoCalc MMBasic extensions).
+        if name.lower() == "center":
+            self.advance()
+            text = None
+            if not self.at_statement_end():
+                text = self.parse_expression()
+                # tolerate `CENTER text, flags` (some adapted programs)
+                while self.match(TokenType.COMMA):
+                    self.parse_expression()
+            return nodes.CenterStatementNode(text, token=token)
+        if name.lower() == "drive":
+            self.advance()
+            path = None
+            if not self.at_statement_end():
+                path = self.parse_expression()
+            return nodes.DriveStatementNode(path, token=token)
+
+        nxt = self.peek().type
+
+        if nxt == TokenType.COLON:
+            self.advance()
+            self.advance()
+            return nodes.LabelNode(name, token=token)
+        if nxt == TokenType.EQUAL:
+            return self.parse_assignment(token)
+        if nxt in (TokenType.PLUS_EQUAL, TokenType.MINUS_EQUAL):
+            return self.parse_compound_assignment(token)
+        if nxt == TokenType.LPAREN:
+            if self._paren_followed_by_equals():
+                return self.parse_assignment(token)   # A(1)=5
+            return self.parse_sub_call(token, paren=True)
+        # bare identifier: SUB call without parentheses (Tree a, b) or no args
+        return self.parse_sub_call(token, paren=False)
+
+    def parse_compound_assignment(self, token):
+        """`a += expr` / `a -= expr` (PicoCalc BASIC extension)."""
+        var = self.parse_variable_reference()
+        op_tok = self.advance()  # PLUS_EQUAL / MINUS_EQUAL
+        expr = self.parse_expression()
+        op = "+" if op_tok.type == TokenType.PLUS_EQUAL else "-"
+        return nodes.LetStatementNode(
+            var, nodes.BinaryOpNode(nodes.VariableNode(var.name), op, expr),
+            token=token)
+
+    def _paren_followed_by_equals(self):
+        """True if the paren group starting at peek() closes right before '='."""
+        depth = 0
+        i = self.pos + 1
+        n = len(self.tokens)
+        while i < n:
+            t = self.tokens[i].type
+            if t == TokenType.LPAREN:
+                depth += 1
+            elif t == TokenType.RPAREN:
+                depth -= 1
+                if depth == 0:
+                    nxt = self.tokens[i + 1].type if i + 1 < n else TokenType.EOF
+                    return nxt == TokenType.EQUAL
+            elif t in (TokenType.EOF, TokenType.NEWLINE):
+                return False
+            i += 1
+        return False
+
+    def parse_sub_call(self, token, paren):
+        name = token.value
+        self.advance()  # consume the name token
+        args = []
+        if paren:
+            self.expect(TokenType.LPAREN)
+            if not self.at(TokenType.RPAREN):
+                args.append(self._arg_expression())
+                while self.match(TokenType.COMMA):
+                    args.append(self._arg_expression())
+            self.expect(TokenType.RPAREN)
+        else:
+            while not self.at_statement_end():
+                args.append(self._arg_expression())
+                if not self.match(TokenType.COMMA):
+                    break
+        return nodes.SubCallStatementNode(name, args, token=token)
+
+    def _skip_newlines(self):
+        while self.at(TokenType.NEWLINE) or self.at(TokenType.APOSTROPHE):
+            self.advance()
+            if self.at(TokenType.NEWLINE):
+                self.advance()
+
+    def _collect_block(self, stop_types, stop_pred=None):
+        """Collect statements until a stop token. Returns a list.
+
+        `stop_types` is a tuple of TokenTypes that end the block; `stop_pred`
+        is an optional callable(current) for extra stops (e.g. END+SUB).
+        """
+        statements = []
+        while True:
+            self._skip_newlines()
+            if self.at(TokenType.EOF):
+                raise ParseError("Missing block terminator", self.current())
+            if self.at_any(stop_types):
+                return statements
+            if stop_pred is not None and stop_pred():
+                return statements
+            if self.at(TokenType.LINE_NUMBER):
+                tok = self.advance()
+                statements.append(nodes.LabelNode(str(tok.value), token=tok))
+                self.match(TokenType.COLON)
+                continue
+            stmt = self.parse_statement()
+            if stmt is not None:
+                statements.append(stmt)
+            if self.match(TokenType.COLON):
+                while self.at(TokenType.COLON):
+                    self.advance()
+                continue
+
+    def _parse_param_list(self):
+        """Parse `(a, b As type, ...)` - returns a list of VariableNodes."""
+        params = []
+        if not self.match(TokenType.LPAREN):
+            while not self.at_statement_end():
+                params.append(self.parse_variable_reference())
+                if self.match(TokenType.AS):
+                    self._take_name("type name")
+                if not self.match(TokenType.COMMA):
+                    break
+            return params
+        if not self.at(TokenType.RPAREN):
+            while True:
+                params.append(self.parse_variable_reference())
+                if self.match(TokenType.AS):
+                    self._take_name("type name")
+                if not self.match(TokenType.COMMA):
+                    break
+        self.expect(TokenType.RPAREN)
+        return params
+
+    def parse_sub(self, sub_token):
+        name_token = self.expect(TokenType.IDENTIFIER)
+        name = name_token.value
+        params = self._parse_param_list()
+
+        def _at_endsub():
+            return (self.at(TokenType.END) and
+                    self.peek().type == TokenType.SUB) or \
+                   self.at(TokenType.ENDSUB)
+
+        # allow `SUB name(): <body>` (body on the same line)
+        self.match(TokenType.COLON)
+
+        body = self._collect_block((TokenType.ENDSUB,), stop_pred=_at_endsub)
+        if self.at(TokenType.END):
+            self.advance()
+            self.expect(TokenType.SUB)
+        else:
+            self.advance()
+        return nodes.SubStatementNode(name, params, body, token=sub_token)
+
+    def parse_function(self, fn_token):
+        name_token = self._take_name("FUNCTION name")
+        name = name_token.value
+        params = self._parse_param_list()
+        # optional AS <type>
+        return_type = None
+        if self.match(TokenType.AS):
+            if self.at(TokenType.IDENTIFIER):
+                return_type = self.advance().value.lower()
+        self.match(TokenType.COLON)
+
+        def _at_endfn():
+            return (self.at(TokenType.END) and
+                    self.peek().type == TokenType.FUNCTION) or \
+                   self.at(TokenType.ENDFUNCTION)
+
+        body = self._collect_block((TokenType.ENDFUNCTION,),
+                                   stop_pred=_at_endfn)
+        if self.at(TokenType.END):
+            self.advance()
+            self.expect(TokenType.FUNCTION)
+        else:
+            self.advance()
+        return nodes.FunctionStatementNode(name, params, body, token=fn_token,
+                                           return_type=return_type)
+
+    def parse_local(self, local_token):
+        names = []
+        inits = []
+        # MMBasic 6.x: LOCAL <type> a = expr, b
+        if self.at(TokenType.IDENTIFIER) and \
+                self.current().value.lower() in self._TYPE_WORDS:
+            self.advance()
+        if not self.at_statement_end():
+            while True:
+                var = self.parse_variable_reference()
+                names.append(var.name)
+                init = None
+                if self.match(TokenType.EQUAL):
+                    init = self.parse_expression()
+                inits.append(init)
+                if not self.match(TokenType.COMMA):
+                    break
+        return nodes.LocalStatementNode(names, inits, token=local_token)
+
+    def parse_const(self, const_token):
+        entries = []
+        while True:
+            name_tok = self.expect(TokenType.IDENTIFIER)
+            self.expect(TokenType.EQUAL)
+            value = self.parse_expression()
+            entries.append((name_tok.value, value))
+            if not self.match(TokenType.COMMA):
+                break
+        return nodes.ConstStatementNode(entries, token=const_token)
+
+    def parse_exit(self, exit_token):
+        if self.match(TokenType.SUB):
+            return nodes.ExitSubStatementNode(token=exit_token)
+        if self.match(TokenType.DO):
+            return nodes.ExitDoStatementNode(token=exit_token)
+        if self.match(TokenType.SELECT):
+            return nodes.EndSelectStatementNode(token=exit_token)
+        if self.match(TokenType.FOR):
+            return nodes.ExitForStatementNode(token=exit_token)
+        if self.match(TokenType.FUNCTION):
+            return nodes.ExitFunctionStatementNode(token=exit_token)
+        raise ParseError("Expected SUB, DO, FOR, SELECT or FUNCTION after EXIT",
+                         self.current())
+
+    def parse_do(self, do_token):
+        do_cond = None
+        do_until = False
+        if self.match(TokenType.WHILE):
+            do_cond = self.parse_expression()
+        elif self.match(TokenType.UNTIL):
+            do_cond = self.parse_expression()
+            do_until = True
+
+        # MMBasic permits an empty inline body (`DO WHILE condition: LOOP`).
+        # Consume that statement separator before locating the LOOP marker.
+        self.match(TokenType.COLON)
+        body = self._collect_block((TokenType.LOOP,))
+        self.expect(TokenType.LOOP)
+        loop_cond = None
+        loop_until = False
+        if self.match(TokenType.WHILE):
+            loop_cond = self.parse_expression()
+        elif self.match(TokenType.UNTIL):
+            loop_cond = self.parse_expression()
+            loop_until = True
+        return nodes.DoLoopStatementNode(do_cond, do_until, loop_cond,
+                                         loop_until, body, token=do_token)
+
+    def parse_select(self, select_token):
+        self.expect(TokenType.CASE)
+        expr = self.parse_expression()
+        # tolerate a stray trailing ')' in some adapted programs
+        self.match(TokenType.RPAREN)
+        cases = []
+
+        def _at_end():
+            return (self.at(TokenType.END) and
+                    self.peek().type == TokenType.SELECT) or \
+                   self.at(TokenType.ENDSELECT)
+
+        while True:
+            self._skip_newlines()
+            if self.at(TokenType.EOF):
+                raise ParseError("Missing END SELECT", self.current())
+            if self.at(TokenType.CASE):
+                self.advance()
+                if self.match(TokenType.ELSE):
+                    self.match(TokenType.COLON)
+                    stmts = self._collect_block(
+                        (TokenType.CASE, TokenType.ENDSELECT, TokenType.LOOP),
+                        stop_pred=_at_end)
+                    cases.append(nodes.CaseClauseNode([], True, stmts,
+                                                      token=select_token))
+                    continue
+                values = []
+                ranges = []
+                while True:
+                    lo = self.parse_expression()
+                    if self.match(TokenType.TO):
+                        hi = self.parse_expression()
+                        ranges.append((lo, hi))
+                    else:
+                        values.append(lo)
+                    if not self.match(TokenType.COMMA):
+                        break
+                # `CASE value, value2: statements` (optional colon separator).
+                self.match(TokenType.COLON)
+                stmts = self._collect_block(
+                    (TokenType.CASE, TokenType.ENDSELECT, TokenType.LOOP),
+                    stop_pred=_at_end)
+                cases.append(nodes.CaseClauseNode(values, False, stmts,
+                                                  ranges=ranges,
+                                                  token=select_token))
+                continue
+            if self.at(TokenType.LOOP):
+                break  # implicitly closed by the enclosing DO's Loop
+            if self.at(TokenType.END) and self.peek().type == TokenType.SELECT:
+                self.advance()
+                self.advance()
+                break
+            if self.at(TokenType.ENDSELECT):
+                self.advance()
+                break
+            raise ParseError("Expected CASE or END SELECT", self.current())
+
+        return nodes.SelectStatementNode(expr, cases, token=select_token)
+
+
+    def parse_pixel(self, pix_token):
+        x = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        y = self.parse_expression()
+        color = None
+        if self.match(TokenType.COMMA):
+            color = self.parse_expression()
+        return nodes.PixelStatementNode(x, y, color, token=pix_token)
+
+    def _parse_optional_arg(self):
+        """Parse an optional argument; an empty slot (double comma) is None."""
+        if self.at(TokenType.COMMA) or self.at_statement_end():
+            return None
+        return self.parse_expression()
+
+    def parse_draw_line(self, line_token):
+        x1 = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        y1 = self.parse_expression()
+        self.match(TokenType.RPAREN)
+        self.expect(TokenType.COMMA)
+        x2 = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        y2 = self.parse_expression()
+        thickness = None
+        color = None
+        if self.match(TokenType.COMMA):
+            thickness = self._parse_optional_arg()
+        if self.match(TokenType.COMMA):
+            color = self.parse_expression()
+        return nodes.LineStatementNode(x1, y1, x2, y2, thickness, color,
+                                       token=line_token)
+
+    def parse_box(self, box_token):
+        x = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        y = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        w = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        h = self.parse_expression()
+        args = []
+        while self.match(TokenType.COMMA):
+            args.append(self._parse_optional_arg())
+        # args: [thickness] [outline] [fill]
+        thickness = args[0] if len(args) > 0 else None
+        outline = args[1] if len(args) > 1 else None
+        fill = args[2] if len(args) > 2 else None
+        return nodes.BoxStatementNode(x, y, w, h, thickness, outline, fill,
+                                      token=box_token)
+
+    def parse_circle(self, circle_token):
+        x = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        y = self.parse_expression()
+        self.expect(TokenType.COMMA)
+        r = self.parse_expression()
+        args = []
+        while self.match(TokenType.COMMA):
+            args.append(self._parse_optional_arg())
+        # tolerate a stray trailing ')' in some adapted programs
+        self.match(TokenType.RPAREN)
+        return nodes.CircleStatementNode(x, y, r, args, token=circle_token)
+
+    def parse_polygon(self, poly_token):
+        self.parse_expression()  # count is accepted for MMBasic compatibility
+        self.expect(TokenType.COMMA)
+        xs = self.parse_array_reference()
+        self.expect(TokenType.COMMA)
+        ys = self.parse_array_reference()
+        outline = None
+        fill = None
+        if self.match(TokenType.COMMA):
+            outline = self.parse_expression()
+        if self.match(TokenType.COMMA):
+            fill = self.parse_expression()
+        # tolerate a stray trailing ')' in some adapted programs
+        self.match(TokenType.RPAREN)
+        return nodes.PolygonStatementNode(xs, ys, outline, fill, token=poly_token)
+
+    def parse_array_reference(self):
+        """`name` or `name()` - a whole-array reference."""
+        name_tok = self.expect(TokenType.IDENTIFIER)
+        if self.match(TokenType.LPAREN):
+            self.expect(TokenType.RPAREN)
+        return nodes.ArrayRefNode(name_tok.value, token=name_tok)
+
+    def parse_color(self, color_token):
+        color = self.parse_expression()
+        background = None
+        if self.match(TokenType.COMMA):
+            background = self.parse_expression()
+        return nodes.ColorStatementNode(color, background, token=color_token)
+
+    def parse_text(self, text_token):
+        x = self.parse_expression()
+        self.match(TokenType.RPAREN)
+        self.expect(TokenType.COMMA)
+        y = self.parse_expression()
+        self.match(TokenType.RPAREN)
+        self.expect(TokenType.COMMA)
+        text = self.parse_expression()
+        self.match(TokenType.RPAREN)
+        while self.match(TokenType.COMMA):
+            self._parse_optional_arg()
+        self.match(TokenType.RPAREN)
+        return nodes.TextStatementNode(x, y, text, token=text_token)
+
+    def parse_framebuffer(self, fb_token):
+        sub_tok = self._take_name("FRAMEBUFFER sub-command")
+        args = []
+        while not self.at_statement_end():
+            args.append(self.parse_expression())
+            if not self.match(TokenType.COMMA):
+                break
+        return nodes.FrameBufferStatementNode(sub_tok.value, args, token=fb_token)
+
+    def parse_layer(self, layer_token):
+        self._consume_rest_of_statement()
+        return nodes.LayerStatementNode([], token=layer_token)
+
+    def parse_turtle(self, turtle_token):
+        sub_tok = self._take_name("TURTLE sub-command")
+        words = [sub_tok.value.lower()]
+        # optional second word: SET XY / SET HEADING / PEN DOWN|UP
+        if self.at(TokenType.IDENTIFIER) and \
+                self.current().value.lower() in ("xy", "heading", "down",
+                                                 "up"):
+            words.append(self.advance().value.lower())
+        sub = " ".join(words)
+        args = []
+        while not self.at_statement_end():
+            args.append(self.parse_expression())
+            if not self.match(TokenType.COMMA):
+                break
+        return nodes.TurtleStatementNode(sub, args, token=turtle_token)
+
+    def parse_copy(self, copy_token):
+        """COPY source$ TO dest$  (MMBasic file copy; no-op on Picoware)."""
+        source = self.parse_expression()
+        self.match(TokenType.TO)
+        dest = self.parse_expression()
+        return nodes.CopyStatementNode(source, dest, token=copy_token)
+
+    def parse_sort(self, sort_token):
+        """SORT array() [, start [, end]]  (MMBasic sort; no-op on Picoware).
+        Tolerates empty comma slots like `SORT a(),,,,(n)`."""
+        array = self.parse_array_reference()
+        args = []
+        while self.match(TokenType.COMMA):
+            if self.at(TokenType.COMMA) or self.at_statement_end():
+                args.append(None)
+            else:
+                args.append(self.parse_expression())
+        return nodes.SortStatementNode(array, args, token=sort_token)
+
+
+    def parse_expression(self):
+        return self.parse_binary(1)
+
+    #: binary token -> precedence (higher binds tighter). A single
+    #: precedence-climbing loop replaces the old imp/eqv/xor/or/and/
+    #: relational/additive/multiplicative chain, which used ~13 Python frames
+    #: per expression and blew the Pico's small C stack on nested calls like
+    #: `sc=(Sqr(bb)-Sqr(aa))/Sqr(dd)` (MicroPython's recursion limit is much
+    #: lower on the device than on the host port).
+    _BIN_PREC = {
+        TokenType.IMP: 1,
+        TokenType.EQV: 2,
+        TokenType.XOR: 3,
+        TokenType.OR: 4,
+        TokenType.AND: 5,
+        TokenType.EQUAL: 6, TokenType.NOT_EQUAL: 6,
+        TokenType.LESS_THAN: 6, TokenType.GREATER_THAN: 6,
+        TokenType.LESS_EQUAL: 6, TokenType.GREATER_EQUAL: 6,
+        TokenType.PLUS: 7, TokenType.MINUS: 7,
+        TokenType.SHR: 7, TokenType.SHL: 7,
+        TokenType.MULTIPLY: 8, TokenType.DIVIDE: 8,
+        TokenType.BACKSLASH: 8, TokenType.MOD: 8,
+    }
+    _RELATIONAL = frozenset((
+        TokenType.EQUAL, TokenType.NOT_EQUAL, TokenType.LESS_THAN,
+        TokenType.GREATER_THAN, TokenType.LESS_EQUAL, TokenType.GREATER_EQUAL,
+    ))
+
+    def parse_binary(self, min_prec=1):
+        left = self._parse_operand(min_prec)
+        saw_rel = False
+        while True:
+            tok = self.current()
+            prec = self._BIN_PREC.get(tok.type)
+            if prec is not None and prec >= min_prec:
+                if saw_rel and prec == 6:
+                    # relational compares are non-associative (a<b<c invalid)
+                    break
+                self.advance()
+                right = self.parse_binary(prec + 1)
+                left = nodes.BinaryOpNode(left, tok.value, right, token=tok)
+                saw_rel = tok.type in self._RELATIONAL
+                continue
+            saw_rel = False
+            if min_prec <= 8 and not self._in_print_items and self._implicit_mul():
+                # adapted programs rely on 2x == 2*x  and  a b == a*b
+                right = self.parse_binary(9)
+                left = nodes.BinaryOpNode(left, "*", right)
+                continue
+            break
+        return left
+
+    def _parse_operand(self, min_prec):
+        # unary NOT: binds tighter than AND(5) but looser than relational(6),
+        # matching the old `parse_not -> parse_relational` behaviour.
+        if self.at(TokenType.NOT) and min_prec <= 6:
+            op = self.advance()
+            inner = self.parse_binary(6)
+            return nodes.UnaryOpNode("NOT", inner, token=op)
+        if self.at(TokenType.MINUS):
+            op = self.advance()
+            return nodes.UnaryOpNode("-", self._parse_operand(9), token=op)
+        if self.at(TokenType.PLUS):
+            op = self.advance()
+            return nodes.UnaryOpNode("+", self._parse_operand(9), token=op)
+        left = self.parse_primary()
+        if self.at(TokenType.POWER):
+            op = self.advance()
+            right = self._parse_operand(9)
+            return nodes.BinaryOpNode(left, "^", right, token=op)
+        return left
+
+    def _implicit_mul(self):
+        t = self.current().type
+        return (t in (TokenType.NUMBER, TokenType.IDENTIFIER, TokenType.PI,
+                      TokenType.LPAREN)) or (t in BUILTIN_FUNCTIONS)
+
+    def parse_primary(self):
+        token = self.current()
+        type_ = token.type
+
+        if type_ == TokenType.AT:
+            self.advance()
+            return self.parse_primary()
+        if type_ == TokenType.HASH:
+            # `#n` is a file-number reference in expressions (EOF(#1) etc.).
+            self.advance()
+            return self.parse_primary()
+        if type_ == TokenType.NUMBER:
+            self.advance()
+            lit = token.literal_text or ""
+            suffix = None
+            if lit and lit[-1] in "%!#":
+                suffix = lit[-1]
+            return nodes.NumberNode(token.value, token=token,
+                                    literal_text=lit, suffix=suffix)
+        if type_ == TokenType.PI:
+            self.advance()
+            return nodes.NumberNode(math.pi, token=token)
+        if type_ == TokenType.STRING:
+            self.advance()
+            return nodes.StringNode(token.value, token=token)
+        if type_ == TokenType.LPAREN:
+            self.advance()
+            # Inside parentheses implicit multiplication stays active even
+            # within a PRINT list (`MM.Info(modified file$(sel))`).
+            saved = self._in_print_items
+            self._in_print_items = False
+            try:
+                expr = self.parse_expression()
+            finally:
+                self._in_print_items = saved
+            self.expect(TokenType.RPAREN)
+            return expr
+        if type_ == TokenType.IDENTIFIER:
+            if token.value.startswith("fn"):
+                return self._parse_fn_identifier(token)
+            if self.peek().type == TokenType.LPAREN:
+                low = token.value.lower().rstrip("$")
+                if low in IDENTIFIER_FUNCTIONS and low not in self._user_functions:
+                    return self.parse_identifier_function(token)
+            return self.parse_variable_reference()
+        if type_ == TokenType.FN:
+            if self.peek().type == TokenType.IDENTIFIER:
+                return self.parse_fn_call()
+            self.advance()
+            return nodes.VariableNode("fn", [], token=token)
+        if type_ == TokenType.LINE_INPUT:
+            # `line` used as a variable name (PicoCalc BASIC files).
+            self.advance()
+            return nodes.VariableNode("line", [], token=token)
+        if type_ in (TokenType.BASE, TokenType.ANGLE):
+            # Keywords (OPTION BASE / OPTION ANGLE) used as variables.
+            self.advance()
+            return nodes.VariableNode(type_.lower(), [], token=token)
+        if type_ in BUILTIN_FUNCTIONS:
+            if self.peek().type == TokenType.LPAREN or type_ in _ZERO_ARG_FUNCS:
+                return self.parse_builtin_function()
+            # A bare function keyword used as a variable name (e.g. `len`).
+            return self.parse_variable_reference()
+
+        raise ParseError("Expected expression", token)
+
+    _NON_NAME = (TokenType.EOF, TokenType.NEWLINE, TokenType.COLON,
+                 TokenType.COMMA, TokenType.LPAREN, TokenType.RPAREN,
+                 TokenType.EQUAL, TokenType.PLUS, TokenType.MINUS,
+                 TokenType.MULTIPLY, TokenType.DIVIDE, TokenType.POWER,
+                 TokenType.BACKSLASH, TokenType.SEMICOLON, TokenType.HASH,
+                 TokenType.NEWLINE, TokenType.GREATER_THAN, TokenType.LESS_THAN,
+                 TokenType.GREATER_EQUAL, TokenType.LESS_EQUAL,
+                 TokenType.NOT_EQUAL, TokenType.AT)
+
+    def _take_name(self, what="identifier"):
+        """Consume the current token as a name (identifier or keyword)."""
+        token = self.current()
+        if token.type in self._NON_NAME or token.value is None:
+            raise ParseError("Expected %s" % what, token)
+        self.advance()
+        return token
+
+    def _arg_expression(self):
+        """Parse a sub-expression inside parens / call arguments"""
+        saved = self._in_print_items
+        self._in_print_items = False
+        try:
+            return self.parse_expression()
+        finally:
+            self._in_print_items = saved
+
+    def parse_variable_reference(self):
+        token = self._take_name()
+        name = token.value
+        indices = []
+        if self.match(TokenType.LPAREN):
+            if self.at(TokenType.RPAREN):
+                self.advance()
+                return nodes.ArrayRefNode(name, token=token)
+            indices.append(self._arg_expression())
+            while self.match(TokenType.COMMA):
+                indices.append(self._arg_expression())
+            self.expect(TokenType.RPAREN)
+        return nodes.VariableNode(name, indices, token=token)
+
+    def _parse_fn_identifier(self, token):
+        """FNname(...) with FN glued to the name (FNDBL, FNX$)."""
+        self.advance()
+        name = self._fn_canonical(token.value)
+        is_string = token.value[-1:] == "$"
+        args = []
+        if self.match(TokenType.LPAREN):
+            if not self.at(TokenType.RPAREN):
+                args.append(self._arg_expression())
+                while self.match(TokenType.COMMA):
+                    args.append(self._arg_expression())
+            self.expect(TokenType.RPAREN)
+        return nodes.FunctionCallNode(name, args, is_string, token=token)
+
+    def parse_fn_call(self):
+        fn_token = self.expect(TokenType.FN)
+        name_token = self.expect(TokenType.IDENTIFIER)
+        name = self._fn_canonical(name_token.value)
+        is_string = name_token.value[-1:] == "$"
+        args = []
+        if self.match(TokenType.LPAREN):
+            if not self.at(TokenType.RPAREN):
+                args.append(self._arg_expression())
+                while self.match(TokenType.COMMA):
+                    args.append(self._arg_expression())
+            self.expect(TokenType.RPAREN)
+        return nodes.FunctionCallNode(name, args, is_string, token=fn_token)
+
+    def parse_identifier_function(self, token):
+        """A builtin function that lexes as an identifier (UCASE$, DIR$...).
+
+        Only reached when the identifier is followed by '(' and matches an
+        entry in IDENTIFIER_FUNCTIONS.
+        """
+        call_name = IDENTIFIER_FUNCTIONS[token.value.lower().rstrip("$")]
+        is_string = call_name.endswith("$")
+        self.advance()  # consume the identifier
+        args = []
+        self.expect(TokenType.LPAREN)
+        if not self.at(TokenType.RPAREN):
+            args.append(self._arg_expression())
+            while self.match(TokenType.COMMA):
+                args.append(self._arg_expression())
+        self.expect(TokenType.RPAREN)
+        return nodes.FunctionCallNode(call_name, args, is_string, token=token)
+
+    def parse_builtin_function(self):
+        token = self.advance()
+        name, is_string = BUILTIN_FUNCTIONS[token.type]
+        args = []
+        if self.match(TokenType.LPAREN):
+            if not self.at(TokenType.RPAREN):
+                args.append(self._arg_expression())
+                while self.match(TokenType.COMMA):
+                    args.append(self._arg_expression())
+            self.expect(TokenType.RPAREN)
+        return nodes.FunctionCallNode(name, args, is_string, token=token)
+
+
+def parse_source(source, def_type_map=None):
+    """Convenience: tokenize and parse a BASIC source string."""
+    from .lexer import Lexer
+    lexer = Lexer(source)
+    tokens = lexer.tokenize()
+    parser = Parser(tokens, def_type_map=def_type_map, source=source)
+    return parser.parse_program()

--- a/simulator/hardware/mmbasic_runtime/rnd.py
+++ b/simulator/hardware/mmbasic_runtime/rnd.py
@@ -1,0 +1,162 @@
+from micropython import const
+import math
+import struct
+
+#: Multiplier table at 0x3849, indexed 0..7 by the counter at 0x3848.
+MULTIPLIERS = (
+    -26514538.0, 16129081.0, -11769122.0, 13098250.0,
+    -20161190.0, -10426890.0, -13483109.0, 12482518.0,
+)
+
+#: Addend table at 0x386D, indexed 1..3 by the counter at 0x3847. Index 0 is
+#: the seed itself, which is why the counter skips it.
+ADDENDS = (
+    0.0,
+    4.626181748790259e-08,
+    -6.841145960834183e-08,
+    5.723364893128746e-08,
+)
+
+#: The seed RUN copies from 0x37C8. Every run of a program starts here, which
+#: is why MBASIC gives the same "random" numbers every time unless the program
+#: says RANDOMIZE.
+INITIAL_SEED = const(0.8116351366043091)
+
+#: The byte the scramble exclusive-ORs into the high mantissa byte.
+SCRAMBLE_XOR = const(0x4F)
+
+#: The count at which the third counter wraps and perturbs the result.
+PERTURB_AT = const(0xAB)
+
+
+def _single(value):
+    """Round to single precision, the width MBASIC computes in."""
+    try:
+        return struct.unpack('f', struct.pack('f', value))[0]
+    except (OverflowError, struct.error, ValueError):
+        return value
+
+
+def _unpack(value):
+    """(low, mid, high-as-stored, exponent byte) of an MBF single."""
+    if value == 0:
+        return 0, 0, 0, 0
+    fraction, exponent = math.frexp(abs(value))
+    mantissa = round(fraction * 2 ** 24)
+    if mantissa >> 24:                      # rounded up out of 24 bits
+        mantissa >>= 1
+        exponent += 1
+    high = ((mantissa >> 16) & 0x7F) | (0x80 if value < 0 else 0)
+    return mantissa & 0xFF, (mantissa >> 8) & 0xFF, high, (exponent + 128) & 0xFF
+
+
+def _normalise(high, mid, low, guard):
+    """The routine at 0x25DA, for a value whose exponent has been forced to
+    0x80 and whose sign has been cleared.
+
+    Shifts left until the mantissa's top bit is set, pulling in bits from the
+    guard byte, then rounds up if what is left of the guard has its top bit
+    set.
+    """
+    bits = (high << 24) | (mid << 16) | (low << 8) | guard
+    if bits == 0:
+        return 0.0
+    exponent = 0x80
+    while not bits & 0x80000000:
+        bits = (bits << 1) & 0xFFFFFFFF
+        exponent -= 1
+    mantissa = bits >> 8
+    if bits & 0xFF >= 0x80:                 # CM 2635 - round away from zero
+        mantissa += 1
+        if mantissa >> 24:
+            mantissa >>= 1
+            exponent += 1
+    return mantissa * 2.0 ** (exponent - 152)
+
+
+class MbasicRandom:
+    """The generator, with the state MBASIC keeps in three counters and a seed."""
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        """What RUN does at 0x4358: reload the seed, zero the counters.
+
+        This is why a program that does not say RANDOMIZE gets the same
+        numbers every time it is run - on the real machine and now here.
+        """
+        self.seed = INITIAL_SEED
+        self.count = 0          # 0x3846
+        self.addend_index = 0   # 0x3847
+        self.mult_index = 0     # 0x3848
+
+
+    def next(self, argument=None):
+        """One RND.
+
+        RND and RND(x>0) advance the sequence; RND(0) repeats the last value
+        without drawing; RND(x<0) restarts from a value derived from x - and
+        only from its mantissa, so RND(-1) and RND(-2) give the same number
+        while RND(-1000) does not.
+        """
+        if argument is not None and argument == 0:
+            return self.seed
+
+        if argument is not None and argument < 0:
+            # The sign test leaves 0xFF in A, and the negative path writes it
+            # to all three counters and scrambles the argument itself.
+            self.count = self.addend_index = self.mult_index = 0xFF
+            value = _single(argument)
+        else:
+            self.mult_index = (self.mult_index + 1) & 7
+            self.addend_index = self.addend_index + 1 if self.addend_index < 3 else 1
+            value = _single(_single(self.seed * MULTIPLIERS[self.mult_index])
+                            + ADDENDS[self.addend_index])
+
+        low, mid, high, exponent = _unpack(value)
+        new_high = (low ^ SCRAMBLE_XOR) & 0xFF
+        new_mid = mid
+        new_low = high
+
+        self.count = (self.count + 1) & 0xFF
+        if self.count == PERTURB_AT:
+            # Once every 171 draws: INR C / DCR D / INR E at 0x3832.
+            self.count = 0
+            new_high = (new_high + 1) & 0xFF
+            new_mid = (new_mid - 1) & 0xFF
+            new_low = (new_low + 1) & 0xFF
+
+        self.seed = _normalise(new_high, new_mid, new_low, exponent)
+        return self.seed
+
+    def randomize(self, seed):
+        """RANDOMIZE n, from 0x24AD.
+
+        The argument becomes a 16-bit integer and replaces the *middle two*
+        bytes of the seed - its low byte and exponent are left alone - and then
+        one value is drawn and discarded. That is why RANDOMIZE 1 twice in the
+        same run does not give the same number twice: what it did not overwrite
+        is different the second time.
+        """
+        n = int(seed) & 0xFFFF
+        low, _mid, _high, exponent = _unpack(self.seed)
+        self.seed = _mbf(low, n & 0xFF, (n >> 8) & 0xFF, exponent)
+        self.next(1)
+
+    # For a statement that has to be run again - see src/statement_attempt.py
+
+    def state(self):
+        """Everything a retry would have to put back."""
+        return (self.seed, self.count, self.addend_index, self.mult_index)
+
+    def restore(self, state):
+        (self.seed, self.count, self.addend_index, self.mult_index) = state
+
+
+def _mbf(low, mid, high, exponent):
+    """Rebuild a value from its four stored bytes."""
+    if exponent == 0:
+        return 0.0
+    mantissa = ((high | 0x80) << 16) | (mid << 8) | low
+    return (-1 if high & 0x80 else 1) * mantissa * 2.0 ** (exponent - 152)

--- a/simulator/hardware/mmbasic_runtime/runtime.py
+++ b/simulator/hardware/mmbasic_runtime/runtime.py
@@ -1,0 +1,438 @@
+from micropython import const
+from .number import coerce_to_type, to_integer
+from .rnd import MbasicRandom
+from .nodes import (
+    EndSubStatementNode, EndFunctionStatementNode,
+    DoStatementNode, LoopStatementNode
+)
+
+#: Largest implicit array index when a variable is used as an array without
+#: DIM. MBASIC defaults every array to 10 elements per dimension.
+IMPLICIT_DIM = const(10)
+
+_TYPE_BY_DEF = {"integer": "%", "single": "!", "double": "#", "string": "$"}
+_SUFFIXES = const("$%!#")
+
+
+def split_variable_name_and_suffix(full_name):
+    """Split 'err%' into ('err', '%'); 'x' -> ('x', None)."""
+    if full_name and full_name[-1] in _SUFFIXES:
+        return full_name[:-1], full_name[-1]
+    return full_name, None
+
+
+class RuntimeError_(Exception):
+    """A BASIC runtime error carrying an MBASIC error code and a line."""
+
+    def __init__(self, message, code=5, line=0):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.line = line
+
+
+class Runtime:
+    """Execution state for a BASIC program."""
+
+    def __init__(self, program, line_text_map=None, def_type_map=None):
+        self.program = program
+        self.line_text = line_text_map or {}
+        self.def_type_map = def_type_map or {}
+
+        # Flat statement list: [(line_num, statement_node), ...]
+        self.statements = []
+        self.line_to_index = {}
+        self.labels = {}             # label name -> statement index
+        self.sub_defs = {}           # sub name -> {start, end, params}
+        self.function_defs = {}      # function name -> {start, end, params}
+        self.do_loop_map = {}        # do marker idx -> loop marker idx (both ways)
+        self._build_statement_table(program)
+
+        # Program counter = index into self.statements
+        self.pc = 0
+        self.running = False
+        self.ended = False
+
+        self._variables = {}   # name (with suffix) -> value
+        self._arrays = {}      # name -> {'dims': [...], 'data': [...], 'type': ...}
+        self.constants = {}    # name -> value (CONST)
+        self.var_types = {}    # name -> declared type ('integer','float',...)
+        self.array_base = 0
+        self.default_type = "single"   # OPTION DEFAULT
+        self.angle_mode = "radians"    # OPTION ANGLE (MMBasic trig uses Pi)
+        self.explicit = False
+        self.screen_w = 320
+        self.screen_h = 240
+        self.def_functions = {}  # 'fnname' -> {'params': [...], 'body': node}
+
+        self._gosub_stack = []   # list of return indices (int)
+        self._for_stack = []     # list of dicts
+        self._while_stack = []   # list of while statement indices
+        self._clause_stack = []  # list of (statements, next_index) continuations
+        self.sub_stack = []      # SUB call frames
+
+        self._data_items = []    # list of (value, is_string)
+        self._data_index = 0
+        self._collect_data(program)
+
+        self.rnd = MbasicRandom()
+        self.files = {}
+        self.file_store = {}         # filename -> text (persists across CLOSE/OPEN)
+        self.memory = {}             # PEEK/POKE address space
+        self.error_handler = None        # line number for ON ERROR GOTO
+        self.error_active = False
+        self.tron = False
+        self.break_requested = False
+        self.statement_count = 0
+
+
+    def _build_statement_table(self, program):
+        for line_num in program.order:
+            line_node = program.lines[line_num]
+            self.line_to_index[line_num] = len(self.statements)
+            for stmt in line_node.statements:
+                self._flatten(stmt)
+        self.labels = {}
+        for i, (_ln, stmt) in enumerate(self.statements):
+            if type(stmt).__name__ == "LabelNode":
+                self.labels[stmt.name] = i
+
+    def _flatten(self, stmt):
+        """Flatten SUB and DO...LOOP containers into marker + body entries."""
+        name = type(stmt).__name__
+        if name == "SubStatementNode":
+            idx = len(self.statements)
+            self.statements.append((stmt.line_num, stmt))
+            for s in stmt.body:
+                self._flatten(s)
+            end = EndSubStatementNode(stmt.name)
+            self.statements.append((stmt.line_num, end))
+            self.sub_defs[stmt.name] = {
+                "start": idx,
+                "end": len(self.statements) - 1,
+                "params": stmt.params,
+            }
+            return
+        if name == "FunctionStatementNode":
+            idx = len(self.statements)
+            self.statements.append((stmt.line_num, stmt))
+            for s in stmt.body:
+                self._flatten(s)
+            end = EndFunctionStatementNode(stmt.name)
+            self.statements.append((stmt.line_num, end))
+            self.function_defs[stmt.name] = {
+                "start": idx,
+                "end": len(self.statements) - 1,
+                "params": stmt.params,
+                "return_type": getattr(stmt, "return_type", None),
+            }
+            return
+        if name == "DoLoopStatementNode":
+            idx = len(self.statements)
+            do_marker = DoStatementNode(stmt.do_cond, stmt.do_until)
+            self.statements.append((stmt.line_num, do_marker))
+            for s in stmt.body:
+                self._flatten(s)
+            loop_marker = LoopStatementNode(stmt.loop_cond, stmt.loop_until)
+            self.statements.append((stmt.line_num, loop_marker))
+            self.do_loop_map[idx] = len(self.statements) - 1
+            self.do_loop_map[len(self.statements) - 1] = idx
+            return
+        self.statements.append((stmt.line_num, stmt))
+
+    def _collect_data(self, program):
+        # Collect in program order from the flattened statement list (which
+        # includes SUB and DO...LOOP bodies).
+        for _ln, stmt in self.statements:
+            if type(stmt).__name__ == "DataStatementNode":
+                self._data_items.extend(stmt.values)
+
+
+    def resolve_line(self, target):
+        """Return the statement index for a line number, or None."""
+        try:
+            num = int(target)
+        except (TypeError, ValueError):
+            return None
+        return self.line_to_index.get(num)
+
+    def line_for_index(self, index):
+        if 0 <= index < len(self.statements):
+            return self.statements[index][0]
+        return 0
+
+    def statement_at(self, index):
+        if 0 <= index < len(self.statements):
+            return self.statements[index][1]
+        return None
+
+
+    _TYPE_SUFFIX = {
+        "integer": "%", "int": "%", "long": "%", "byte": "%",
+        "single": "!", "float": "!", "double": "#", "string": "$",
+    }
+
+    def _resolve_type(self, name):
+        if name in self.var_types:
+            return self._TYPE_SUFFIX.get(self.var_types[name], "!")
+        if name and name[-1] in _SUFFIXES:
+            return name[-1]
+        letter = name[0] if name else "a"
+        dt = self.def_type_map.get(letter.lower(), self.default_type)
+        return _TYPE_BY_DEF.get(dt, "!")
+
+    def set_constant(self, name, value):
+        self.constants[name] = value
+
+    def set_variable(self, node, value):
+        """Store a scalar value into a variable.
+
+        Array elements go through set_array() with evaluated indices (the
+        interpreter evaluates index expressions before calling it).
+        """
+        name = node.name
+        if node.indices:
+            raise RuntimeError_("Array access requires evaluated indices",
+                                9, node.line_num)
+        suffix = self._resolve_type(name)
+        if isinstance(value, str) and suffix != "$":
+            raise RuntimeError_("Type mismatch", 13, node.line_num)
+        if not isinstance(value, str) and suffix == "$":
+            raise RuntimeError_("Type mismatch", 13, node.line_num)
+        try:
+            value = coerce_to_type(value, suffix)
+        except TypeError:
+            raise RuntimeError_("Type mismatch", 13, node.line_num)
+        self._variables[name] = value
+
+    def get_variable(self, node):
+        """Read a scalar variable, defaulting to 0 or ''."""
+        name = node.name
+        if node.indices:
+            raise RuntimeError_("Array access requires evaluated indices",
+                                9, node.line_num)
+        if name in self.constants:
+            return self.constants[name]
+        if name == "mm.hres":
+            return self.screen_w
+        if name == "mm.vres":
+            return self.screen_h
+        if name.startswith("mm."):
+            return self._mm_value(name)
+        if name in self._variables:
+            return self._variables[name]
+        suffix = self._resolve_type(name)
+        return "" if suffix == "$" else 0
+
+    def _mm_value(self, name):
+        """MMBasic 6.x MM.* system values (minimal Picoware subset)."""
+        key = name[3:]
+        if key == "hres":
+            return self.screen_w
+        if key == "vres":
+            return self.screen_h
+        if key == "ver":
+            return 6.03
+        if key == "errno":
+            return 0
+        if key == "persistent":
+            return 0
+        if key == "errmsg$" or key.endswith("$"):
+            return ""
+        return 0
+
+    def get_whole_array(self, name):
+        arr = self._arrays.get(name)
+        if arr is None:
+            raise RuntimeError_("Subscript out of range", 9, 0)
+        return arr["data"]
+
+    def has_variable(self, name):
+        return name in self._variables
+
+
+    def _array_shape(self, name, indices):
+        """Get or create the array entry; returns the flat data list."""
+        if name in self._arrays:
+            arr = self._arrays[name]
+            dims = arr["dims"]
+            if len(dims) != len(indices):
+                raise RuntimeError_("Subscript out of range", 9, 0)
+        else:
+            # Implicit dimensioning (upper bound IMPLICIT_DIM).
+            dims = [IMPLICIT_DIM] * len(indices)
+            self._arrays[name] = {"dims": list(dims),
+                                  "data": [0] * self._array_size(dims)}
+            arr = self._arrays[name]
+        return arr["data"], dims
+
+    @staticmethod
+    def _array_size(dims):
+        size = 1
+        for d in dims:
+            size *= d + 1
+        return size
+
+    def _array_flat_index(self, indices, dims):
+        base = self.array_base
+        flat = 0
+        for i, dim in enumerate(dims):
+            idx = int(to_integer(indices[i]))
+            if idx < base or idx > dim:
+                raise RuntimeError_("Subscript out of range", 9, 0)
+            flat = flat * (dim + 1) + (idx - base)
+        return flat
+
+    def get_array(self, name, index_values):
+        """Read an array element; `index_values` are already evaluated."""
+        data, dims = self._array_shape(name, index_values)
+        return data[self._array_flat_index(index_values, dims)]
+
+    def set_array(self, name, index_values, value):
+        """Write an array element; `index_values` are already evaluated."""
+        data, dims = self._array_shape(name, index_values)
+        if name in self.var_types:
+            suffix = self._TYPE_SUFFIX.get(self.var_types[name], "!")
+            if isinstance(value, str) != (suffix == "$"):
+                raise RuntimeError_("Type mismatch", 13, 0)
+            try:
+                value = coerce_to_type(value, suffix)
+            except TypeError:
+                raise RuntimeError_("Type mismatch", 13, 0)
+        data[self._array_flat_index(index_values, dims)] = value
+
+    def dim_array(self, name, dim_exprs, line_num=0, type_name=None):
+        """DIM an array from a list of upper-bound expressions."""
+        dims = [int(to_integer(d)) for d in dim_exprs]
+        if any(d < self.array_base for d in dims):
+            raise RuntimeError_("Subscript out of range", 9, line_num)
+        self._arrays[name] = {"dims": dims,
+                              "data": [0] * self._array_size(dims),
+                              "type": type_name}
+        if type_name:
+            self.var_types[name] = type_name
+
+    def declare_scalar(self, name, type_name=None):
+        """Register a typed scalar (e.g. Dim integer gen=0)."""
+        if type_name:
+            self.var_types[name] = type_name
+
+    def erase_array(self, name):
+        if name in self._arrays:
+            del self._arrays[name]
+
+
+    def define_function(self, name, params, body):
+        is_string = name.endswith("$")
+        self.def_functions[name] = {
+            "params": params, "body": body, "is_string": is_string,
+        }
+
+    def call_function(self, name, args, evaluator):
+        """Evaluate a user DEF FN function.
+
+        `evaluator` is a callable(node) that evaluates an expression in the
+        interpreter's current context. Parameter binding is performed by the
+        interpreter (it has the runtime), so this is thin.
+        """
+        fn = self.def_functions.get(name)
+        if fn is None:
+            raise RuntimeError_("Undefined user function %s" % name, 18, 0)
+        return fn  # interpreter performs binding
+
+
+    def next_data(self):
+        if self._data_index >= len(self._data_items):
+            raise RuntimeError_("Out of DATA", 4, 0)
+        item = self._data_items[self._data_index]
+        self._data_index += 1
+        return item
+
+    def restore_data(self, target=None):
+        if target is None:
+            self._data_index = 0
+            return
+        # RESTORE <line|label>: find the first DATA at/after that statement.
+        idx = None
+        if isinstance(target, str):
+            idx = self.labels.get(target)
+        else:
+            try:
+                idx = self.line_to_index.get(int(target))
+            except (TypeError, ValueError):
+                idx = None
+        if idx is None:
+            idx = 0
+        di = 0
+        for i, (_ln, stmt) in enumerate(self.statements):
+            if i >= idx:
+                break
+            if type(stmt).__name__ == "DataStatementNode":
+                di += len(stmt.values)
+        self._data_index = di
+
+    def resolve_target(self, value):
+        """Resolve a GOTO/GOSUB target (label name or line number) to an index."""
+        if isinstance(value, str):
+            return self.labels.get(value)
+        try:
+            num = int(value)
+        except (TypeError, ValueError):
+            return None
+        # numeric labels (bare numbers inside SUB bodies) first, then lines
+        if str(num) in self.labels:
+            return self.labels[str(num)]
+        return self.line_to_index.get(num)
+
+
+    def push_gosub(self, return_index):
+        self._gosub_stack.append(return_index)
+
+    def pop_gosub(self):
+        if not self._gosub_stack:
+            raise RuntimeError_("RETURN without GOSUB", 3, 0)
+        return self._gosub_stack.pop()
+
+    def clear_gosub_stack(self):
+        self._gosub_stack = []
+
+    def reset_for_stack(self):
+        self._for_stack = []
+        self._while_stack = []
+
+
+    def variable_names(self):
+        return list(self._variables.keys())
+
+    def clear_variables(self):
+        self._variables = {}
+        self._arrays = {}
+
+    def reset(self):
+        """Reset for a fresh RUN."""
+        self.pc = 0
+        self.running = False
+        self.ended = False
+        self._variables = {}
+        self._arrays = {}
+        self.constants = {}
+        self.var_types = {}
+        self.array_base = 0
+        self.default_type = "single"
+        self.angle_mode = "radians"
+        self.explicit = False
+        self._gosub_stack = []
+        self._for_stack = []
+        self._while_stack = []
+        self._clause_stack = []
+        self.sub_stack = []
+        self._data_index = 0
+        self.error_handler = None
+        self.error_active = False
+        self.tron = False
+        self.break_requested = False
+        self.statement_count = 0
+        self.rnd.reset()
+        self.files = {}
+        self.file_store = {}
+        self.memory = {}

--- a/simulator/hardware/mmbasic_runtime/tokens.py
+++ b/simulator/hardware/mmbasic_runtime/tokens.py
@@ -1,0 +1,363 @@
+class TokenType:
+    """Token type constants.
+
+    A class of string constants (not an Enum) so MicroPython and CPython both
+    accept it and the values stay readable in logs/reprs.
+    """
+
+    NUMBER = "NUMBER"          # Integer, fixed-point, or floating-point
+    STRING = "STRING"          # "string literal"
+
+    IDENTIFIER = "IDENTIFIER"  # Variables (with optional type suffix: $ % ! #)
+
+    AUTO = "AUTO"
+    CONT = "CONT"
+    DELETE = "DELETE"
+    EDIT = "EDIT"
+    FILES = "FILES"
+    LIST = "LIST"
+    LLIST = "LLIST"
+    LOAD = "LOAD"
+    MERGE = "MERGE"
+    NEW = "NEW"
+    RENUM = "RENUM"
+    RUN = "RUN"
+    SAVE = "SAVE"
+
+    AS = "AS"                  # AS (used in OPEN and FIELD)
+    CLOSE = "CLOSE"
+    FIELD = "FIELD"
+    GET = "GET"
+    INPUT = "INPUT"            # Also used for INPUT statement
+    KILL = "KILL"
+    LINE_INPUT = "LINE_INPUT"  # LINE INPUT
+    LSET = "LSET"
+    MKDIR = "MKDIR"
+    CHDIR = "CHDIR"
+    NAME = "NAME"
+    OPEN = "OPEN"
+    OUTPUT = "OUTPUT"          # OUTPUT (used in OPEN FOR OUTPUT)
+    PUT = "PUT"
+    RESET = "RESET"            # RESET (close all files)
+    RSET = "RSET"
+
+    ALL = "ALL"                # ALL (used in CHAIN)
+    CALL = "CALL"
+    CHAIN = "CHAIN"
+    ELSE = "ELSE"
+    END = "END"
+    FOR = "FOR"
+    FONT = "FONT"              # FONT n (set text font size)
+    GOSUB = "GOSUB"
+    GOTO = "GOTO"
+    IF = "IF"
+    NEXT = "NEXT"
+    ON = "ON"
+    RESUME = "RESUME"
+    RETURN = "RETURN"
+    STEP = "STEP"
+    STOP = "STOP"
+    SYSTEM = "SYSTEM"
+    THEN = "THEN"
+    TO = "TO"
+    WHILE = "WHILE"
+    WEND = "WEND"
+
+    CLEAR = "CLEAR"
+    DATA = "DATA"
+    DEF = "DEF"
+    DEFINT = "DEFINT"
+    DEFSNG = "DEFSNG"
+    DEFDBL = "DEFDBL"
+    DEFSTR = "DEFSTR"
+    DIM = "DIM"
+    ERASE = "ERASE"
+    FN = "FN"
+    LET = "LET"
+    OPTION = "OPTION"
+    BASE = "BASE"
+    READ = "READ"
+    RESTORE = "RESTORE"
+
+    PRINT = "PRINT"
+    LPRINT = "LPRINT"
+    WRITE = "WRITE"
+
+    CLS = "CLS"                 # Picoware extension: clear the screen
+    COMMON = "COMMON"
+    ERROR = "ERROR"
+
+    SUB = "SUB"
+    LOCAL = "LOCAL"
+    CONST = "CONST"
+    ELSEIF = "ELSEIF"
+    SELECT = "SELECT"
+    CASE = "CASE"
+    EXIT = "EXIT"
+    DO = "DO"
+    LOOP = "LOOP"
+    UNTIL = "UNTIL"
+    DEFAULT = "DEFAULT"
+    ANGLE = "ANGLE"
+    RADIANS = "RADIANS"
+    DEGREES = "DEGREES"
+    EXPLICIT = "EXPLICIT"
+    ENDIF = "ENDIF"          # EndIf (no space)
+    ENDSELECT = "ENDSELECT"   # EndSelect (no space)
+    ENDSUB = "ENDSUB"        # EndSub (no space)
+    FUNCTION = "FUNCTION"
+    ENDFUNCTION = "ENDFUNCTION"  # EndFunction (no space)
+
+    PLAY = "PLAY"
+    PAUSE = "PAUSE"
+
+    TURTLE = "TURTLE"
+    FRAMEBUFFER = "FRAMEBUFFER"
+    LAYER = "LAYER"
+    CREATE = "CREATE"
+    COPY = "COPY"
+    MERGE = "MERGE"
+    IMAGE = "IMAGE"
+    PIXEL = "PIXEL"
+    BOX = "BOX"
+    CIRCLE = "CIRCLE"
+    POLYGON = "POLYGON"
+    COLOR = "COLOR"
+    TEXT = "TEXT"
+
+    RGB = "RGB"
+    CHOICE = "CHOICE"
+    PI = "PI"
+    AT = "AT"                  # @ (PRINT @(x,y) positioning / @var ref)
+    ATAN2 = "ATAN2"
+
+    SHR = "SHR"              # >>
+    SHL = "SHL"              # <<
+    ERR = "ERR"
+    ERL = "ERL"
+    FRE = "FRE"
+    HELP = "HELP"
+    OUT = "OUT"
+    POKE = "POKE"
+    RANDOMIZE = "RANDOMIZE"
+    REM = "REM"
+    REMARK = "REMARK"          # Synonym for REM
+    SORT = "SORT"
+    SWAP = "SWAP"
+    TRON = "TRON"
+    TROFF = "TROFF"
+    USING = "USING"
+    WAIT = "WAIT"
+    WIDTH = "WIDTH"
+
+    PLUS = "PLUS"              # +
+    MINUS = "MINUS"            # -
+    PLUS_EQUAL = "PLUS_EQUAL"  # += (compound assignment)
+    MINUS_EQUAL = "MINUS_EQUAL"  # -= (compound assignment)
+    MULTIPLY = "MULTIPLY"      # *
+    DIVIDE = "DIVIDE"          # /
+    POWER = "POWER"            # ^
+    BACKSLASH = "BACKSLASH"    # \ (integer division)
+    AMPERSAND = "AMPERSAND"    # & (string concatenation or standalone)
+    MOD = "MOD"                # MOD
+
+    EQUAL = "EQUAL"            # =
+    NOT_EQUAL = "NOT_EQUAL"    # <>
+    LESS_THAN = "LESS_THAN"    # <
+    GREATER_THAN = "GREATER_THAN"  # >
+    LESS_EQUAL = "LESS_EQUAL"  # <=
+    GREATER_EQUAL = "GREATER_EQUAL"  # >=
+
+    NOT = "NOT"
+    AND = "AND"
+    OR = "OR"
+    XOR = "XOR"
+    EQV = "EQV"
+    IMP = "IMP"
+
+    ABS = "ABS"
+    ATN = "ATN"
+    CDBL = "CDBL"
+    CINT = "CINT"
+    COS = "COS"
+    CSNG = "CSNG"
+    CVD = "CVD"                # CVD (convert string to double)
+    CVI = "CVI"                # CVI (convert string to integer)
+    CVS = "CVS"                # CVS (convert string to single)
+    EXP = "EXP"
+    FIX = "FIX"
+    INT = "INT"
+    LOG = "LOG"
+    RND = "RND"
+    SGN = "SGN"
+    SIN = "SIN"
+    SQR = "SQR"
+    TAN = "TAN"
+
+    ASC = "ASC"
+    CHR = "CHR"                # CHR$
+    EVAL = "EVAL"              # EVAL(expression$)
+    HEX = "HEX"                # HEX$
+    INKEY = "INKEY"            # INKEY$
+    INPUT_FUNC = "INPUT_FUNC"  # INPUT$ (different from INPUT statement)
+    INSTR = "INSTR"
+    LEFT = "LEFT"              # LEFT$
+    LEN = "LEN"
+    MID = "MID"                # MID$
+    MKD = "MKD"                # MKD$ (convert double to string)
+    MKI = "MKI"                # MKI$ (convert integer to string)
+    MKS = "MKS"                # MKS$ (convert single to string)
+    OCT = "OCT"                # OCT$
+    RIGHT = "RIGHT"            # RIGHT$
+    SPACE = "SPACE"            # SPACE$
+    STR = "STR"                # STR$
+    STRING_FUNC = "STRING_FUNC"  # STRING$ function
+    TIME = "TIME"              # TIME$ current local time
+    VAL = "VAL"
+
+    EOF_FUNC = "EOF_FUNC"      # EOF
+    INP = "INP"
+    LOC = "LOC"                # LOC
+    LOF = "LOF"                # LOF
+    PEEK = "PEEK"
+    POS = "POS"
+    SPC = "SPC"                # SPC (print spacing function)
+    TAB = "TAB"                # TAB (print tab function)
+    USR = "USR"
+    VARPTR = "VARPTR"
+
+    LPAREN = "LPAREN"          # (
+    RPAREN = "RPAREN"          # )
+    COMMA = "COMMA"            # ,
+    SEMICOLON = "SEMICOLON"    # ;
+    COLON = "COLON"            # :
+    HASH = "HASH"              # # (file number prefix)
+
+    NEWLINE = "NEWLINE"
+    LINE_NUMBER = "LINE_NUMBER"  # Line numbers at start of statement
+    EOF = "EOF"
+    QUESTION = "QUESTION"      # ? (shorthand for PRINT)
+    APOSTROPHE = "APOSTROPHE"  # ' (comment, like REM)
+
+
+class Token:
+    """A single token in MBASIC source code.
+
+    Attributes:
+        type: TokenType constant (keyword, identifier, number, etc.)
+        value: Normalized value (lowercase for identifiers/keywords)
+        line: Line number where the token appears
+        column: Column number where the token starts
+        literal_text: Source text of a NUMBER token, suffix included
+    """
+
+    __slots__ = (
+        "type", "value", "line", "column", "literal_text",
+    )
+
+    def __init__(self, type_, value, line, column, literal_text=None):
+        self.type = type_
+        self.value = value
+        self.line = line
+        self.column = column
+        self.literal_text = literal_text
+
+    def __repr__(self):
+        return "Token(%s, %r, %d:%d)" % (
+            self.type, self.value, self.line, self.column)
+
+
+# Keywords mapping (case-insensitive; lexer normalizes to lowercase).
+# String functions include $ as part of the name.
+KEYWORDS = {
+    "auto": TokenType.AUTO, "cont": TokenType.CONT, "delete": TokenType.DELETE,
+    "edit": TokenType.EDIT, "files": TokenType.FILES, "list": TokenType.LIST,
+    "llist": TokenType.LLIST, "load": TokenType.LOAD, "merge": TokenType.MERGE,
+    "new": TokenType.NEW, "renum": TokenType.RENUM, "run": TokenType.RUN,
+    "save": TokenType.SAVE,
+
+    "as": TokenType.AS, "close": TokenType.CLOSE, "field": TokenType.FIELD,
+    "get": TokenType.GET, "input": TokenType.INPUT, "kill": TokenType.KILL,
+    "line": TokenType.LINE_INPUT,  # special handling for "LINE INPUT"
+    "lset": TokenType.LSET, "name": TokenType.NAME, "open": TokenType.OPEN,
+    "mkdir": TokenType.MKDIR, "chdir": TokenType.CHDIR,
+    "rename": TokenType.NAME,
+    "output": TokenType.OUTPUT, "put": TokenType.PUT, "reset": TokenType.RESET,
+    "rset": TokenType.RSET,
+
+    "all": TokenType.ALL, "call": TokenType.CALL, "chain": TokenType.CHAIN,
+    "else": TokenType.ELSE, "end": TokenType.END, "for": TokenType.FOR,
+    "font": TokenType.FONT,
+    "gosub": TokenType.GOSUB, "goto": TokenType.GOTO, "if": TokenType.IF,
+    "next": TokenType.NEXT, "on": TokenType.ON, "resume": TokenType.RESUME,
+    "return": TokenType.RETURN, "step": TokenType.STEP, "stop": TokenType.STOP,
+    "system": TokenType.SYSTEM, "then": TokenType.THEN, "to": TokenType.TO,
+    "while": TokenType.WHILE, "wend": TokenType.WEND,
+
+    "base": TokenType.BASE, "clear": TokenType.CLEAR, "common": TokenType.COMMON,
+    "data": TokenType.DATA, "def": TokenType.DEF, "defint": TokenType.DEFINT,
+    "defsng": TokenType.DEFSNG, "defdbl": TokenType.DEFDBL,
+    "defstr": TokenType.DEFSTR, "dim": TokenType.DIM, "erase": TokenType.ERASE,
+    "fn": TokenType.FN, "let": TokenType.LET, "option": TokenType.OPTION,
+    "read": TokenType.READ, "restore": TokenType.RESTORE,
+
+    "print": TokenType.PRINT, "lprint": TokenType.LPRINT, "write": TokenType.WRITE,
+
+    "cls": TokenType.CLS,
+    "error": TokenType.ERROR, "err": TokenType.ERR, "erl": TokenType.ERL,
+    "sub": TokenType.SUB, "local": TokenType.LOCAL, "const": TokenType.CONST,
+    "elseif": TokenType.ELSEIF, "select": TokenType.SELECT,
+    "case": TokenType.CASE, "exit": TokenType.EXIT, "do": TokenType.DO,
+    "loop": TokenType.LOOP, "until": TokenType.UNTIL,
+    "default": TokenType.DEFAULT, "angle": TokenType.ANGLE,
+    "radians": TokenType.RADIANS, "degrees": TokenType.DEGREES,
+    "explicit": TokenType.EXPLICIT, "endif": TokenType.ENDIF,
+    "endselect": TokenType.ENDSELECT, "endsub": TokenType.ENDSUB,
+    "function": TokenType.FUNCTION,
+    "endfunction": TokenType.ENDFUNCTION,
+    "play": TokenType.PLAY, "pause": TokenType.PAUSE,
+    "turtle": TokenType.TURTLE, "framebuffer": TokenType.FRAMEBUFFER,
+    "layer": TokenType.LAYER, "create": TokenType.CREATE,
+    "copy": TokenType.COPY,
+    "image": TokenType.IMAGE, "pixel": TokenType.PIXEL,
+    "box": TokenType.BOX, "circle": TokenType.CIRCLE,
+    "polygon": TokenType.POLYGON, "color": TokenType.COLOR,
+    "text": TokenType.TEXT, "rgb": TokenType.RGB,
+    "choice": TokenType.CHOICE, "pi": TokenType.PI,
+    "fre": TokenType.FRE, "help": TokenType.HELP, "out": TokenType.OUT,
+    "poke": TokenType.POKE, "randomize": TokenType.RANDOMIZE, "rem": TokenType.REM,
+    "remark": TokenType.REMARK, "sort": TokenType.SORT, "swap": TokenType.SWAP, "tron": TokenType.TRON,
+    "troff": TokenType.TROFF, "using": TokenType.USING, "wait": TokenType.WAIT,
+    "width": TokenType.WIDTH,
+
+    "mod": TokenType.MOD, "not": TokenType.NOT, "and": TokenType.AND,
+    "or": TokenType.OR, "xor": TokenType.XOR, "eqv": TokenType.EQV,
+    "imp": TokenType.IMP,
+
+    "abs": TokenType.ABS, "atn": TokenType.ATN, "atan2": TokenType.ATAN2,
+    "cdbl": TokenType.CDBL,
+    "cint": TokenType.CINT, "cos": TokenType.COS, "csng": TokenType.CSNG,
+    "cvd": TokenType.CVD, "cvi": TokenType.CVI, "cvs": TokenType.CVS,
+    "exp": TokenType.EXP, "fix": TokenType.FIX, "int": TokenType.INT,
+    "log": TokenType.LOG, "rnd": TokenType.RND, "sgn": TokenType.SGN,
+    "sin": TokenType.SIN, "sqr": TokenType.SQR, "tan": TokenType.TAN,
+
+    "asc": TokenType.ASC, "chr$": TokenType.CHR, "hex$": TokenType.HEX,
+    "eval": TokenType.EVAL,
+    "inkey$": TokenType.INKEY, "input$": TokenType.INPUT_FUNC,
+    "instr": TokenType.INSTR, "left$": TokenType.LEFT, "len": TokenType.LEN,
+    "mid$": TokenType.MID, "mkd$": TokenType.MKD, "mki$": TokenType.MKI,
+    "mks$": TokenType.MKS, "oct$": TokenType.OCT, "right$": TokenType.RIGHT,
+    "space$": TokenType.SPACE, "str$": TokenType.STR,
+    "string$": TokenType.STRING_FUNC, "time$": TokenType.TIME,
+    "val": TokenType.VAL,
+
+    "eof": TokenType.EOF_FUNC, "inp": TokenType.INP, "loc": TokenType.LOC,
+    "lof": TokenType.LOF, "peek": TokenType.PEEK, "pos": TokenType.POS,
+    "spc": TokenType.SPC, "tab": TokenType.TAB, "usr": TokenType.USR,
+    "varptr": TokenType.VARPTR,
+}
+
+#: Keywords MBASIC allows to be followed directly by '#' for file I/O.
+FILE_IO_KEYWORDS = ("print", "lprint", "input", "write", "field", "get",
+                    "put", "close")

--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -1015,6 +1015,11 @@ def print_capabilities():
         ("jpegdec", jpeg_status, "host djpeg decode with visible placeholder fallback"),
         ("bmp", "real", "direct uncompressed BMP decoder"),
         ("battery", "simulated", "scriptable battery percentage"),
+        (
+            "mmbasic",
+            "simulated",
+            "Python parser/runtime matching the firmware C module contract",
+        ),
         ("psram", "simulated", "global byte heap + LCD RGB565 render"),
         ("engine", "simulated", "2D lifecycle/collision helpers plus deterministic 3D sprite/wall projection"),
         ("gameboy", "real" if _exists(gameboy_runner) else "partial", "Walnut-CGB native RGB565 frame/input helper with placeholder fallback"),

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -548,6 +548,9 @@ def _run_sim_check(opts):
     _run_library_route_check()
     _run_stale_app_link_check(opts)
     _run_duplicate_app_link_check(opts)
+    _run_mmbasic_parity_check(opts)
+    mmbasic_clock_path = opts["sd"].rstrip("/") + "/sim_reports/mmbasic-clock.bmp"
+    _mkdir_p(_dirname(mmbasic_clock_path))
     commands = (
         "sh "
         + _quote(THIS_DIR + "/build.sh")
@@ -580,10 +583,12 @@ def _run_sim_check(opts):
         + _quote(THIS_DIR + "/run.py")
         + " --headless --open MMBasic --wait-view mmbasic --keys enter --assert-text "
         + _quote("MMBasic 6.03")
-        + " --frames 300 --audio silent --network offline --sd "
+        + " --frames 80 --audio silent --network offline --sd "
         + _quote(opts["sd"])
         + " --apps-source "
-        + _quote(opts["apps_source"]),
+        + _quote(opts["apps_source"])
+        + " --screenshot "
+        + _quote(mmbasic_clock_path),
         "micropython "
         + _quote(THIS_DIR + "/run.py")
         + " --headless --app Forecast --wait-view app_Forecast --frames 220 --audio silent --network offline --sd "
@@ -638,6 +643,7 @@ def _run_sim_check(opts):
         if status != 0:
             print("[sim-check:fail]", cmd, status)
             raise SystemExit(1)
+    _run_mmbasic_clock_frame_check(mmbasic_clock_path)
     _run_keyboard_background_check()
     _run_lcd_parity_check()
     _run_uart_parity_check()
@@ -831,6 +837,114 @@ def _run_keyboard_background_check():
         raise RuntimeError("simulator disabled background keyboard consumed a key")
     picoware_keyboard.deinit()
     print("[sim-check:ok] picocalc background keyboard callbacks")
+
+
+def _run_mmbasic_parity_check(opts):
+    """Exercise the native MMBasic constructor and lifecycle contract."""
+    import lcd
+    import mmbasic
+    import sd_mp
+    import sim_runtime
+
+    original_headless = sim_runtime.headless
+    original_lcd = sim_runtime.get_lcd()
+    original_sd_root = sim_runtime.sd_root
+    path = "sim_reports/mmbasic-parity.bas"
+    try:
+        sim_runtime.headless = True
+        sim_runtime.sd_root = opts["sd"]
+        lcd.LCD()
+
+        engine = mmbasic.MMBasic(0xFFFF, 0, 0x07E0, 320, 320, 8, 8, 0, 0)
+        if engine._start():
+            raise RuntimeError("simulator MMBasic accepted an empty start")
+        if not engine._start(source='PRINT "Parity probe"\nEND'):
+            raise RuntimeError("simulator MMBasic rejected source input")
+        if engine.has_graphics:
+            raise RuntimeError("simulator MMBasic misclassified console source")
+        if engine.tick(5) != (1, "", 0):
+            raise RuntimeError("simulator MMBasic END status mismatch")
+
+        sd_mp.write(path, b'CLS\nDO WHILE INKEY$ = "": LOOP\n')
+        engine = mmbasic.MMBasic(0xFFFF, 0, 0x07E0, 320, 320, 8, 8, 0, 0)
+        if not engine._start(path=path):
+            raise RuntimeError("simulator MMBasic rejected path input")
+        if engine.tick(5) != (0, "", 0):
+            raise RuntimeError("simulator MMBasic INKEY loop status mismatch")
+        if not engine.has_graphics:
+            raise RuntimeError("simulator MMBasic missed executed graphics")
+        engine.feed_char("x")
+        if engine.tick(5) != (1, "", 0):
+            raise RuntimeError("simulator MMBasic input completion mismatch")
+        engine.set_footer("Done")
+        engine.console_output("Complete")
+        engine.render(True)
+    finally:
+        sd_mp.remove(path)
+        sim_runtime.set_lcd(original_lcd)
+        sim_runtime.sd_root = original_sd_root
+        sim_runtime.headless = original_headless
+        gc.collect()
+    print("[sim-check:ok] MMBasic native constructor source path input graphics")
+
+
+def _run_mmbasic_clock_frame_check(path):
+    """Prove the bundled BASIC clock rendered a face and red second hand."""
+    import ustruct
+
+    try:
+        with open(path, "rb") as handle:
+            data = handle.read()
+    except OSError:
+        raise RuntimeError("simulator MMBasic clock screenshot missing")
+    if len(data) < 54 or data[:2] != b"BM":
+        raise RuntimeError("simulator MMBasic clock screenshot is not a BMP")
+
+    offset = ustruct.unpack_from("<I", data, 10)[0]
+    width = ustruct.unpack_from("<I", data, 18)[0]
+    height = ustruct.unpack_from("<I", data, 22)[0]
+    if width != 320 or height != 320:
+        raise RuntimeError("simulator MMBasic clock screenshot size mismatch")
+    row_size = ((width * 3 + 3) // 4) * 4
+    if len(data) < offset + row_size * height:
+        raise RuntimeError("simulator MMBasic clock screenshot is truncated")
+
+    non_black = 0
+    red = 0
+    grey = 0
+    for row in range(height):
+        pos = offset + row * row_size
+        for _ in range(width):
+            blue = data[pos]
+            green = data[pos + 1]
+            red_value = data[pos + 2]
+            pos += 3
+            if red_value or green or blue:
+                non_black += 1
+            if red_value >= 220 and green <= 40 and blue <= 40:
+                red += 1
+            if (
+                80 <= red_value <= 220
+                and abs(red_value - green) <= 8
+                and abs(red_value - blue) <= 8
+            ):
+                grey += 1
+
+    if non_black < 350 or red < 50 or grey < 200:
+        raise RuntimeError(
+            "simulator MMBasic clock framebuffer incomplete: non_black="
+            + str(non_black)
+            + " red="
+            + str(red)
+            + " grey="
+            + str(grey)
+        )
+    print(
+        "[sim-check:ok] MMBasic clock framebuffer face and red hand",
+        non_black,
+        red,
+        grey,
+    )
 
 
 def _run_lcd_parity_check():


### PR DESCRIPTION
## Summary

- restore the last Python MMBasic parser/runtime inside the Unix simulator
- expose the native C module constructor and lifecycle through a simulator adapter
- add source/path/input/graphics contract checks and clock-framebuffer regression coverage

## Why

Picoware moved MMBasic from Python to a firmware C module. The Unix simulator cannot import that target-specific module, so opening the bundled Clock app failed or only showed a placeholder instead of executing `clock.bas`.

## Validation

- `micropython simulator/run.py --sim-check --audio silent --network offline --sd <fresh-temp-dir>`
- clock framebuffer check: 431 non-black pixels, 134 red-hand pixels, 297 grey face/hand pixels
- complete simulator coverage: 54 passed, 0 failed, 0 skipped
- `ruff check simulator/hardware/mmbasic.py simulator/hardware/mmbasic_runtime simulator/hardware/sim_runtime.py simulator/run.py`
- `git diff --check origin/dev...HEAD`

## Scope

Simulator-only. Firmware continues using the native C MMBasic implementation.
