### PR TITLE
Improve Agent MCP reliability and user feedback

### DIFF
--- a/simulator/hardware/sd_mp.py
+++ b/simulator/hardware/sd_mp.py
@@ -95,8 +95,16 @@ def is_directory(path):
 
 
 def create_directory(path):
-    """Create a directory at the given VFS path."""
-    sim_runtime.mkdir_p(_path(path))
+    """Create one directory; like FAT32, its parent must already exist."""
+    target = _path(path)
+    try:
+        os.stat(target)
+        if is_directory(path):
+            return True
+        raise OSError("path exists and is not a directory")
+    except OSError:
+        pass
+    os.mkdir(target)
     return True
 
 
@@ -162,10 +170,8 @@ def readinto(path, buffer):
 
 
 def write(path, data, overwrite=True):
-    """Write data to a VFS path, creating parent directories."""
+    """Write data to a VFS path; the parent directory must exist."""
     target = _path(path)
-    parent = target.rsplit("/", 1)[0] if "/" in target else "."
-    sim_runtime.mkdir_p(parent)
     with open(target, "wb" if overwrite else "ab") as handle:
         handle.write(data)
     return True
@@ -213,11 +219,32 @@ def get_file_size(path):
         return 0
 
 
+def _filesystem_space():
+    """Return simulated SD total and available bytes from its host filesystem."""
+    info = os.statvfs(sim_runtime.sd_root)
+    block_size = info[1] if info[1] else info[0]
+    return block_size * info[2], block_size * info[4]
+
+
+def get_free_space():
+    """Return available bytes for the simulated SD card."""
+    try:
+        return _filesystem_space()[1]
+    except OSError:
+        return 0
+
+
+def get_total_space():
+    """Return total bytes for the simulated SD card."""
+    try:
+        return _filesystem_space()[0]
+    except OSError:
+        return 0
+
+
 def file_open(path):
-    """Open a file on the VFS, creating it if missing."""
+    """Open a file on the VFS, creating it only under an existing parent."""
     target = _path(path)
-    parent = target.rsplit("/", 1)[0] if "/" in target else "."
-    sim_runtime.mkdir_p(parent)
     try:
         open(target, "rb").close()
     except OSError:
@@ -256,8 +283,6 @@ def file_write(file_obj, data):
     """Write data at the current position of an open VFS file."""
     pos = file_obj.position
     target = _path(file_obj.path)
-    parent = target.rsplit("/", 1)[0] if "/" in target else "."
-    sim_runtime.mkdir_p(parent)
     try:
         handle = open(target, "r+b")
     except OSError:

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -97,6 +97,9 @@ def _parse_args(argv):
         "wait_view": "",
         "assert_text": "",
         "sim_check": False,
+        "agent_check": False,
+        "agent_live_check": False,
+        "agent_live_app_check": False,
         "reset_sd": False,
         "sd_profile": "dev",
         "record": "",
@@ -184,6 +187,12 @@ def _parse_args(argv):
             opts["assert_text"] = argv[i]
         elif arg == "--sim-check":
             opts["sim_check"] = True
+        elif arg == "--agent-check":
+            opts["agent_check"] = True
+        elif arg == "--agent-live-check":
+            opts["agent_live_check"] = True
+        elif arg == "--agent-live-app-check":
+            opts["agent_live_app_check"] = True
         elif arg == "--reset-sd":
             opts["reset_sd"] = True
         elif arg == "--sd-profile" and i + 1 < len(argv):
@@ -193,7 +202,7 @@ def _parse_args(argv):
             i += 1
             opts["record"] = _abspath(argv[i])
         elif arg == "--help":
-            print("usage: micropython simulator/run.py [--viewer] [--sdl] [--headless] [--frames N] [--exit-after-frames N] [--speed auto|real|pico2w|fast|unlimited] [--fps N] [--network real|offline] [--bluetooth virtual|off] [--audio real|silent] [--keys a,b] [--keys-text TEXT] [--record FILE] [--open NAME] [--app NAME] [--game NAME] [--apps-source PATH] [--reset-sd] [--sd-profile clean|dev|media|network-fixtures] [--screenshot PATH] [--coverage apps|games|all] [--script FILE] [--wait-view NAME] [--assert-text TEXT] [--capabilities] [--sim-check]")
+            print("usage: micropython simulator/run.py [--viewer] [--sdl] [--headless] [--frames N] [--exit-after-frames N] [--speed auto|real|pico2w|fast|unlimited] [--fps N] [--network real|offline] [--bluetooth virtual|off] [--audio real|silent] [--keys a,b] [--keys-text TEXT] [--record FILE] [--open NAME] [--app NAME] [--game NAME] [--apps-source PATH] [--reset-sd] [--sd-profile clean|dev|media|network-fixtures] [--screenshot PATH] [--coverage apps|games|all] [--script FILE] [--wait-view NAME] [--assert-text TEXT] [--capabilities] [--agent-check] [--agent-live-check] [--agent-live-app-check] [--sim-check]")
             raise SystemExit
         else:
             print("Unknown argument:", arg)
@@ -566,6 +575,14 @@ def _run_sim_check(opts):
     _run_library_route_check()
     _run_stale_app_link_check(opts)
     _run_duplicate_app_link_check(opts)
+    # Run Agent contracts before optional app routes so an unrelated launcher
+    # failure cannot hide Agent regressions.
+    _run_agent_time_grounding_check()
+    _run_agent_tool_loop_check()
+    _run_agent_followup_check()
+    _run_agent_chat_typing_check()
+    _run_agent_new_session_check()
+    _run_agent_sd_capacity_check()
     commands = (
         "sh "
         + _quote(THIS_DIR + "/build.sh")
@@ -776,6 +793,302 @@ def _run_desktop_native_check(opts):
         sim_runtime.headless = original_headless
         gc.collect()
     print("[sim-check:ok] Desktop native logic and MMBasic hardware bridge")
+
+
+def _run_agent_check():
+    """Run only the Picoware Agent contracts."""
+    _run_agent_time_grounding_check()
+    _run_agent_tool_loop_check()
+    _run_agent_followup_check()
+    _run_agent_activity_check()
+    _run_agent_chat_typing_check()
+    _run_agent_new_session_check()
+    _run_agent_sd_capacity_check()
+
+
+def _run_agent_live_check():
+    """Exercise LM Studio MCP, device SD tools, and a stateful follow-up."""
+    from time import localtime
+    from picoware.system.agent.agent import Agent, MODE_APP_CREATOR, MODE_DEVICE_MANAGER
+    from picoware.system.agent.llm import LLM, LOCAL_MCP
+    from picoware.system.storage import Storage
+
+    class LiveRTC:
+        def datetime(self):
+            value = localtime()
+            return (
+                value[0], value[1], value[2], value[6],
+                value[3], value[4], value[5], 0,
+            )
+
+    class LiveTime:
+        is_set = True
+        is_fetching = False
+        rtc = LiveRTC()
+
+    class LiveViewManager:
+        def __init__(self):
+            self.storage = Storage()
+            self.thread_manager = None
+            self.time = LiveTime()
+            self.gmt_offset = 2
+            self.has_wifi = False
+
+        def log(self, message):
+            print(message)
+
+    view_manager = LiveViewManager()
+    storage = view_manager.storage
+    marker_path = "picoware/cache/agent-live-check.txt"
+    app_path = "picoware/apps/AgentLiveApp.py"
+    paths = (
+        marker_path,
+        marker_path + ".agent-tmp",
+        marker_path + ".agent-bak",
+        "picoware/settings/agent-live-request.json",
+        "picoware/settings/agent-live-response.json",
+        "picoware/settings/agent-live-conversation.json",
+        "picoware/settings/agent-live-memory.json",
+        "picoware/settings/agent-live-state.json",
+        app_path,
+        app_path + ".agent-tmp",
+        app_path + ".agent-bak",
+        "picoware/settings/agent-live-app-request.json",
+        "picoware/settings/agent-live-app-response.json",
+        "picoware/settings/agent-live-app-conversation.json",
+        "picoware/settings/agent-live-app-memory.json",
+        "picoware/settings/agent-live-app-state.json",
+    )
+    for path in paths:
+        storage.remove(path)
+
+    agent = Agent(
+        view_manager,
+        MODE_DEVICE_MANAGER,
+        LLM(storage, LOCAL_MCP, "qwen/qwen3.5-9b"),
+        file_path=paths[3],
+        cleanup=False,
+    )
+    agent._response_path = paths[4]
+    agent._conv_path = paths[5]
+    agent._mem_path = paths[6]
+    agent._state_path = paths[7]
+    agent._native_response_id = ""
+    agent._conversation = []
+    app_agent = None
+
+    try:
+        result = agent.run_payload({
+            "message": (
+                "Use the authoritative current-time integration. Then use "
+                "storage_write to create picoware/cache/agent-live-check.txt "
+                "containing exactly LIVE_OK followed by one space and the "
+                "current local date in YYYY-MM-DD form. Use storage_read to "
+                "verify it. Reply with only the complete file content."
+            ),
+            "conversation": [],
+        })
+        if result.get("status") != "completed":
+            raise RuntimeError("live LM Studio Agent request failed: " + str(result.get("message")))
+        if not storage.exists(marker_path):
+            raise RuntimeError("live LM Studio Agent did not create the SD marker")
+        marker = storage.read(marker_path, "r").strip()
+        today = localtime()
+        expected = "LIVE_OK %04d-%02d-%02d" % (today[0], today[1], today[2])
+        if marker != expected:
+            raise RuntimeError(
+                "live LM Studio current-time or SD result mismatch: " + marker
+            )
+        if result.get("message", "").strip() != marker:
+            raise RuntimeError("live LM Studio final answer did not match verified SD data")
+        first_stats = agent.last_stats
+        if first_stats.get("device_tool_calls", 0) < 2:
+            raise RuntimeError("live LM Studio request did not execute both SD tools")
+
+        followup = agent.run_payload({
+            "message": "What exact marker did you write? Reply with only its first word.",
+            "conversation": result.get("conversation", []),
+        })
+        if followup.get("status") != "completed" or followup.get("message", "").strip() != "LIVE_OK":
+            raise RuntimeError("live LM Studio stateful follow-up mismatch")
+        followup_stats = agent.last_stats
+
+        app_agent = Agent(
+            view_manager,
+            MODE_APP_CREATOR,
+            LLM(storage, LOCAL_MCP, "qwen/qwen3.5-9b"),
+            file_path=paths[11],
+            cleanup=False,
+        )
+        app_agent._response_path = paths[12]
+        app_agent._conv_path = paths[13]
+        app_agent._mem_path = paths[14]
+        app_agent._state_path = paths[15]
+        app_agent._native_response_id = ""
+        app_agent._conversation = []
+        app_result = app_agent.run_payload({
+            "message": (
+                "Create a minimal Picoware app at exactly "
+                "picoware/apps/AgentLiveApp.py. It must draw the text Agent "
+                "Live App in start, return True from start, handle BUTTON_BACK "
+                "with view_manager.back() in non-blocking run, and clean up in "
+                "stop. Use the API-reference tools before writing and read the "
+                "complete file back to verify it."
+            ),
+            "conversation": [],
+        })
+        if app_result.get("status") != "completed" or not storage.exists(app_path):
+            raise RuntimeError(
+                "live LM Studio App Creator failed: " + str(app_result.get("message"))
+            )
+        source = storage.read(app_path, "r")
+        for required in ("def start", "def run", "def stop", "BUTTON_BACK", "view_manager.back"):
+            if required not in source:
+                raise RuntimeError("live LM Studio App Creator omitted " + required)
+        compile(source, app_path, "exec")
+        app_stats = app_agent.last_stats
+        if app_stats.get("device_tool_calls", 0) < 4:
+            raise RuntimeError("live LM Studio App Creator skipped API or SD verification tools")
+
+        web_result = agent.run_payload({
+            "message": (
+                "Search the current web for two Raspberry Pi Pico 2 W boards "
+                "sold on Amazon Germany. Return exactly two bullet points with "
+                "the product title and a direct http URL for each. Use the web "
+                "tools and do not invent products or URLs."
+            ),
+            "conversation": followup.get("conversation", []),
+        })
+        if web_result.get("status") != "completed":
+            raise RuntimeError(
+                "live LM Studio Amazon web request failed: "
+                + str(web_result.get("message"))
+            )
+        web_message = web_result.get("message", "")
+        if "amazon" not in web_message.lower() or "http" not in web_message.lower():
+            raise RuntimeError("live LM Studio Amazon result omitted direct web evidence")
+        web_stats = agent.last_stats
+        if web_stats.get("mcp_calls", 0) < 1:
+            raise RuntimeError("live LM Studio Amazon request did not execute an MCP tool")
+        print(
+            "[agent-live-check:pass] marker=" + marker
+            + " rounds=" + str(first_stats.get("response_rounds", 0))
+            + " device_tools=" + str(first_stats.get("device_tool_calls", 0))
+            + " mcp_calls=" + str(first_stats.get("mcp_calls", 0))
+            + " followup_rounds=" + str(followup_stats.get("response_rounds", 0))
+            + " app_tools=" + str(app_stats.get("device_tool_calls", 0))
+            + " web_mcp_calls=" + str(web_stats.get("mcp_calls", 0))
+        )
+        print("[agent-live-check:web] " + web_message[:500].replace("\n", " | "))
+    finally:
+        agent.cancel()
+        if app_agent is not None:
+            app_agent.cancel()
+        for path in paths:
+            storage.remove(path)
+
+
+def _run_agent_live_app_check():
+    """Exercise only live LM Studio App Creator SD generation."""
+    from time import localtime
+    from picoware.system.agent.agent import Agent, MODE_APP_CREATOR
+    from picoware.system.agent.llm import LLM, LOCAL_MCP
+    from picoware.system.storage import Storage
+
+    class LiveRTC:
+        def datetime(self):
+            value = localtime()
+            return (
+                value[0], value[1], value[2], value[6],
+                value[3], value[4], value[5], 0,
+            )
+
+    class LiveTime:
+        is_set = True
+        is_fetching = False
+        rtc = LiveRTC()
+
+    class LiveViewManager:
+        def __init__(self):
+            self.storage = Storage()
+            self.thread_manager = None
+            self.time = LiveTime()
+            self.gmt_offset = 2
+            self.has_wifi = False
+
+        def log(self, message):
+            print(message)
+
+    view_manager = LiveViewManager()
+    storage = view_manager.storage
+    app_path = "picoware/apps/AgentLiveApp.py"
+    paths = (
+        app_path,
+        app_path + ".agent-tmp",
+        app_path + ".agent-bak",
+        "picoware/settings/agent-live-app-request.json",
+        "picoware/settings/agent-live-app-response.json",
+        "picoware/settings/agent-live-app-conversation.json",
+        "picoware/settings/agent-live-app-memory.json",
+        "picoware/settings/agent-live-app-state.json",
+    )
+    for path in paths:
+        storage.remove(path)
+
+    agent = Agent(
+        view_manager,
+        MODE_APP_CREATOR,
+        LLM(storage, LOCAL_MCP, "qwen/qwen3.5-9b"),
+        file_path=paths[3],
+        cleanup=False,
+    )
+    agent._response_path = paths[4]
+    agent._conv_path = paths[5]
+    agent._mem_path = paths[6]
+    agent._state_path = paths[7]
+    agent._native_response_id = ""
+    agent._conversation = []
+
+    try:
+        result = agent.run_payload({
+            "message": (
+                "Create a minimal Picoware app at exactly "
+                "picoware/apps/AgentLiveApp.py. It must draw the text Agent "
+                "Live App in start, return True from start, handle BUTTON_BACK "
+                "with view_manager.back() in non-blocking run, and clean up in "
+                "stop. Use the API-reference tools before writing, validate "
+                "the saved app, and read the complete file back exactly once "
+                "to verify it. Then stop using tools and report success."
+            ),
+            "conversation": [],
+        })
+        if result.get("status") != "completed" or not storage.exists(app_path):
+            raise RuntimeError(
+                "live LM Studio App Creator failed: " + str(result.get("message"))
+            )
+        source = storage.read(app_path, "r")
+        for required in (
+            "def start(view_manager)",
+            "def run(view_manager)",
+            "def stop(view_manager)",
+            "BUTTON_BACK",
+            "view_manager.back",
+        ):
+            if required not in source:
+                raise RuntimeError("live LM Studio App Creator omitted " + required)
+        compile(source, app_path, "exec")
+        stats = agent.last_stats
+        if stats.get("device_tool_calls", 0) < 4:
+            raise RuntimeError("live LM Studio App Creator skipped API or SD verification tools")
+        print(
+            "[agent-live-app-check:pass] rounds="
+            + str(stats.get("response_rounds", 0))
+            + " device_tools=" + str(stats.get("device_tool_calls", 0))
+        )
+    finally:
+        agent.cancel()
+        for path in paths:
+            storage.remove(path)
 
 
 def _run_library_route_check():
@@ -1436,6 +1749,1026 @@ def _run_audio_shutdown_check():
     print("[sim-check:ok] audio sidecar shutdown")
 
 
+def _run_agent_time_grounding_check():
+    """Verify Agent clock metadata and cutoff-safe MCP grounding."""
+    from picoware.system.agent.agent import _current_time_grounding
+    from picoware.system.agent.tools.network import network_get_time_info
+
+    class ProbeRTC:
+        def datetime(self):
+            return (2026, 8, 15, 6, 11, 52, 3, 0)
+
+    class ProbeTime:
+        def __init__(self, is_set):
+            self.is_set = is_set
+            self.is_fetching = False
+            self.rtc = ProbeRTC()
+
+    class ProbeViewManager:
+        def __init__(self, is_set):
+            self.gmt_offset = 2
+            self.time = ProbeTime(is_set)
+
+    ready = ProbeViewManager(True)
+    info = network_get_time_info(ready)
+    if info["current_local_datetime"] != "2026-08-15T11:52:03":
+        raise RuntimeError("Agent current-time formatting mismatch")
+    if info["gmt_offset_hours"] != 2 or info["utc_offset"] != "+02:00":
+        raise RuntimeError("Agent current-time UTC offset mismatch")
+    if not info["clock_is_set"] or info["clock_is_fetching"]:
+        raise RuntimeError("Agent current-time state mismatch")
+    grounding = _current_time_grounding(ready)
+    if "2026-08-15T11:52:03" not in grounding or "+02:00" not in grounding:
+        raise RuntimeError("Agent MCP grounding omitted current time")
+    if "web or research tool" not in grounding:
+        raise RuntimeError("Agent MCP grounding omitted post-cutoff guidance")
+
+    unset = _current_time_grounding(ProbeViewManager(False))
+    if "clock is not set" not in unset or "current-time tool" not in unset:
+        raise RuntimeError("Agent MCP unset-clock guidance mismatch")
+    print("[sim-check:ok] Agent current-time metadata and MCP grounding")
+
+
+def _run_agent_tool_loop_check():
+    """Verify built-in and native MCP repeated-tool loop detection."""
+    from picoware.system.agent.agent import (
+        MAX_TOOL_CALLS_PER_RUN,
+        _NativeResearchSink,
+        _native_tool_loop_issue,
+        _tool_loop_issue,
+        _tool_loop_policy,
+    )
+
+    history = []
+    for _ in range(2):
+        if _tool_loop_issue(history, "network_get_info", {}) != "":
+            raise RuntimeError("Agent loop guard rejected the allowed retry")
+    issue = _tool_loop_issue(history, "network_get_info", {})
+    if "repeated with identical arguments" not in issue:
+        raise RuntimeError("Agent loop guard missed an identical third call")
+
+    history = []
+    for index in range(MAX_TOOL_CALLS_PER_RUN):
+        if _tool_loop_issue(history, "tool_" + str(index), {}) != "":
+            raise RuntimeError("Agent loop guard rejected an allowed tool call")
+    if _tool_loop_issue(history, "one_too_many", {}) != "tool-call budget exceeded":
+        raise RuntimeError("Agent loop guard missed the tool-call budget")
+
+    trace = []
+    for _ in range(3):
+        trace.append(
+            {
+                "type": "tool_call",
+                "tool": "get_current_time",
+                "arguments": {},
+                "provider_info": {
+                    "type": "plugin",
+                    "plugin_id": "local/toolguard-current-time",
+                },
+            }
+        )
+    if "repeated with identical arguments" not in _native_tool_loop_issue(trace):
+        raise RuntimeError("Agent native MCP audit missed a repeated tool loop")
+    if _native_tool_loop_issue(trace[:2]) != "":
+        raise RuntimeError("Agent native MCP audit rejected the allowed retry")
+
+    class ProbeHTTP:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    probe_http = ProbeHTTP()
+    sink = _NativeResearchSink(probe_http)
+    event = {
+        "type": "tool_call.arguments",
+        "tool": "Web Search",
+        "arguments": {"query": "same"},
+        "provider_info": {"type": "plugin", "plugin_id": "duckduckgo"},
+    }
+    encoded_event = ("data: " + __import__("json").dumps(event) + "\n\n").encode()
+    sink.write(encoded_event)
+    success_event = dict(event)
+    success_event["type"] = "tool_call.success"
+    success_event["output"] = "bounded evidence"
+    sink.write(("data: " + __import__("json").dumps(success_event) + "\n\n").encode())
+    if sink.evidence != ["bounded evidence"]:
+        raise RuntimeError("Agent streaming MCP guard did not retain completed evidence")
+    sink.write(encoded_event)
+    if sink.issue or probe_http.closed:
+        raise RuntimeError("Agent streaming MCP guard rejected the allowed retry")
+    sink.write(encoded_event)
+    if "repeated with identical arguments" not in sink.issue or not probe_http.closed:
+        raise RuntimeError("Agent streaming MCP guard did not stop a live loop")
+
+    single_http = ProbeHTTP()
+    single_sink = _NativeResearchSink(single_http, max_calls=1)
+    single_sink.write(encoded_event)
+    single_sink.write(
+        ("data: " + __import__("json").dumps(success_event) + "\n\n").encode()
+    )
+    if (
+        not single_sink.complete
+        or single_sink.issue
+        or not single_http.closed
+        or single_sink.call_count != 1
+        or single_sink.evidence != ["bounded evidence"]
+    ):
+        raise RuntimeError("Agent did not end a native stage after its first result")
+
+    class ProbeFile:
+        def __init__(self, path):
+            self.path = path
+
+    class ProbeStorage:
+        def __init__(self):
+            self.files = {}
+
+        def remove(self, path):
+            self.files.pop(path, None)
+            return True
+
+        def file_open(self, path):
+            self.files[path] = bytearray()
+            return ProbeFile(path)
+
+        def file_write(self, file_obj, data, _mode="wb"):
+            self.files[file_obj.path].extend(data)
+            return True
+
+        def file_close(self, _file_obj):
+            return None
+
+    spool_storage = ProbeStorage()
+    spool_http = ProbeHTTP()
+    spool_sink = _NativeResearchSink(
+        spool_http, spool_storage, "agent-mcp-stream.tmp"
+    )
+    split_event = (
+        "data: " + __import__("json").dumps(success_event) + "\n\n"
+    ).encode()
+    split_at = len(split_event) // 2
+    spool_sink.write(split_event[:split_at])
+    spool_sink.write(split_event[split_at:])
+    chat_end = b'data: {"type":"chat.end","result":{"output":[]}}\n\n'
+    spool_sink.write(chat_end)
+    spool_sink.close()
+    if spool_sink.evidence != ["bounded evidence"] or spool_sink.result != {}:
+        raise RuntimeError("Agent SD-spooled MCP parser result mismatch")
+    if bytes(spool_storage.files["agent-mcp-stream.tmp"]) != split_event + chat_end:
+        raise RuntimeError("Agent MCP stream was not mirrored exactly to SD")
+
+    from picoware.system.http import HTTP
+
+    class ProbeChunkSocket:
+        def __init__(self, payload_size):
+            self.remaining = payload_size
+            self.lines = [b"10000\r\n", b"0\r\n", b"\r\n"]
+            self.max_read = 0
+
+        def readline(self):
+            return self.lines.pop(0) if self.lines else b""
+
+        def read(self, count):
+            self.max_read = max(self.max_read, count)
+            if self.remaining:
+                actual = min(count, self.remaining)
+                self.remaining -= actual
+                return b"x" * actual
+            return b"\r\n" if count == 2 else b""
+
+        def close(self):
+            return None
+
+    class ProbeSink:
+        def __init__(self):
+            self.bytes_written = 0
+
+        def write(self, value):
+            if isinstance(value, (bytes, bytearray)):
+                self.bytes_written += len(value)
+
+        def flush(self):
+            return None
+
+    chunk_http = HTTP(chunk_size=4096)
+    chunk_http._running = True
+    chunk_socket = ProbeChunkSocket(65536)
+    chunk_sink = ProbeSink()
+    chunk_http.read_chunked(chunk_socket, chunk_sink)
+    if chunk_socket.max_read > 4096 or chunk_sink.bytes_written != 65536:
+        raise RuntimeError("HTTP chunked reader materialized a server-sized chunk")
+
+    policy = _tool_loop_policy()
+    if "no more than 16 tool calls" not in policy or "Never repeat" not in policy:
+        raise RuntimeError("Agent native MCP request omitted loop policy")
+    print("[sim-check:ok] Agent built-in and native MCP tool-loop guards")
+
+
+def _run_agent_followup_check():
+    """Verify Responses follow-ups and a device-executed nested SD write."""
+    import json
+    from picoware.system.agent.agent import (
+        Agent, MAX_NATIVE_MCP_CALLS, _argument_signature, _native_response_id,
+    )
+    from picoware.system.agent.tools import dispatch
+    from picoware.system.agent.tools.api_reference import (
+        picoware_api_read,
+        picoware_api_search,
+    )
+
+    class ProbeFile:
+        def __init__(self, path):
+            self.path = path
+            self.position = 0
+
+    class ProbeStorage:
+        def __init__(self):
+            self.files = {}
+            self.dirs = {"picoware", "picoware/settings", "picoware/apps"}
+            self.free_space = 3 * 1024 * 1024 * 1024
+            self.total_space = 8 * 1024 * 1024 * 1024
+            self.max_write_fragment = 0
+
+        def exists(self, path):
+            return path in self.files or path in self.dirs
+
+        def is_directory(self, path):
+            return path in self.dirs
+
+        def listdir(self, path=""):
+            prefix = path + "/" if path else ""
+            entries = []
+            for candidate in tuple(self.dirs) + tuple(self.files):
+                if not candidate.startswith(prefix) or candidate == path:
+                    continue
+                entry = candidate[len(prefix):].split("/", 1)[0]
+                if entry and entry not in entries:
+                    entries.append(entry)
+            return entries
+
+        def mkdir(self, path):
+            parent = path.rsplit("/", 1)[0] if "/" in path else ""
+            if parent and parent not in self.dirs:
+                return False
+            self.dirs.add(path)
+            return True
+
+        def remove(self, path):
+            self.files.pop(path, None)
+            self.dirs.discard(path)
+            return True
+
+        def write(self, path, data, mode="w"):
+            if isinstance(data, str):
+                data = data.encode("utf-8")
+            self.max_write_fragment = max(self.max_write_fragment, len(data))
+            if mode == "w" or path not in self.files:
+                self.files[path] = bytes(data)
+            else:
+                self.files[path] += bytes(data)
+            return True
+
+        def serialize(self, path):
+            return json.loads(self.files[path].decode("utf-8"))
+
+        def deserialize(self, value, path):
+            self.files[path] = json.dumps(value).encode("utf-8")
+            return True
+
+        def file_open(self, path):
+            parent = path.rsplit("/", 1)[0] if "/" in path else ""
+            if parent and parent not in self.dirs:
+                return None
+            self.files.setdefault(path, b"")
+            return ProbeFile(path)
+
+        def file_close(self, _file):
+            return None
+
+        def file_write(self, file_obj, data, mode="b"):
+            if isinstance(data, str):
+                data = data.encode("utf-8")
+            self.max_write_fragment = max(self.max_write_fragment, len(data))
+            current = self.files.get(file_obj.path, b"")
+            before = current[:file_obj.position]
+            after_offset = file_obj.position + len(data)
+            after = current[after_offset:] if after_offset < len(current) else b""
+            self.files[file_obj.path] = before + bytes(data) + after
+            file_obj.position += len(data)
+            return True
+
+        def file_readinto(self, file_obj, buffer):
+            data = self.files.get(file_obj.path, b"")
+            chunk = data[file_obj.position:file_obj.position + len(buffer)]
+            buffer[:len(chunk)] = chunk
+            file_obj.position += len(chunk)
+            return len(chunk)
+
+        def file_seek(self, file_obj, position):
+            file_obj.position = position
+            return True
+
+        def size(self, path):
+            return len(self.files.get(path, b""))
+
+        def read_chunked(self, path, start=0, chunk_size=1024):
+            return self.files.get(path, b"")[start:start + chunk_size]
+
+        def read(self, path, mode="r", index=0, count=0):
+            data = self.files.get(path, b"")
+            data = data[index:index + count] if count else data[index:]
+            return data.decode("utf-8") if mode == "r" else data
+
+        def copy(self, source, destination, _chunk_size=2048):
+            if source not in self.files or destination in self.files:
+                return False
+            self.files[destination] = bytes(self.files[source])
+            return True
+
+        def rename(self, old_path, new_path):
+            if old_path not in self.files or new_path in self.files:
+                return False
+            self.files[new_path] = self.files.pop(old_path)
+            return True
+
+    class ProbeRTC:
+        def datetime(self):
+            return (2026, 8, 15, 6, 12, 0, 0, 0)
+
+    class ProbeTime:
+        is_set = True
+        is_fetching = False
+        rtc = ProbeRTC()
+
+    class ProbeViewManager:
+        def __init__(self):
+            self.storage = ProbeStorage()
+            self.time = ProbeTime()
+            self.gmt_offset = 2
+            self.thread_manager = None
+            self.logs = []
+
+        def log(self, message):
+            self.logs.append(message)
+
+    class ProbeLLM:
+        id = 6
+        model = "qwen/qwen3.5-9b"
+        mcp_integrations = ["local/toolguard-current-time"]
+        thinking_payload = {}
+        headers = {}
+        url = "http://127.0.0.1:1234/v1/responses"
+        native_mcp = True
+
+    class ProbeResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+        def close(self):
+            return None
+
+    class ProbeHTTP:
+        def __init__(self):
+            self.requests = []
+
+        def post(self, _url, **kwargs):
+            request = json.loads(
+                kwargs["storage"].files[kwargs["send_file"]].decode("utf-8")
+            )
+            self.requests.append(request)
+            index = len(self.requests)
+            if index == 1:
+                return ProbeResponse({
+                    "id": "resp_1",
+                    "output": [{
+                        "type": "function_call",
+                        "name": "storage_write",
+                        "call_id": "call_1",
+                        "arguments": json.dumps({
+                            "file_path": "picoware/apps/generated/example.py",
+                            "data": "print('ok')\n",
+                            "mode": "w",
+                            "encoding": "utf-8",
+                        }),
+                    }],
+                    "usage": {"input_tokens": 100},
+                })
+            return ProbeResponse({
+                "id": "resp_" + str(index),
+                "output": [{"type": "message", "content": "answer " + str(index)}],
+            })
+
+    if _native_response_id(None) != "" or _native_response_id("   ") != "":
+        raise RuntimeError("Agent accepted an invalid native response ID")
+    if _native_response_id("x" * 513) != "":
+        raise RuntimeError("Agent accepted an oversized native response ID")
+
+    view_manager = ProbeViewManager()
+    agent = Agent(
+        view_manager,
+        mode=1,
+        llm=ProbeLLM(),
+        file_path="agent-followup-request.json",
+        cleanup=False,
+    )
+    agent.http = ProbeHTTP()
+    agent._conv_path = "agent-followup-conversation.json"
+    agent._mem_path = "agent-followup-memory.json"
+    agent._response_path = "agent-followup-response.json"
+    agent._state_path = "agent-followup-state.json"
+
+    initial_response_tools = [tool["name"] for tool in agent._response_tools({})]
+    bounded_response_tools = [
+        tool["name"]
+        for tool in agent._response_tools({"network_get_info": 1})
+    ]
+    bounded_chat_tools = [
+        tool["function"]["name"]
+        for tool in agent._chat_completion_tools({"network_get_info": 1})
+    ]
+    if (
+        "network_get_info" not in initial_response_tools
+        or "network_get_info" in bounded_response_tools
+        or "network_get_info" in bounded_chat_tools
+    ):
+        raise RuntimeError("Agent did not retire network_get_info after one call")
+    cached_info = {"board_name": "PicoCalc", "is_wifi_connected": True}
+    info_signature = ("network_get_info", _argument_signature({}))
+    info_history = [("network_get_info", info_signature[1])]
+    reused_info = agent._execute_mode_guarded_tool(
+        info_history,
+        {info_signature: cached_info},
+        {"network_get_info": 1},
+        "network_get_info",
+        {},
+    )
+    if reused_info is not cached_info or len(info_history) != 1:
+        raise RuntimeError("Agent did not safely reuse repeated network info")
+
+    large_input = [{"role": "user", "content": "evidence " + ("x" * 30000)}]
+    agent._build_responses_request(large_input, [], agent._response_tools({}))
+    streamed_request = json.loads(
+        view_manager.storage.files[agent._file_path].decode("utf-8")
+    )
+    if streamed_request.get("input") != large_input:
+        raise RuntimeError("Agent streamed Responses request changed its input")
+    if view_manager.storage.max_write_fragment > 4096:
+        raise RuntimeError(
+            "Agent streamed Responses request wrote an oversized fragment: "
+            + str(view_manager.storage.max_write_fragment)
+        )
+    view_manager.storage.max_write_fragment = 0
+
+    result = agent.run_payload({"message": "Create a nested example app.", "conversation": []})
+    if result["message"] != "answer 2":
+        raise RuntimeError(
+            "Agent Responses custom-tool result mismatch: " + repr(result)
+        )
+    generated = view_manager.storage.files.get("picoware/apps/generated/example.py")
+    if generated != b"print('ok')\n":
+        raise RuntimeError("Agent Responses did not execute and verify the SD write")
+    followup = agent.run_payload({
+        "message": "What did you create?",
+        "conversation": result["conversation"],
+    })
+    if followup["message"] != "answer 3":
+        raise RuntimeError("Agent follow-up native response mismatch")
+
+    first, second, third = agent.http.requests
+    if not first.get("store") or "previous_response_id" in first:
+        raise RuntimeError("Agent first native request state mismatch")
+    if not first.get("instructions") or not first.get("tools"):
+        raise RuntimeError("Agent first Responses request omitted instructions or tools")
+    if second.get("previous_response_id") != "resp_1":
+        raise RuntimeError("Agent function output omitted previous response ID")
+    if not second.get("instructions"):
+        raise RuntimeError("Agent tool-output round omitted turn-scoped instructions")
+    if second.get("input", [{}])[0].get("type") != "function_call_output":
+        raise RuntimeError("Agent omitted Responses function_call_output")
+    if third.get("previous_response_id") != "resp_2":
+        raise RuntimeError("Agent visible follow-up omitted previous response ID")
+    if not third.get("instructions"):
+        raise RuntimeError("Agent visible follow-up omitted turn-scoped instructions")
+    if agent._native_response_id != "resp_3":
+        raise RuntimeError("Agent did not advance native response state")
+
+    class ProbeScanHTTP:
+        def post(self, _url, **kwargs):
+            catalog = [
+                {"id": "mcp/duckduckgo", "type": "mcp"},
+                {"id": "plugin:local/toolguard-current-time", "type": "plugin"},
+            ]
+            body = {
+                "output": [{
+                    "type": "tool_call",
+                    "output": json.dumps(catalog),
+                }]
+            }
+            kwargs["storage"].write(
+                kwargs["save_to_file"], json.dumps(body), mode="w"
+            )
+            return ProbeResponse({})
+
+    agent.http = ProbeScanHTTP()
+    integrations, scan_error = agent.scan_integrations()
+    if scan_error or integrations != [
+        "mcp/duckduckgo", "plugin:local/toolguard-current-time"
+    ]:
+        raise RuntimeError("Agent SD-spooled integration scan mismatch")
+    if view_manager.storage.exists(agent._response_path):
+        raise RuntimeError("Agent integration scan left its SD response spool behind")
+
+    appended = dispatch.execute_tool(
+        view_manager,
+        "storage_write",
+        {
+            "file_path": "/sd/picoware/apps/generated/example.py",
+            "data": "print('more')\n",
+            "mode": "a",
+            "encoding": "utf-8",
+        },
+    )
+    if not appended.get("ok") or view_manager.storage.files.get(
+        "picoware/apps/generated/example.py"
+    ) != b"print('ok')\nprint('more')\n":
+        raise RuntimeError("Agent recoverable append contract mismatch")
+    root_listing = dispatch.execute_tool(
+        view_manager, "storage_listdir", {"dir_path": "/sd"}
+    )
+    if not root_listing.get("ok") or "picoware" not in root_listing.get("entries", []):
+        raise RuntimeError("Agent SD-root listing contract mismatch")
+    capacity = dispatch.execute_tool(view_manager, "storage_get_info")
+    if (
+        not capacity.get("ok")
+        or capacity.get("free_bytes") != 3 * 1024 * 1024 * 1024
+        or capacity.get("total_bytes") != 8 * 1024 * 1024 * 1024
+        or capacity.get("used_bytes") != 5 * 1024 * 1024 * 1024
+        or not capacity.get("free")
+    ):
+        raise RuntimeError("Agent SD capacity contract mismatch: " + repr(capacity))
+    escaped = dispatch.execute_tool(
+        view_manager,
+        "storage_write",
+        {"file_path": "../escape.py", "data": "bad", "mode": "w"},
+    )
+    if escaped.get("ok"):
+        raise RuntimeError("Agent SD path normalization allowed a root escape")
+
+    sections = picoware_api_search(view_manager, "button input", 4)
+    if not sections.get("ok") or not sections.get("sections"):
+        raise RuntimeError("Agent App Creator API search returned no section")
+    reference = picoware_api_read(view_manager, sections["sections"][0], 1024)
+    if not reference.get("ok") or not reference.get("content"):
+        raise RuntimeError("Agent App Creator API read returned no content")
+    valid_source = (
+        "from picoware.system.buttons import BUTTON_BACK\n\n"
+        "def start(view_manager):\n    return True\n\n"
+        "def run(view_manager):\n"
+        "    if view_manager.button == BUTTON_BACK:\n"
+        "        view_manager.back()\n\n"
+        "def stop(view_manager):\n    pass\n"
+    )
+    valid_write = dispatch.execute_tool(
+        view_manager,
+        "storage_write",
+        {
+            "file_path": "picoware/apps/generated/valid.py",
+            "data": valid_source,
+            "mode": "w",
+            "encoding": "utf-8",
+        },
+    )
+    validation = dispatch.execute_tool(
+        view_manager,
+        "picoware_app_validate",
+        {"file_path": "picoware/apps/generated/valid.py"},
+    )
+    if not valid_write.get("ok") or not validation.get("ok"):
+        raise RuntimeError("Agent App Creator validator rejected a valid app")
+    tool_names = [tool.get("name") for tool in first.get("tools", [])]
+    if (
+        "storage_write" not in tool_names
+        or "picoware_api_search" not in tool_names
+        or "picoware_app_validate" not in tool_names
+    ):
+        raise RuntimeError("Agent Responses request omitted device tools")
+    if len(first.get("instructions", "")) > 12000:
+        raise RuntimeError("Agent App Creator request still embeds the full API reference")
+
+    class WebLLM(ProbeLLM):
+        mcp_integrations = [
+            "local/toolguard-current-time",
+            "danielsig/visit-website",
+            "danielsig/duckduckgo",
+            "mcp/modelcontextprotocolfetch",
+            "mcp/microsoftplaywright-mcp",
+        ]
+
+    agent.llm = WebLLM()
+    search_profile = agent._selected_integrations(
+        "Search the current web for the official OpenAI homepage"
+    )
+    search_ids = [item.get("id") for item in search_profile]
+    if (
+        "danielsig/duckduckgo" not in search_ids
+        or "mcp/microsoftplaywright-mcp" not in search_ids
+        or "mcp/modelcontextprotocolfetch" in search_ids
+    ):
+        raise RuntimeError("Agent web search did not pair DuckDuckGo with Playwright")
+    agent._build_native_research_request(
+        "Search the current web for the official OpenAI homepage",
+        search_profile,
+    )
+    native_chat_request = json.loads(
+        view_manager.storage.files[agent._file_path].decode("utf-8")
+    )
+    if "max_tool_calls" in native_chat_request:
+        raise RuntimeError("Agent sent unsupported max_tool_calls to /api/v1/chat")
+    playwright_item = next(
+        item for item in search_profile if "playwright" in item.get("id", "")
+    )
+    if playwright_item.get("allowed_tools") != [
+        "browser_navigate", "browser_snapshot", "browser_wait_for",
+    ]:
+        raise RuntimeError("Agent Playwright profile exposed unbounded tools")
+    explicit_playwright_ids = [
+        item.get("id")
+        for item in agent._selected_integrations("Playwright: inspect this page")
+    ]
+    if "mcp/microsoftplaywright-mcp" not in explicit_playwright_ids:
+        raise RuntimeError("Agent explicit Playwright request was filtered out")
+    amazon_profile = agent._selected_integrations("Find two items on Amazon")
+    amazon_ids = [item.get("id") for item in amazon_profile]
+    if "mcp/microsoftplaywright-mcp" not in amazon_ids:
+        raise RuntimeError("Agent Amazon profile omitted Playwright")
+    if (
+        "danielsig/duckduckgo" in amazon_ids
+        or "danielsig/visit-website" in amazon_ids
+        or "mcp/modelcontextprotocolfetch" in amazon_ids
+    ):
+        raise RuntimeError("Agent Amazon profile loaded a redundant web fallback")
+    url_profile = agent._selected_integrations("Read https://example.com/page")
+    url_ids = [item.get("id") for item in url_profile]
+    if (
+        "mcp/microsoftplaywright-mcp" not in url_ids
+        or "mcp/modelcontextprotocolfetch" in url_ids
+        or "danielsig/visit-website" in url_ids
+        or "danielsig/duckduckgo" in url_ids
+    ):
+        raise RuntimeError("Agent direct-URL profile did not prefer Playwright")
+    explicit_fetch_ids = [
+        item.get("id")
+        for item in agent._selected_integrations(
+            "Fetch https://example.com/page with the fetch integration"
+        )
+    ]
+    if (
+        "mcp/modelcontextprotocolfetch" not in explicit_fetch_ids
+        or "mcp/microsoftplaywright-mcp" not in explicit_fetch_ids
+    ):
+        raise RuntimeError("Agent explicit fetch request lost a requested web MCP")
+
+    class PipelineAgent(Agent):
+        __slots__ = ("pipeline_calls",)
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.pipeline_calls = []
+
+        def _run_native_research(
+            self, user_message, integrations, max_tool_calls=MAX_NATIVE_MCP_CALLS
+        ):
+            self.pipeline_calls.append(
+                (user_message, integrations, max_tool_calls)
+            )
+            ids = [item.get("id", "") for item in integrations]
+            if any("duckduckgo" in value for value in ids):
+                return "OpenAI result https://openai.com/", 1, ""
+            if any("playwright" in value for value in ids):
+                return "OpenAI | Research & Deployment https://openai.com/", 1, ""
+            return "", 0, "API error: unexpected pipeline stage"
+
+    pipeline_agent = PipelineAgent(
+        view_manager,
+        mode=0,
+        llm=WebLLM(),
+        file_path="agent-pipeline-request.json",
+        cleanup=False,
+    )
+    pipeline_integrations = pipeline_agent._selected_integrations(
+        "Search the current web for the official OpenAI homepage and read it"
+    )
+    pipeline_evidence, pipeline_calls, pipeline_error = (
+        pipeline_agent._run_native_research_pipeline(
+            "Search the current web for the official OpenAI homepage and read it",
+            pipeline_integrations,
+        )
+    )
+    if pipeline_error or pipeline_calls != 2 or len(pipeline_agent.pipeline_calls) != 2:
+        raise RuntimeError("Agent deterministic web pipeline did not run two stages")
+    first_stage = pipeline_agent.pipeline_calls[0]
+    second_stage = pipeline_agent.pipeline_calls[1]
+    if (
+        first_stage[2] != 1
+        or second_stage[2] != 1
+        or not any("duckduckgo" in item.get("id", "") for item in first_stage[1])
+        or not any("playwright" in item.get("id", "") for item in second_stage[1])
+        or second_stage[1][0].get("allowed_tools") != ["browser_navigate"]
+        or "https://openai.com/" not in second_stage[0]
+        or "# Browser page evidence" not in pipeline_evidence
+    ):
+        raise RuntimeError("Agent deterministic web pipeline stages are incorrect")
+
+    class DeviceMCPs(ProbeLLM):
+        mcp_integrations = [
+            "danielsig/duckduckgo",
+            "mcp/nutrition",
+            "mcp/microsoftmarkitdown",
+            "local/toolguard-current-time",
+            "mcp/germany",
+            "mcp/modelcontextprotocolfilesystem",
+            "mcp/modelcontextprotocolfetch",
+            "mcp/microsoftplaywright-mcp",
+        ]
+
+    agent.llm = DeviceMCPs()
+    plain_ids = [
+        item.get("id")
+        for item in agent._selected_integrations("Reply with exactly OK")
+    ]
+    if plain_ids != ["local/toolguard-current-time"]:
+        raise RuntimeError("Agent plain chat loaded unrelated MCP integrations")
+    nutrition_ids = [
+        item.get("id")
+        for item in agent._selected_integrations("Show the nutrition and calories")
+    ]
+    if "mcp/nutrition" not in nutrition_ids or "mcp/germany" in nutrition_ids:
+        raise RuntimeError("Agent nutrition profile selected the wrong MCPs")
+    host_file_ids = [
+        item.get("id")
+        for item in agent._selected_integrations("Read a host filesystem file")
+    ]
+    if "mcp/modelcontextprotocolfilesystem" not in host_file_ids:
+        raise RuntimeError("Agent explicit host-filesystem profile omitted its MCP")
+    bounded_tools = agent._response_tools({"picoware_api_search": 2})
+    bounded_names = [tool.get("name") for tool in bounded_tools]
+    if "picoware_api_search" in bounded_names or "storage_write" not in bounded_names:
+        raise RuntimeError("Agent reference budget hid an SD tool or retained search")
+    if agent._mode_tool_limit("network_send_request") != 1:
+        raise RuntimeError("Agent generic network fetch is not limited to one call")
+    after_research = agent._response_tools({}, ("network_send_request",))
+    after_research_names = [tool.get("name") for tool in after_research]
+    if "network_send_request" in after_research_names:
+        raise RuntimeError("Agent retained generic network fetch after MCP research")
+    print("[sim-check:ok] Agent Responses SD tool and follow-up chain")
+
+
+def _run_agent_chat_typing_check():
+    """Verify a chat letter opens the editor without losing that letter."""
+    from picoware.applications import agent as agent_app
+    from picoware.system.buttons import BUTTON_A
+
+    class ProbeKeyboard:
+        def __init__(self):
+            self.response = "stale"
+            self.title = ""
+            self.forced = False
+
+        def reset(self):
+            self.response = ""
+
+        def run(self, force=False):
+            self.forced = force
+            return True
+
+    class ProbeInput:
+        def __init__(self):
+            self.reset_called = False
+
+        def button_to_char(self, button):
+            return "A" if button == BUTTON_A else ""
+
+        def reset(self):
+            self.reset_called = True
+
+    class ProbeViewManager:
+        def __init__(self):
+            self.button = BUTTON_A
+            self.keyboard = ProbeKeyboard()
+            self.input_manager = ProbeInput()
+
+    view_manager = ProbeViewManager()
+    agent_app._state = agent_app.STATE_CHAT
+    agent_app._mode_label = "Chat"
+    agent_app.run(view_manager)
+    if (
+        agent_app._state != agent_app.STATE_TYPE
+        or view_manager.keyboard.response != "A"
+        or view_manager.keyboard.title != "Chat"
+        or not view_manager.keyboard.forced
+        or not view_manager.input_manager.reset_called
+    ):
+        raise RuntimeError("Agent chat letter did not open a seeded input editor")
+    agent_app._state = agent_app.STATE_MENU
+    print("[sim-check:ok] Agent chat letter opens the seeded input editor")
+
+
+def _run_agent_activity_check():
+    """Verify the Agent waiting screen visibly advances while work continues."""
+    from picoware.applications import agent as agent_app
+
+    class ProbeSize:
+        x = 320
+        y = 320
+
+    class ProbeFontSize:
+        y = 8
+
+    class ProbeDraw:
+        def __init__(self):
+            self.size = ProbeSize()
+            self.font_size = ProbeFontSize()
+            self.font = 0
+            self.text = []
+            self.rectangles = []
+            self.swaps = 0
+
+        def fill_screen(self, _color):
+            return None
+
+        def _fill_rectangle(self, x, y, w, h, color):
+            self.rectangles.append((x, y, w, h, color))
+
+        def _text(self, _x, _y, text, _color, _font):
+            self.text.append(text)
+
+        def len(self, text):
+            return len(text) * 6
+
+        def swap(self):
+            self.swaps += 1
+
+    class ProbeViewManager:
+        def __init__(self):
+            self.draw = ProbeDraw()
+            self.background_color = 0
+            self.foreground_color = 0xFFFF
+            self.selected_color = 0x1234
+
+    view_manager = ProbeViewManager()
+    agent_app._start_activity(view_manager, "Preparing")
+    first_frame = agent_app._activity_frame
+    agent_app._activity_last_ms = (
+        agent_app.ticks_ms() - agent_app.ACTIVITY_FRAME_MS
+    )
+    agent_app._activity_started_ms = agent_app.ticks_ms() - 3000
+    agent_app._animate_activity(view_manager, "LM Studio")
+    if (
+        agent_app._activity_frame == first_frame
+        or view_manager.draw.swaps != 2
+        or not any("Request in progress" == text for text in view_manager.draw.text)
+        or not any("Still working - " in text for text in view_manager.draw.text)
+        or not any("BACK=Cancel" == text for text in view_manager.draw.text)
+        or len(view_manager.draw.rectangles) != agent_app.ACTIVITY_SEGMENTS * 2
+    ):
+        raise RuntimeError("Agent activity indicator did not visibly advance")
+    print("[sim-check:ok] Agent waiting activity indicator advances")
+
+
+def _run_agent_new_session_check():
+    """Verify Tab confirms a fresh session in every Agent chat mode."""
+    from picoware.applications import agent as agent_app
+    from picoware.system.buttons import BUTTON_TAB
+
+    class ProbeSize:
+        x = 320
+        y = 320
+
+    class ProbeFont:
+        width = 5
+        spacing = 1
+        height = 8
+        size = 0
+
+    class ProbeDraw:
+        def __init__(self):
+            self.size = ProbeSize()
+            self.font = 0
+            self.prompts = []
+
+        def get_font(self, _font):
+            return ProbeFont()
+
+        def fill_screen(self, _color):
+            return None
+
+        def _fill_rectangle(self, _x, _y, _w, _h, _color):
+            return None
+
+        def _fill_round_rectangle(self, _x, _y, _w, _h, _radius, _color):
+            return None
+
+        def _text(self, _x, _y, text, _color, _font):
+            self.prompts.append(text)
+
+        def len(self, text):
+            return len(text) * 6
+
+        def swap(self):
+            return None
+
+    class ProbeInput:
+        def button_to_char(self, _button):
+            return ""
+
+    class ProbeAgent:
+        def __init__(self):
+            self.reset_calls = 0
+            self._conversation = [{"role": "user", "content": "old"}]
+
+        @property
+        def conversation(self):
+            return list(self._conversation)
+
+        def reset_conversation(self):
+            self.reset_calls += 1
+            self._conversation = []
+
+    class ProbeViewManager:
+        def __init__(self, confirmed):
+            self.button = BUTTON_TAB
+            self.draw = ProbeDraw()
+            self.background_color = 0
+            self.selected_color = 1
+            self.input_manager = ProbeInput()
+            self.confirmed = confirmed
+            self.alert_message = ""
+
+        def alert(self, message, _back):
+            self.alert_message = message
+            return self.confirmed
+
+    for label in ("Chat", "App Creator", "Device Manager"):
+        view_manager = ProbeViewManager(True)
+        probe_agent = ProbeAgent()
+        agent_app._agent = probe_agent
+        agent_app._mode_label = label
+        agent_app._conversation = probe_agent.conversation
+        agent_app._state = agent_app.STATE_CHAT
+        agent_app.run(view_manager)
+        if (
+            probe_agent.reset_calls != 1
+            or agent_app._conversation
+            or "Start a new " + label + " session?" not in view_manager.alert_message
+            or not any("TAB=New" in text for text in view_manager.draw.prompts)
+        ):
+            raise RuntimeError("Agent Tab new-session failed for " + label)
+
+    view_manager = ProbeViewManager(False)
+    probe_agent = ProbeAgent()
+    agent_app._agent = probe_agent
+    agent_app._mode_label = "Chat"
+    agent_app._conversation = probe_agent.conversation
+    agent_app._state = agent_app.STATE_CHAT
+    agent_app.run(view_manager)
+    if probe_agent.reset_calls != 0 or not agent_app._conversation:
+        raise RuntimeError("Agent cancelled new-session confirmation lost chat")
+
+    prompt_h = agent_app._chat_layout(view_manager)[1]
+    if prompt_h != 22:
+        raise RuntimeError("Agent compact footer height changed: " + str(prompt_h))
+
+    agent_app._agent = None
+    agent_app._conversation = None
+    agent_app._state = agent_app.STATE_MENU
+    print("[sim-check:ok] Agent Tab confirms new session in all modes")
+
+
+def _run_agent_sd_capacity_check():
+    """Verify the simulator storage adapter exposes real capacity counters."""
+    from picoware.system.agent.tools import dispatch
+    from picoware.system.storage import Storage
+
+    class ProbeViewManager:
+        def __init__(self):
+            self.storage = Storage()
+
+    result = dispatch.execute_tool(ProbeViewManager(), "storage_get_info")
+    if (
+        not result.get("ok")
+        or result.get("total_bytes", 0) <= 0
+        or result.get("free_bytes", -1) < 0
+        or result.get("free_bytes", 0) > result.get("total_bytes", 0)
+    ):
+        raise RuntimeError("Agent simulator SD capacity failed: " + repr(result))
+    print("[sim-check:ok] Agent simulator SD capacity counters")
+
+
 def _run_circular_choice_check():
     """Render the native circular Choice path without board-module reloading."""
     import sim_runtime
@@ -1697,6 +3030,10 @@ def main():
         _run_sim_check(opts)
         return
 
+    if opts["agent_check"]:
+        _run_agent_check()
+        return
+
     if opts["coverage"]:
         _run_coverage(opts)
         return
@@ -1735,6 +3072,12 @@ def main():
         opts["sd_profile"],
         opts["record"],
     )
+    if opts["agent_live_check"]:
+        _run_agent_live_check()
+        return
+    if opts["agent_live_app_check"]:
+        _run_agent_live_app_check()
+        return
     sim_runtime.set_script_expectations(opts["wait_view"], opts["assert_text"])
     if opts["capabilities"]:
         sim_runtime.print_capabilities()

--- a/src/MicroPython/picoware/applications/agent.py
+++ b/src/MicroPython/picoware/applications/agent.py
@@ -1,9 +1,10 @@
 """Picoware Agent - LLM-powered assistant with chat GUI."""
 import micropython
+from utime import ticks_diff, ticks_ms
 from picoware.system.buttons import (
-    BUTTON_UP, BUTTON_DOWN, BUTTON_CENTER, BUTTON_BACK,
+    BUTTON_UP, BUTTON_DOWN, BUTTON_CENTER, BUTTON_BACK, BUTTON_TAB,
 )
-from picoware.system.colors import TFT_WHITE, TFT_DARKGREY, TFT_LIGHTGREY
+from picoware.system.colors import TFT_WHITE, TFT_DARKGREY, TFT_LIGHTGREY, TFT_GREEN
 
 STATE_MENU = micropython.const(0)
 STATE_CHAT = micropython.const(1)
@@ -11,6 +12,12 @@ STATE_TYPE = micropython.const(2)
 STATE_SETTINGS = micropython.const(3)
 STATE_SETTINGS_PROVIDER = micropython.const(4)
 STATE_SETTINGS_MODEL = micropython.const(5)
+STATE_SETTINGS_INTEGRATION = micropython.const(6)
+STATE_WAITING = micropython.const(7)
+STATE_SETTINGS_SCAN = micropython.const(8)
+
+ACTIVITY_FRAME_MS = micropython.const(250)
+ACTIVITY_SEGMENTS = micropython.const(8)
 
 _agent          = None
 _menu           = None
@@ -23,6 +30,23 @@ _max_scroll     = 0
 _settings_menu  = None
 _settings       = None
 _choice         = None
+_integration_ids = None
+_integration_toggle_list = None
+_agent_task      = None
+_pending_result  = None
+_pending_error   = ""
+_pending_done    = False
+_last_phase      = ""
+_activity_started_ms = 0
+_activity_last_ms = 0
+_activity_frame  = 0
+_chat_cache      = None
+_chat_cache_key  = None
+_scan_agent       = None
+_scan_task        = None
+_scan_result      = None
+_scan_error       = ""
+_scan_done        = False
 
 
 @micropython.native
@@ -76,7 +100,9 @@ def _chat_layout(view_manager):
     font = draw.get_font(draw.font)
 
     header_h = max(22, h * 8 // 100)
-    prompt_h = max(26, h * 11 // 100)
+    # Keep the shortcut bar only tall enough for one readable text line.  The
+    # old 11% footer used 35 px on PicoCalc and needlessly hid chat content.
+    prompt_h = max(font.height + 6, h * 7 // 100)
     chat_y   = header_h + 2
     chat_h   = h - header_h - prompt_h - 4
 
@@ -153,7 +179,7 @@ def _render_chat(view_manager):
     header_h, prompt_h, chat_y, chat_h, max_chars, font, bubble_w, pad = \
         _chat_layout(view_manager)
 
-    global _scroll_offset, _max_scroll
+    global _scroll_offset, _max_scroll, _chat_cache, _chat_cache_key
 
     draw.fill_screen(bg)
 
@@ -165,17 +191,22 @@ def _render_chat(view_manager):
         draw._text(w - pad - font.width * 2, (header_h - font.height) // 2,
                    "++" if _scroll_offset > 0 else "  ", TFT_DARKGREY, font.size)
 
-    # Build line list
-    all_lines = []
-    for msg in _conversation:
-        wrapped = _wrap_text(msg["content"], max_chars)
-        is_user = (msg["role"] == "user")
-        for line in wrapped:
-            all_lines.append((line, is_user))
-        all_lines.append(("", None))
-
-    if all_lines and all_lines[-1][1] is None:
-        all_lines.pop()
+    # Wrapping is expensive on Pico; reuse it while only the scroll changes.
+    cache_key = (id(_conversation), len(_conversation), max_chars)
+    if _chat_cache_key != cache_key:
+        all_lines = []
+        for msg in _conversation:
+            wrapped = _wrap_text(msg["content"], max_chars)
+            is_user = (msg["role"] == "user")
+            for line in wrapped:
+                all_lines.append((line, is_user))
+            all_lines.append(("", None))
+        if all_lines and all_lines[-1][1] is None:
+            all_lines.pop()
+        _chat_cache = all_lines
+        _chat_cache_key = cache_key
+    else:
+        all_lines = _chat_cache
 
     # Content height
     line_h  = font.height + 3
@@ -233,7 +264,7 @@ def _render_chat(view_manager):
     # Prompt bar
     bar_y = h - prompt_h
     draw._fill_rectangle(0, bar_y, w, prompt_h, TFT_DARKGREY)
-    prompt = "OK=Type   BACK=Menu"
+    prompt = "OK=Type  TAB=New  BACK=Menu"
     pw = draw.len(prompt)
     draw._text((w - pw) // 2, bar_y + (prompt_h - font.height) // 2,
                prompt, TFT_LIGHTGREY, font.size)
@@ -241,23 +272,160 @@ def _render_chat(view_manager):
     draw.swap()
 
 
-def _show_thinking(view_manager):
-    """Clear screen and display a centred thinking indicator.
+def _show_thinking(
+    view_manager,
+    phase: str = "Preparing",
+    frame: int = 0,
+    elapsed_seconds: int = 0,
+):
+    """Display one frame of the non-blocking Agent activity indicator.
 
     Args:
         view_manager (ViewManager): The view manager context.
+        phase (str): Current Agent execution phase.
+        frame (int): Highlighted activity-bar segment.
+        elapsed_seconds (int): Seconds since the request started.
     """
     draw = view_manager.draw
     w, h = draw.size.x, draw.size.y
     bg = view_manager.background_color
+    fg = view_manager.foreground_color
+    active = view_manager.selected_color
 
     draw.fill_screen(bg)
-    msg = "Thinking..."
-    mw = draw.len(msg)
+    msg = phase or "Working..."
+    if len(msg) > 28:
+        msg = msg[:25] + "..."
     fh = draw.font_size.y
-    draw._text((w - mw) // 2, (h - fh) // 2, msg,
-               view_manager.foreground_color, draw.font)
+
+    title = "Request in progress"
+    draw._text((w - draw.len(title)) // 2, h // 5, title, fg, draw.font)
+    draw._text((w - draw.len(msg)) // 2, h // 2 - fh * 2, msg, fg, draw.font)
+
+    # This is deliberately indeterminate: movement proves the UI is alive
+    # without suggesting a completion percentage the model cannot provide.
+    bar_w = min(w * 2 // 3, 192)
+    gap = max(2, w // 160)
+    segment_w = (bar_w - gap * (ACTIVITY_SEGMENTS - 1)) // ACTIVITY_SEGMENTS
+    bar_x = (w - bar_w) // 2
+    bar_y = h // 2
+    for index in range(ACTIVITY_SEGMENTS):
+        distance = (frame - index) % ACTIVITY_SEGMENTS
+        color = active if distance < 2 else TFT_DARKGREY
+        draw._fill_rectangle(
+            bar_x + index * (segment_w + gap),
+            bar_y,
+            segment_w,
+            max(5, fh // 2),
+            color,
+        )
+
+    alive = "Still working - " + str(elapsed_seconds) + "s"
+    draw._text(
+        (w - draw.len(alive)) // 2,
+        bar_y + fh + 4,
+        alive,
+        TFT_LIGHTGREY,
+        draw.font,
+    )
+    cancel = "BACK=Cancel"
+    draw._text(
+        (w - draw.len(cancel)) // 2,
+        h - fh - 6,
+        cancel,
+        TFT_LIGHTGREY,
+        draw.font,
+    )
     draw.swap()
+
+
+def _start_activity(view_manager, phase: str) -> None:
+    """Initialize and draw an indeterminate activity animation."""
+    global _last_phase, _activity_started_ms, _activity_last_ms, _activity_frame
+    now = ticks_ms()
+    _last_phase = phase
+    _activity_started_ms = now
+    _activity_last_ms = now
+    _activity_frame = 0
+    _show_thinking(view_manager, phase, 0, 0)
+
+
+def _animate_activity(view_manager, phase: str) -> None:
+    """Advance the activity display at a bounded refresh rate."""
+    global _last_phase, _activity_last_ms, _activity_frame
+    now = ticks_ms()
+    phase = phase or "Working..."
+    if (
+        phase == _last_phase
+        and ticks_diff(now, _activity_last_ms) < ACTIVITY_FRAME_MS
+    ):
+        return
+    _last_phase = phase
+    _activity_last_ms = now
+    _activity_frame = (_activity_frame + 1) % ACTIVITY_SEGMENTS
+    elapsed = max(0, ticks_diff(now, _activity_started_ms)) // 1000
+    _show_thinking(view_manager, phase, _activity_frame, elapsed)
+
+
+def _agent_worker(payload) -> None:
+    """Run the complete multi-request Agent loop away from the UI thread."""
+    global _pending_result, _pending_error, _pending_done
+    try:
+        _pending_result = _agent.run_payload(payload)
+        _pending_error = ""
+    except Exception as exc:
+        _pending_result = None
+        _pending_error = str(exc)
+    finally:
+        _pending_done = True
+
+
+def _start_agent_request(view_manager, user_text: str) -> bool:
+    """Queue one Agent request on Picoware's shared thread manager."""
+    global _agent_task, _pending_result, _pending_error, _pending_done
+    global _state, _last_phase, _chat_cache, _chat_cache_key
+    from picoware.system.thread import ThreadTask
+    from gc import collect
+
+    manager = view_manager.thread_manager
+    if manager is None:
+        return False
+    # Wrapped display lines can be rebuilt after the request. Releasing them
+    # here leaves the maximum heap available for HTTP/MCP parsing.
+    _chat_cache = None
+    _chat_cache_key = None
+    collect()
+    _pending_result = None
+    _pending_error = ""
+    _pending_done = False
+    _agent_task = ThreadTask(
+        "Agent",
+        function=_agent_worker,
+        args=({"message": user_text, "conversation": list(_conversation)},),
+        timeout=190000,
+        stack_size=64 * 1024,
+    )
+    manager.add_task(_agent_task)
+    _state = STATE_WAITING
+    _start_activity(view_manager, "Preparing")
+    return True
+
+
+def _finish_agent_request(view_manager) -> None:
+    """Commit one background result to the visible conversation exactly once."""
+    global _conversation, _state, _scroll_offset, _agent_task
+    global _pending_result, _pending_error, _pending_done
+    if _pending_result is not None:
+        _conversation = _pending_result.get("conversation", _conversation)
+    elif _pending_error:
+        _conversation.append({"role": "assistant", "content": "Error: " + _pending_error})
+    _pending_result = None
+    _pending_error = ""
+    _pending_done = False
+    _agent_task = None
+    _scroll_offset = 32767
+    _state = STATE_CHAT
+    _render_chat(view_manager)
 
 def _set_settings(view_manager):
     """Load or create the agent settings.
@@ -332,6 +500,7 @@ def _start_settings_menu(view_manager):
     )
     _settings_menu.add_item("Agent Provider")
     _settings_menu.add_item("Agent Model")
+    _settings_menu.add_item("Scan Integrations")
     _settings_menu.draw()
 
 
@@ -411,13 +580,189 @@ def _open_model_choice(view_manager):
     _state = STATE_SETTINGS_MODEL
 
 
+def _integration_scan_worker(scanner) -> None:
+    """Scan LM Studio integrations outside the UI thread."""
+    global _scan_result, _scan_error, _scan_done
+    try:
+        _scan_result, _scan_error = scanner.scan_integrations()
+    except Exception as exc:
+        message = str(exc)
+        if len(message) > 120:
+            message = message[:120] + "..."
+        _scan_result, _scan_error = [], "Scan failed: " + message
+    finally:
+        _scan_done = True
+
+
+def _open_integration_choice(view_manager):
+    """Start a non-blocking LM Studio integration scan."""
+    global _state, _scan_agent, _scan_task, _scan_result, _scan_error, _scan_done
+    global _chat_cache, _chat_cache_key
+    from picoware.system.agent.agent import Agent, MODE_CHAT
+    from picoware.system.agent.llm import LLM, LOCAL_MCP
+    from picoware.system.thread import ThreadTask
+    from gc import collect
+
+    if _settings["provider"] != LOCAL_MCP:
+        view_manager.alert("Select LM Studio MCP first", False)
+        _back_to_settings_menu(view_manager)
+        return
+
+    draw = view_manager.draw
+    draw.fill_screen(view_manager.background_color)
+    font = draw.get_font(draw.font)
+    draw._text(
+        draw.scale_x(10),
+        draw.scale_y(10),
+        "Scanning LM Studio...",
+        view_manager.foreground_color,
+        font.size,
+    )
+    draw.swap()
+
+    manager = view_manager.thread_manager
+    if manager is None:
+        view_manager.alert("Background tasks unavailable", False)
+        _back_to_settings_menu(view_manager)
+        return
+
+    _scan_result = None
+    _scan_error = ""
+    _scan_done = False
+    _chat_cache = None
+    _chat_cache_key = None
+    collect()
+    _scan_agent = Agent(
+        view_manager,
+        MODE_CHAT,
+        LLM(view_manager.storage, LOCAL_MCP, _settings["model"]),
+        file_path="picoware/settings/agent_scan.json",
+        cleanup=False,
+    )
+    _scan_task = ThreadTask(
+        "Agent MCP scan",
+        function=_integration_scan_worker,
+        args=(_scan_agent,),
+        timeout=190000,
+        stack_size=64 * 1024,
+    )
+    manager.add_task(_scan_task)
+    _state = STATE_SETTINGS_SCAN
+
+
+def _finish_integration_scan(view_manager):
+    """Create the integration toggles after a background scan finishes."""
+    global _state, _integration_ids, _integration_toggle_list
+    global _scan_agent, _scan_task, _scan_result, _scan_error, _scan_done
+    from picoware.gui.toggle_list import ToggleList
+    from picoware.system.agent.llm import parse_mcp_integrations
+    from picoware.system.settings import Settings
+
+    _integration_ids = _scan_result or []
+    error = _scan_error
+    _scan_agent = None
+    _scan_task = None
+    _scan_result = None
+    _scan_error = ""
+    _scan_done = False
+
+    if error:
+        view_manager.alert(error, False)
+        _back_to_settings_menu(view_manager)
+        return
+    if not _integration_ids:
+        view_manager.alert("No integrations found", False)
+        _back_to_settings_menu(view_manager)
+        return
+
+    draw = view_manager.draw
+    draw.fill_screen(view_manager.background_color)
+    if _integration_toggle_list is not None:
+        del _integration_toggle_list
+        _integration_toggle_list = None
+    settings = Settings(view_manager.storage)
+    enabled = parse_mcp_integrations(settings.local_mcp_servers)
+    available_entries = []
+    for integration_id in _integration_ids:
+        runtime_id = (
+            integration_id[7:]
+            if integration_id.startswith("plugin:")
+            else integration_id
+        )
+        if runtime_id in enabled:
+            available_entries.append(integration_id)
+    if len(available_entries) != len(enabled):
+        settings.local_mcp_servers = ",".join(available_entries)
+        enabled = parse_mcp_integrations(settings.local_mcp_servers)
+    _integration_toggle_list = ToggleList(
+        view_manager,
+        TFT_DARKGREY,
+        view_manager.background_color,
+        TFT_GREEN,
+        TFT_DARKGREY,
+        callback=lambda index, state: _set_integration_active(
+            view_manager, index, state
+        ),
+        state_text_color=True,
+    )
+    for integration_id in _integration_ids:
+        runtime_id = (
+            integration_id[7:]
+            if integration_id.startswith("plugin:")
+            else integration_id
+        )
+        _integration_toggle_list.add_toggle(
+            integration_id,
+            runtime_id in enabled,
+        )
+    _state = STATE_SETTINGS_INTEGRATION
+
+
+def _set_integration_active(view_manager, index: int, active: bool):
+    """Persist one integration toggle immediately."""
+    from picoware.system.settings import Settings
+    from picoware.system.agent.llm import parse_mcp_integrations
+
+    integration_id = _integration_ids[index]
+    runtime_id = (
+        integration_id[7:]
+        if integration_id.startswith("plugin:")
+        else integration_id
+    )
+    settings = Settings(view_manager.storage)
+    raw_entries = []
+    for raw in settings.local_mcp_servers.replace("\n", ",").split(","):
+        entry = raw.strip()
+        if entry and entry not in raw_entries:
+            raw_entries.append(entry)
+
+    enabled = parse_mcp_integrations(settings.local_mcp_servers)
+    if active:
+        if runtime_id in enabled:
+            return
+        if len(enabled) >= 16:
+            view_manager.alert("Maximum of 16 integrations enabled", False)
+            _integration_toggle_list.update_toggle(index, integration_id, False)
+            return
+        raw_entries.append(integration_id)
+    else:
+        filtered = []
+        for entry in raw_entries:
+            parsed = parse_mcp_integrations(entry, 1)
+            if not parsed or parsed[0] != runtime_id:
+                filtered.append(entry)
+        raw_entries = filtered
+
+    settings.local_mcp_servers = ",".join(raw_entries)
+
+
 def _back_to_settings_menu(view_manager):
     """Clean up the Choice sub-view and return to the settings menu.
 
     Args:
         view_manager (ViewManager): The view manager context.
     """
-    global _state, _choice
+    global _state, _choice, _integration_toggle_list
 
     draw = view_manager.draw
     draw.fill_screen(view_manager.background_color)
@@ -425,10 +770,45 @@ def _back_to_settings_menu(view_manager):
     if _choice is not None:
         del _choice
         _choice = None
+    if _integration_toggle_list is not None:
+        del _integration_toggle_list
+        _integration_toggle_list = None
 
     _state = STATE_SETTINGS
     if _settings_menu is not None:
         _settings_menu.draw()
+
+
+def _open_chat_input(view_manager, initial_text: str = "") -> None:
+    """Open the chat editor and preserve an initiating letter key."""
+    global _state
+    kb = view_manager.keyboard
+    kb.reset()
+    kb.response = initial_text
+    kb.title = _mode_label
+    _state = STATE_TYPE
+    view_manager.input_manager.reset()
+    kb.run(force=True)
+
+
+def _confirm_new_session(view_manager) -> bool:
+    """Confirm and clear the current mode's persisted conversation."""
+    global _conversation, _scroll_offset, _max_scroll
+    global _chat_cache, _chat_cache_key
+
+    message = "Start a new " + _mode_label + " session?\nOK=Yes  BACK=No"
+    if not view_manager.alert(message, False):
+        _render_chat(view_manager)
+        return False
+
+    _agent.reset_conversation()
+    _conversation = _agent.conversation
+    _scroll_offset = 0
+    _max_scroll = 0
+    _chat_cache = None
+    _chat_cache_key = None
+    _render_chat(view_manager)
+    return True
 
 
 def start(view_manager) -> bool:
@@ -483,6 +863,7 @@ def start(view_manager) -> bool:
     _menu.add_item("Chat")
     _menu.add_item("App Creator")
     _menu.add_item("Device Manager")
+    _menu.add_item("New Conversation")
     _menu.add_item("Settings")
     _menu.draw()
 
@@ -500,6 +881,8 @@ def run(view_manager) -> None:
     """
     global _state, _agent, _agent_mode, _mode_label, _conversation
     global _scroll_offset, _max_scroll
+    global _pending_error, _pending_done, _last_phase
+    global _scan_error, _scan_done
 
     btn = view_manager.button
 
@@ -510,8 +893,20 @@ def run(view_manager) -> None:
             _menu.scroll_down()
         elif btn == BUTTON_CENTER:
             idx = _menu.selected_index
-            if idx == 3:
+            if idx == 4:
                 _start_settings_menu(view_manager)
+                return
+            if idx == 3:
+                if _agent is None:
+                    view_manager.alert("Open an Agent mode first", False)
+                    _menu.draw()
+                    return
+                _agent.reset_conversation()
+                _conversation = []
+                _scroll_offset = 0
+                _max_scroll = 0
+                _state = STATE_CHAT
+                _render_chat(view_manager)
                 return
             from picoware.system.agent.agent import Agent, MODE_CHAT, MODE_APP_CREATOR, MODE_DEVICE_MANAGER
             from picoware.system.agent.llm import LLM
@@ -530,8 +925,14 @@ def run(view_manager) -> None:
                 _menu.draw()
                 return
             
-            _agent = Agent(view_manager, _agent_mode,LLM(view_manager.storage, _settings["provider"], _settings["model"]))
-            _conversation = []
+            if _agent is not None:
+                _agent.cancel()
+            _agent = Agent(
+                view_manager,
+                _agent_mode,
+                LLM(view_manager.storage, _settings["provider"], _settings["model"]),
+            )
+            _conversation = _agent.conversation
             _scroll_offset = 0
             _max_scroll = 0
             _state = STATE_CHAT
@@ -554,6 +955,8 @@ def run(view_manager) -> None:
                 _open_provider_choice(view_manager)
             elif idx == 1:
                 _open_model_choice(view_manager)
+            elif idx == 2:
+                _open_integration_choice(view_manager)
 
     elif _state == STATE_SETTINGS_PROVIDER:
         if btn == BUTTON_BACK:
@@ -585,6 +988,38 @@ def run(view_manager) -> None:
             _save_settings(view_manager)
             _back_to_settings_menu(view_manager)
 
+    elif _state == STATE_SETTINGS_INTEGRATION:
+        if not _integration_toggle_list.run():
+            _back_to_settings_menu(view_manager)
+
+    elif _state == STATE_SETTINGS_SCAN:
+        if btn == BUTTON_BACK and _scan_agent is not None:
+            _scan_agent.cancel()
+            if _scan_task is not None:
+                manager = view_manager.thread_manager
+                if manager is not None and manager.remove_task(_scan_task.id):
+                    _scan_error = "Scan cancelled."
+                    _scan_done = True
+                else:
+                    _scan_task.stop()
+        if _scan_done:
+            _finish_integration_scan(view_manager)
+
+    elif _state == STATE_WAITING:
+        if btn == BUTTON_BACK:
+            _agent.cancel()
+            if _agent_task is not None:
+                manager = view_manager.thread_manager
+                if manager is not None and manager.remove_task(_agent_task.id):
+                    _pending_error = "Request cancelled."
+                    _pending_done = True
+                else:
+                    _agent_task.stop()
+        phase = _agent.status if _agent is not None else "Working"
+        _animate_activity(view_manager, phase)
+        if _pending_done:
+            _finish_agent_request(view_manager)
+
     elif _state == STATE_CHAT:
         if btn == BUTTON_UP:
             if _scroll_offset > 0:
@@ -595,15 +1030,16 @@ def run(view_manager) -> None:
                 _scroll_offset += 1
                 _render_chat(view_manager)
         elif btn == BUTTON_CENTER:
-            kb = view_manager.keyboard
-            kb.reset()
-            kb.title = _mode_label
-            _state = STATE_TYPE
-            view_manager.input_manager.reset()
-            view_manager.keyboard.run(force=True)
+            _open_chat_input(view_manager)
+        elif btn == BUTTON_TAB:
+            _confirm_new_session(view_manager)
         elif btn == BUTTON_BACK:
             _state = STATE_MENU
             _menu.draw()
+        else:
+            first_char = view_manager.input_manager.button_to_char(btn)
+            if first_char and first_char.isalpha():
+                _open_chat_input(view_manager, first_char)
 
     elif _state == STATE_TYPE:
         kb = view_manager.keyboard
@@ -619,27 +1055,17 @@ def run(view_manager) -> None:
         user_text = (kb.response or "").strip()
 
         if user_text:
-            _show_thinking(view_manager)
-
-            try:
-                result = _agent.run_payload({
-                    "message": user_text,
-                })
-                _conversation = result["conversation"]
-                if result["status"] != "completed":
-                    _conversation.append({
-                        "role": "assistant",
-                        "content": result["message"],
-                    })
-            except Exception as exc:
+            if not _start_agent_request(view_manager, user_text):
                 _conversation.append({
                     "role": "assistant",
-                    "content": "Error: " + str(exc),
+                    "content": "Error: Agent background task could not start.",
                 })
+                _scroll_offset = 32767
+                _state = STATE_CHAT
+                _render_chat(view_manager)
+            return
 
-        _scroll_offset = 32767
         _state = STATE_CHAT
-        _render_chat(view_manager)
         _render_chat(view_manager)
 
 
@@ -651,7 +1077,10 @@ def stop(view_manager) -> None:
     """
     from picoware.system.boards import BOARD_HAS_ESP32
     from gc import collect
-    global _agent, _menu, _conversation, _scroll_offset, _max_scroll, _settings_menu, _settings, _choice
+    global _agent, _menu, _conversation, _scroll_offset, _max_scroll
+    global _settings_menu, _settings, _choice, _integration_ids
+    global _integration_toggle_list, _agent_task, _chat_cache, _chat_cache_key
+    global _scan_agent, _scan_task, _scan_result, _scan_error, _scan_done
 
     _save_settings(view_manager)
 
@@ -660,8 +1089,18 @@ def stop(view_manager) -> None:
     _max_scroll = 0
 
     if _agent is not None:
+        _agent.cancel()
         del _agent
         _agent = None
+    if _agent_task is not None:
+        _agent_task.stop()
+        _agent_task = None
+    if _scan_agent is not None:
+        _scan_agent.cancel()
+        _scan_agent = None
+    if _scan_task is not None:
+        _scan_task.stop()
+        _scan_task = None
     if _menu is not None:
         del _menu
         _menu = None
@@ -674,9 +1113,17 @@ def stop(view_manager) -> None:
     if _settings is not None:
         del _settings
         _settings = None
+    if _integration_toggle_list is not None:
+        del _integration_toggle_list
+        _integration_toggle_list = None
+    _integration_ids = None
+    _chat_cache = None
+    _chat_cache_key = None
+    _scan_result = None
+    _scan_error = ""
+    _scan_done = False
 
     if BOARD_HAS_ESP32 == 0:
         view_manager.freq(False)
 
     collect()
- 

--- a/src/MicroPython/picoware/applications/system/settings.py
+++ b/src/MicroPython/picoware/applications/system/settings.py
@@ -17,8 +17,10 @@ STATE_USB_STREAM = const(10)  # toggle (enable/disable USB stream)
 STATE_ANTHROPIC_API_KEY = const(11)  # keyboard input for Anthropic API key
 STATE_GEMINI_API_KEY = const(12)  # keyboard input for Gemini API key
 STATE_LOCAL_URL = const(13)  # keyboard input for Local URL
-STATE_XAI_API_KEY = const(14)  # keyboard input for xAI API key
-STATE_SCREEN_BRIGHTNESS = const(15)  # choice (10 - 100)
+STATE_LOCAL_API_KEY = const(14)  # keyboard input for Local API key
+STATE_LOCAL_MCP_SERVERS = const(15)  # keyboard input for LM Studio MCP servers
+STATE_XAI_API_KEY = const(16)  # keyboard input for xAI API key
+STATE_SCREEN_BRIGHTNESS = const(17)  # choice (10 - 100)
 
 # modes
 _MODE_MENU = const(0)
@@ -34,7 +36,9 @@ _MODE_DEEPSEEK_KEYBOARD = const(9)
 _MODE_ANTHROPIC_KEYBOARD = const(10)
 _MODE_GEMINI_KEYBOARD = const(11)
 _MODE_LOCAL_URL_KEYBOARD = const(12)
-_MODE_XAI_KEYBOARD = const(13)
+_MODE_LOCAL_API_KEYBOARD = const(13)
+_MODE_LOCAL_MCP_SERVERS_KEYBOARD = const(14)
+_MODE_XAI_KEYBOARD = const(15)
 
 
 _settings = None
@@ -55,6 +59,8 @@ _deepseek_save_requested = False
 _anthropic_save_requested = False
 _gemini_save_requested = False
 _local_url_save_requested = False
+_local_api_key_save_requested = False
+_local_mcp_servers_save_requested = False
 _xai_save_requested = False
 
 
@@ -125,6 +131,8 @@ def __config() -> tuple:
         ("Anthropic API Key", "anthropic_api_key", ""),
         ("Gemini API Key", "gemini_api_key", ""),
         ("Local URL", "local_url", "http://127.0.0.1:8080/v1/chat/completions"),
+        ("Local API Key", "local_api_key", ""),
+        ("Local Integrations", "local_mcp_servers", ""),
         ("xAI API Key", "xai_api_key", ""),
         ("Screen Brightness", "screen_brightness", 100),
     )
@@ -613,6 +621,57 @@ def __local_url_save_callback(result: str) -> None:
     global _local_url_save_requested
     _local_url_save_requested = True
 
+
+def __open_local_api_key_keyboard() -> None:
+    """Open the keyboard for entering the Local API key."""
+    global _mode, _local_api_key_save_requested
+
+    keyboard = _view_manager.keyboard
+    keyboard.reset()
+    keyboard.title = "Local API Key"
+    keyboard.response = _settings.local_api_key
+    keyboard.set_save_callback(__local_api_key_save_callback)
+    keyboard.input_manager.reset()
+    keyboard.run(force=True)
+    _local_api_key_save_requested = False
+    _mode = _MODE_LOCAL_API_KEYBOARD
+
+
+def __local_api_key_save_callback(result: str) -> None:
+    """Callback triggered when the Local API key keyboard is saved.
+
+    Args:
+        result (str): The saved keyboard value.
+    """
+    global _local_api_key_save_requested
+    _local_api_key_save_requested = True
+
+
+def __open_local_mcp_servers_keyboard() -> None:
+    """Open the keyboard for entering LM Studio MCP server IDs."""
+    global _mode, _local_mcp_servers_save_requested
+
+    keyboard = _view_manager.keyboard
+    keyboard.reset()
+    keyboard.title = "Local Integrations"
+    keyboard.response = _settings.local_mcp_servers
+    keyboard.set_save_callback(__local_mcp_servers_save_callback)
+    keyboard.input_manager.reset()
+    keyboard.run(force=True)
+    _local_mcp_servers_save_requested = False
+    _mode = _MODE_LOCAL_MCP_SERVERS_KEYBOARD
+
+
+def __local_mcp_servers_save_callback(result: str) -> None:
+    """Mark the LM Studio MCP server setting ready to save.
+
+    Args:
+        result (str): Comma-separated MCP server IDs.
+    """
+    global _local_mcp_servers_save_requested
+    _local_mcp_servers_save_requested = True
+
+
 def __open_xai_keyboard() -> None:
     """Open the keyboard for entering the xAI API key."""
     global _mode, _xai_save_requested
@@ -798,6 +857,10 @@ def run(view_manager) -> None:
                 __open_gemini_keyboard()
             elif selected == STATE_LOCAL_URL:
                 __open_local_url_keyboard()
+            elif selected == STATE_LOCAL_API_KEY:
+                __open_local_api_key_keyboard()
+            elif selected == STATE_LOCAL_MCP_SERVERS:
+                __open_local_mcp_servers_keyboard()
             elif selected == STATE_XAI_API_KEY:
                 __open_xai_keyboard()
             elif selected == STATE_SCREEN_BRIGHTNESS:
@@ -924,6 +987,28 @@ def run(view_manager) -> None:
         if _local_url_save_requested:
             _local_url_save_requested = False
             _settings.local_url = view_manager.keyboard.response or ""
+            view_manager.keyboard.reset()
+            __back_to_menu()
+        elif not view_manager.keyboard.run():
+            view_manager.keyboard.reset()
+            __back_to_menu()
+
+    elif _mode == _MODE_LOCAL_API_KEYBOARD:
+        global _local_api_key_save_requested
+        if _local_api_key_save_requested:
+            _local_api_key_save_requested = False
+            _settings.local_api_key = view_manager.keyboard.response or ""
+            view_manager.keyboard.reset()
+            __back_to_menu()
+        elif not view_manager.keyboard.run():
+            view_manager.keyboard.reset()
+            __back_to_menu()
+
+    elif _mode == _MODE_LOCAL_MCP_SERVERS_KEYBOARD:
+        global _local_mcp_servers_save_requested
+        if _local_mcp_servers_save_requested:
+            _local_mcp_servers_save_requested = False
+            _settings.local_mcp_servers = view_manager.keyboard.response or ""
             view_manager.keyboard.reset()
             __back_to_menu()
         elif not view_manager.keyboard.run():

--- a/src/MicroPython/picoware/gui/toggle.py
+++ b/src/MicroPython/picoware/gui/toggle.py
@@ -20,6 +20,7 @@ class Toggle:
         border_width: int = 1,
         should_clear: bool = True,
         use_lvgl: bool = True,
+        state_text_color: bool = False,
     ):
         """Initialize the Toggle switch with drawing context and styling.
 
@@ -36,6 +37,7 @@ class Toggle:
             border_width (int): The width of the border. Defaults to 1.
             should_clear (bool): Whether to clear on init. Defaults to True.
             use_lvgl (bool): Whether to use LVGL rendering. Defaults to True.
+            state_text_color (bool): Color text by toggle state. Defaults to False.
         """
         from picoware.system.system import System
 
@@ -52,6 +54,7 @@ class Toggle:
         self.on_color = on_color
         self.border_color = border_color
         self.border_width = border_width
+        self.state_text_color = state_text_color
 
         self.use_lvgl = False if not use_lvgl else draw.use_lvgl
         self._lvgl_toggle = None
@@ -262,6 +265,18 @@ class Toggle:
                     self.foreground_color,
                 )
         else:
+            if self.state_text_color and selected:
+                self.display._rectangle(
+                    self.position.x,
+                    self.position.y,
+                    self.size.x,
+                    self.size.y - self.border_width,
+                    self.border_color,
+                )
+            if self.state_text_color:
+                text_color = self.on_color if self._state else self.foreground_color
+            else:
+                text_color = self.on_color if selected else self.foreground_color
             self.display._line(
                 self.position.x, self.position.y + self.size.y - self.border_width,
                 self.position.x + self.size.x,
@@ -272,7 +287,7 @@ class Toggle:
                 self.position.x + self.display.scale_x(5), 
                 self.position.y + self.size.y // 2 - self.display.scale_y(8),
                 self._text,
-                self.on_color if selected else self.foreground_color,
+                text_color,
             )
 
             toggle_width = int(display_size.x * 0.09375)

--- a/src/MicroPython/picoware/gui/toggle_list.py
+++ b/src/MicroPython/picoware/gui/toggle_list.py
@@ -15,6 +15,7 @@ class ToggleList:
         border_color: int = 0xFFFF,
         border_width: int = 1,
         callback: callable = None,  # (index: int, state: bool)
+        state_text_color: bool = False,
     ):
         """Initialize the ToggleList with styling and an optional callback.
 
@@ -26,6 +27,7 @@ class ToggleList:
             border_color (int): The color of the border. Defaults to 0xFFFF.
             border_width (int): The width of the border. Defaults to 1.
             callback (callable): Optional callback called when a toggle changes. Defaults to None.
+            state_text_color (bool): Color labels by toggle state. Defaults to False.
         """
         from picoware.system.vector import Vector
 
@@ -37,6 +39,7 @@ class ToggleList:
         self.on_color = on_color
         self.border_color = border_color
         self.border_width = border_width
+        self.state_text_color = state_text_color
 
         self.toggle_list = []
         self.states = []
@@ -125,6 +128,7 @@ class ToggleList:
                 self.border_width,
                 False,
                 False,  # only because it clears objects
+                self.state_text_color,
             )
         )
 

--- a/src/MicroPython/picoware/system/agent/agent.py
+++ b/src/MicroPython/picoware/system/agent/agent.py
@@ -3,21 +3,306 @@
 import json
 from micropython import const
 from picoware.system.agent.tools import dispatch
-from picoware.system.agent.llm import LLM, DEEPSEEK
+from picoware.system.agent.llm import LLM, DEEPSEEK, native_mcp_url
 from picoware.system.agent.context import chat, app_creator, device_manager
 
 MODE_CHAT = const(0) # general chat mode
 MODE_APP_CREATOR = const(1) # creates/edits Picoware apps
 MODE_DEVICE_MANAGER = const(2) # manages files, has network access, can run commands, etc.
 
-MAX_TOOL_ITERATIONS = const(50)
+MAX_TOOL_ITERATIONS = const(12)
+MAX_TOOL_CALLS_PER_RUN = const(16)
+MAX_IDENTICAL_TOOL_CALLS = const(2)
 MAX_CONVERSATION_MESSAGES = const(20)
+MAX_CONVERSATION_BYTES = const(32768)
+MAX_MESSAGE_CHARS = const(8192)
+MAX_NATIVE_RESPONSE_ID_LENGTH = const(512)
+MAX_MODEL_OUTPUT_TOKENS = const(4096)
+MAX_NATIVE_RESEARCH_TOKENS = const(768)
+MAX_NATIVE_MCP_CALLS = const(4)
+MAX_NATIVE_EVIDENCE_CHARS = const(8192)
+MAX_PROVIDER_RESPONSE_BYTES = const(262144)
+MAX_NATIVE_SSE_EVENT_BYTES = const(16384)
+MAX_NATIVE_STREAM_BYTES = const(262144)
+MAX_SCAN_RESPONSE_BYTES = const(32768)
+INTEGRATION_CATALOG_ID = "mcp/picoware-integration-catalog"
+
+
+def _current_time_grounding(view_manager) -> str:
+    """Build cutoff-safe current-time guidance for LM Studio MCP requests."""
+    from picoware.system.agent.tools.network import network_get_time_info
+
+    info = network_get_time_info(view_manager)
+    current = info["current_local_datetime"]
+    if info["clock_is_set"] and current:
+        return (
+            "\n\n# Current date and time\n"
+            "The Picoware device clock is set. The current local date and "
+            "time is " + current + " (configured UTC offset "
+            + info["utc_offset"] + "). Use this date when interpreting "
+            "words such as today, latest, current, tomorrow, and yesterday. "
+            "For facts newer than the model's training cutoff, use an "
+            "available web or research tool instead of relying on model "
+            "memory."
+        )
+
+    return (
+        "\n\n# Current date and time\n"
+        "The Picoware device clock is not set. Do not guess the current date "
+        "from model training data. For requests involving today, latest, "
+        "current, tomorrow, or yesterday, call an available current-time "
+        "tool first. Use an available web or research tool for facts newer "
+        "than the model's training cutoff."
+    )
+
+
+def _tool_loop_policy() -> str:
+    """Return preventive tool-use rules for LM Studio's internal MCP loop."""
+    return (
+        "\n\n# Tool loop protection\n"
+        "Use no more than 16 tool calls for this request. Never repeat a "
+        "successful tool call with identical arguments. If a tool fails, "
+        "retry at most once and only when the retry can provide new "
+        "information. When the available result is sufficient, stop calling "
+        "tools and answer. Never repeat a completed action."
+    )
+
+
+def _argument_signature(arguments):
+    """Return a bounded signature without retaining large tool arguments."""
+    try:
+        value = json.dumps(arguments)
+    except Exception:
+        value = str(arguments)
+    checksum = 2166136261
+    for char in value:
+        checksum ^= ord(char)
+        checksum = (checksum * 16777619) & 0xFFFFFFFF
+    return len(value), checksum
+
+
+def _tool_loop_issue(history, name: str, arguments) -> str:
+    """Record one tool call and return a loop/budget violation if present."""
+    if len(history) >= MAX_TOOL_CALLS_PER_RUN:
+        return "tool-call budget exceeded"
+
+    signature = _argument_signature(arguments)
+    repeated = 0
+    for previous_name, previous_signature in history:
+        if previous_name == name and previous_signature == signature:
+            repeated += 1
+    if repeated >= MAX_IDENTICAL_TOOL_CALLS:
+        return "tool '" + name + "' repeated with identical arguments"
+
+    history.append((name, signature))
+    return ""
+
+
+def _native_tool_loop_issue(output) -> str:
+    """Audit LM Studio's completed MCP trace for repeated or excessive calls."""
+    history = []
+    if not isinstance(output, list):
+        return ""
+
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if item_type in ("tool_call", "mcp_call", "mcp_tool_call"):
+            name = item.get("tool", item.get("name", "unknown"))
+            arguments = item.get("arguments", {})
+            provider = item.get("provider_info", {})
+        elif item_type == "invalid_tool_call":
+            metadata = item.get("metadata", {})
+            name = metadata.get("tool_name", "invalid_tool_call")
+            arguments = metadata.get("arguments", {})
+            provider = item.get("provider_info", {})
+        else:
+            continue
+
+        if not isinstance(provider, dict):
+            provider = {}
+        provider_id = provider.get("plugin_id", provider.get("server_label", ""))
+        qualified_name = (str(provider_id) + ":" if provider_id else "") + str(name)
+        issue = _tool_loop_issue(history, qualified_name, arguments)
+        if issue:
+            return issue
+    return ""
+
+
+def _native_response_id(value) -> str:
+    """Return a bounded LM Studio response ID or an empty string."""
+    if not isinstance(value, str):
+        return ""
+    response_id = value.strip()
+    if not response_id or len(response_id) > MAX_NATIVE_RESPONSE_ID_LENGTH:
+        return ""
+    return response_id
+
+
+class _NativeResearchSink:
+    """Consume LM Studio native SSE while enforcing the tool-loop policy."""
+
+    __slots__ = (
+        "http", "buffer", "history", "result", "issue", "error", "call_count",
+        "evidence", "evidence_chars", "storage", "path", "file", "total_bytes",
+        "max_calls", "complete",
+    )
+
+    def __init__(
+        self, http, storage=None, path: str = "",
+        max_calls: int = MAX_NATIVE_MCP_CALLS,
+    ):
+        self.http = http
+        self.buffer = bytearray()
+        self.history = []
+        self.result = None
+        self.issue = ""
+        self.error = ""
+        self.call_count = 0
+        self.evidence = []
+        self.evidence_chars = 0
+        self.storage = storage
+        self.path = path
+        self.file = None
+        self.total_bytes = 0
+        self.max_calls = max(1, min(int(max_calls), MAX_NATIVE_MCP_CALLS))
+        self.complete = False
+        if storage is not None and path:
+            storage.remove(path)
+            self.file = storage.file_open(path)
+            if self.file is None:
+                self.issue = "could not open the MCP SD spool"
+
+    def close(self) -> None:
+        """Close the temporary SD spool without retaining its contents in RAM."""
+        if self.file is not None:
+            try:
+                self.storage.file_close(self.file)
+            except Exception:
+                pass
+            self.file = None
+
+    def _stop(self, issue: str) -> None:
+        if not self.issue:
+            self.issue = issue
+        self.http.close()
+
+    def _consume_event(self, raw) -> None:
+        # chat.end can contain the complete trace again. Tool evidence was
+        # already captured from bounded success events, so do not materialize
+        # this duplicate response tree on the Pico heap.
+        if raw.find(b'"chat.end"') >= 0:
+            self.result = {}
+            return
+        start = raw.find(b"data:")
+        if start < 0:
+            return
+        start += 5
+        while start < len(raw) and raw[start] in (9, 32):
+            start += 1
+        try:
+            event = json.loads(raw[start:].decode("utf-8"))
+        except (UnicodeError, ValueError):
+            self._stop("LM Studio MCP returned an invalid streaming event")
+            return
+        if not isinstance(event, dict):
+            return
+        event_type = event.get("type")
+        if event_type == "tool_call.arguments":
+            provider = event.get("provider_info", {})
+            if not isinstance(provider, dict):
+                provider = {}
+            provider_id = provider.get("plugin_id", provider.get("server_label", ""))
+            name = (str(provider_id) + ":" if provider_id else "") + str(event.get("tool", "unknown"))
+            if self.call_count >= self.max_calls:
+                self._stop("native MCP tool-call budget exceeded")
+                return
+            issue = _tool_loop_issue(self.history, name, event.get("arguments", {}))
+            if issue:
+                self._stop(issue)
+                return
+            self.call_count += 1
+        elif event_type == "tool_call.success":
+            output = event.get("output", "")
+            if not isinstance(output, str):
+                output = str(output)
+            remaining = MAX_NATIVE_EVIDENCE_CHARS - self.evidence_chars
+            if remaining > 0 and output:
+                value = output[:remaining]
+                self.evidence.append(value)
+                self.evidence_chars += len(value)
+            if self.call_count >= self.max_calls:
+                # The completed tool output is the evidence needed by the
+                # next deterministic stage. End this generation before the
+                # model can request another variation of the same tool.
+                self.complete = True
+                self.http.close()
+        elif event_type == "error":
+            detail = event.get("error", {})
+            self.error = detail.get("message", str(detail)) if isinstance(detail, dict) else str(detail)
+
+    def write(self, value) -> None:
+        if self.issue or self.complete:
+            return
+        if isinstance(value, str):
+            # Ignore HTTP's UART-style progress markers.
+            return
+        if not isinstance(value, (bytes, bytearray)):
+            return
+        next_total = self.total_bytes + len(value)
+        if next_total > MAX_NATIVE_STREAM_BYTES:
+            self._stop("LM Studio MCP stream exceeded the 262144-byte device limit")
+            return
+        if self.file is not None:
+            if not self.storage.file_write(self.file, value, "wb"):
+                self._stop("could not write the MCP stream to SD")
+                return
+        self.total_bytes = next_total
+        self.buffer.extend(value)
+        while True:
+            end = self.buffer.find(b"\n\n")
+            delimiter = 2
+            if end < 0:
+                end = self.buffer.find(b"\r\n\r\n")
+                delimiter = 4
+            if end < 0:
+                break
+            if end > MAX_NATIVE_SSE_EVENT_BYTES:
+                self._stop("LM Studio MCP streaming event exceeded the device limit")
+                return
+            raw_event = self.buffer[:end]
+            # MicroPython bytearray does not implement slice deletion. The
+            # remainder is bounded by MAX_NATIVE_SSE_EVENT_BYTES, so replacing
+            # this small buffer remains heap-safe.
+            self.buffer = self.buffer[end + delimiter:]
+            self._consume_event(raw_event)
+            if self.issue:
+                break
+        if len(self.buffer) > MAX_NATIVE_SSE_EVENT_BYTES:
+            self._stop("LM Studio MCP streaming event exceeded the device limit")
+
+    def flush(self) -> None:
+        return
+
 
 class Agent:
     """Agent that can perform tasks using tools and LLMs."""
-    __slots__ = ["mode", "tools", "llm", "view_manager", "http", "_file_path", "_conv_path", "_mem_path", "_msg_path"]
+    __slots__ = [
+        "mode", "tools", "llm", "view_manager", "http", "_file_path",
+        "_conv_path", "_mem_path", "_response_path", "_state_path",
+        "_native_response_id", "_conversation", "_status", "_cancelled",
+        "_last_stats",
+    ]
 
-    def __init__(self, view_manager, mode: int = MODE_CHAT, llm: LLM = None, file_path: str = "picoware/settings/agent_request.json"):
+    def __init__(
+        self,
+        view_manager,
+        mode: int = MODE_CHAT,
+        llm: LLM = None,
+        file_path: str = "picoware/settings/agent_request.json",
+        cleanup: bool = True,
+    ):
         """Initialize the agent with a mode, LLM, and request file path.
 
         Args:
@@ -25,6 +310,7 @@ class Agent:
             mode (int): The agent mode constant. Defaults to MODE_CHAT.
             llm (LLM): The LLM client to use. Defaults to None.
             file_path (str): Path to the API request file. Defaults to "picoware/settings/agent_request.json".
+            cleanup (bool): Remove prior conversation files. Defaults to True.
         """
         from picoware.system.http import HTTP
         self.view_manager = view_manager
@@ -35,19 +321,80 @@ class Agent:
         self._file_path = file_path
         self._conv_path = "picoware/settings/agent_conv.json"
         self._mem_path = "picoware/settings/agent_mem.json"
-        self._msg_path = "picoware/settings/agent_msg.json"
+        self._response_path = "picoware/settings/agent_response.json"
+        self._state_path = "picoware/settings/agent_state_" + str(mode) + ".json"
+        self._native_response_id = ""
+        self._conversation = []
+        self._status = "Ready"
+        self._cancelled = False
+        self._last_stats = {}
 
-        s = self.view_manager.storage
-        s.remove(self._conv_path)
-        s.remove(self._mem_path)
-        s.remove(self._msg_path)
-    
+        if cleanup:
+            s = self.view_manager.storage
+            s.remove(self._conv_path)
+            s.remove(self._mem_path)
+            s.remove(self._response_path)
+        self._load_state()
+
     def __del__(self):
         """Cleanup resources on deletion."""
         self.tools.clear()
         self.llm = None
         self.http = None
-    
+
+    @property
+    def conversation(self) -> list:
+        """Return a copy of the persisted visible conversation."""
+        return list(self._conversation)
+
+    @property
+    def status(self) -> str:
+        """Return the current user-facing execution phase."""
+        return self._status
+
+    @property
+    def last_stats(self) -> dict:
+        """Return the last bounded provider statistics."""
+        return dict(self._last_stats)
+
+    def cancel(self) -> None:
+        """Request cancellation of the active model/tool loop."""
+        self._cancelled = True
+        self._status = "Cancelling..."
+        if self.http is not None:
+            self.http.close()
+
+    def reset_conversation(self) -> None:
+        """Clear persisted visible and provider-side conversation state."""
+        self._native_response_id = ""
+        self._conversation = []
+        self.view_manager.storage.remove(self._state_path)
+
+    def _fingerprint(self) -> str:
+        return (
+            str(self.llm.id) + "|" + str(self.mode) + "|" + self.llm.model
+            + "|" + ",".join(self.llm.mcp_integrations)
+        )
+
+    def _load_state(self) -> None:
+        storage = self.view_manager.storage
+        if not storage.exists(self._state_path):
+            return
+        state = storage.serialize(self._state_path)
+        if not isinstance(state, dict) or state.get("fingerprint") != self._fingerprint():
+            return
+        self._native_response_id = _native_response_id(state.get("response_id"))
+        self._conversation = self._sanitize_conversation(state.get("conversation"))
+
+    def _save_state(self) -> None:
+        self.view_manager.storage.deserialize(
+            {
+                "fingerprint": self._fingerprint(),
+                "response_id": self._native_response_id,
+                "conversation": self._conversation,
+            },
+            self._state_path,
+        )
     @property
     def file_path(self) -> str:
         """Get the file path associated with the agent."""
@@ -166,6 +513,52 @@ class Agent:
         finally:
             storage.file_close(src)
 
+    @staticmethod
+    def _write_file_fragment(storage, file_obj, value) -> None:
+        """Write one bounded request fragment or fail the request build."""
+        if not storage.file_write(file_obj, value, mode="w"):
+            raise OSError("could not write Agent request file")
+
+    @staticmethod
+    def _write_json_string(storage, file_obj, value: str) -> None:
+        """Write one JSON string without materializing its complete encoding."""
+        Agent._write_file_fragment(storage, file_obj, '"')
+        offset = 0
+        while offset < len(value):
+            chunk = value[offset:offset + 512]
+            # json.dumps handles every JSON control character. Strip only the
+            # surrounding quotes from this deliberately small fragment.
+            escaped = json.dumps(chunk)[1:-1]
+            Agent._write_file_fragment(storage, file_obj, escaped)
+            offset += len(chunk)
+        Agent._write_file_fragment(storage, file_obj, '"')
+
+    @staticmethod
+    def _write_json_value(storage, file_obj, value) -> None:
+        """Recursively stream a JSON-compatible value in bounded fragments."""
+        if isinstance(value, str):
+            Agent._write_json_string(storage, file_obj, value)
+            return
+        if isinstance(value, list) or isinstance(value, tuple):
+            Agent._write_file_fragment(storage, file_obj, "[")
+            for index, item in enumerate(value):
+                if index:
+                    Agent._write_file_fragment(storage, file_obj, ",")
+                Agent._write_json_value(storage, file_obj, item)
+            Agent._write_file_fragment(storage, file_obj, "]")
+            return
+        if isinstance(value, dict):
+            Agent._write_file_fragment(storage, file_obj, "{")
+            for index, key in enumerate(value):
+                if index:
+                    Agent._write_file_fragment(storage, file_obj, ",")
+                Agent._write_json_string(storage, file_obj, str(key))
+                Agent._write_file_fragment(storage, file_obj, ":")
+                Agent._write_json_value(storage, file_obj, value[key])
+            Agent._write_file_fragment(storage, file_obj, "}")
+            return
+        Agent._write_file_fragment(storage, file_obj, json.dumps(value))
+
     def _write_system_message(self, storage) -> None:
         """Write the system message to the conversation file.
 
@@ -208,7 +601,7 @@ class Agent:
         # tools
         storage.write(
             self._file_path,
-            '],"tools":' + json.dumps(tools) + ',"tool_choice":"auto",',
+            '],"tools":' + json.dumps(tools) + ',"tool_choice":"auto"',
             mode="a",
         )
 
@@ -217,41 +610,853 @@ class Agent:
         _payload_str = json.dumps(_payload)
         # strip { }
         _payload_str = _payload_str[1:-1]
-        storage.write(self._file_path, _payload_str, mode="a")
+        if _payload_str:
+            storage.write(self._file_path, "," + _payload_str, mode="a")
 
         # close
         storage.write(self._file_path, "}", mode="a")
 
 
-    def _run_loop(self) -> str:
+    @staticmethod
+    def _native_message_content(item: dict) -> str:
+        """Extract text from one LM Studio native message item.
+
+        Args:
+            item (dict): Native API output item.
+
+        Returns:
+            str: Extracted message text.
+        """
+        content = item.get("content", "")
+        if isinstance(content, str):
+            return content
+        if not isinstance(content, list):
+            return ""
+
+        parts = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text", part.get("content", ""))
+                if isinstance(text, str) and text:
+                    parts.append(text)
+        return "\n".join(parts)
+
+    @staticmethod
+    def _web_profile(user_message: str):
+        """Return whether the turn needs search and/or page retrieval."""
+        text = user_message.lower()
+        search_markers = (
+            " web", "search", "latest", "news", "amazon", "price",
+            "buy", "shop", "online", "find item", "find product",
+            "look up", "research", "current information", "current facts",
+        )
+        fetch_markers = (
+            "http://", "https://", "www.", "visit ", "open page",
+            "read page", "read website", "fetch ", "this url", "this link",
+        )
+        return (
+            any(marker in text for marker in search_markers),
+            any(marker in text for marker in fetch_markers),
+        )
+
+    @staticmethod
+    def _integration_profile_needed(integration: str, user_message: str) -> bool:
+        """Return whether a non-web MCP is relevant to this user turn."""
+        lower = integration.lower()
+        text = " " + user_message.lower() + " "
+        if "nutrition" in lower:
+            markers = (
+                " nutrition", " nutrient", " calorie", " protein", " meal",
+                " food", " diet", " ernahrung", " ernaehrung", " kalorie",
+                " mahlzeit",
+            )
+        elif "markitdown" in lower:
+            markers = (
+                " markdown", " convert", " document", " pdf", " docx",
+                " xlsx", " pptx", " datei umwandeln",
+            )
+        elif "filesystem" in lower:
+            markers = (
+                " host filesystem", " lm studio file", " local computer file",
+                " host file", " host directory", " host folder",
+            )
+        elif "germany" in lower:
+            markers = (
+                " germany", " german ", " deutschland", " bundestag",
+                " bundesregierung",
+            )
+        else:
+            name = lower.rsplit("/", 1)[-1]
+            for separator in ("-", "_", "."):
+                name = name.replace(separator, " ")
+            name = name.replace("modelcontextprotocol", "")
+            markers = tuple(
+                " " + token + " " for token in name.split() if len(token) >= 4
+            )
+        return any(marker in text for marker in markers)
+
+    def _selected_integrations(self, user_message: str):
+        """Return a bounded MCP profile with known tools explicitly allowed."""
+        selected = []
+        needs_search, needs_fetch = self._web_profile(" " + user_message)
+        message_lower = user_message.lower()
+        amazon_request = "amazon" in message_lower
+        explicit_fetch = "fetch" in message_lower
+        explicit_playwright = "playwright" in message_lower
+        configured = self.llm.mcp_integrations
+        has_fetch = any("fetch" in integration.lower() for integration in configured)
+        has_playwright = any(
+            "playwright" in integration.lower() for integration in configured
+        )
+        has_page_reader = has_fetch or has_playwright
+        for integration in configured:
+            lower = integration.lower()
+            if "visit-website" in lower:
+                if has_page_reader or not needs_fetch:
+                    continue
+            elif "duckduckgo" in lower:
+                if not needs_search or (amazon_request and has_page_reader):
+                    continue
+            elif "playwright" in lower:
+                if not needs_search and not needs_fetch and not explicit_playwright:
+                    continue
+            elif "fetch" in lower:
+                if (
+                    (not needs_fetch and not amazon_request)
+                    or (has_playwright and not explicit_fetch)
+                ):
+                    continue
+            elif "toolguard-current-time" not in lower:
+                if not self._integration_profile_needed(integration, user_message):
+                    continue
+            item = {"type": "plugin", "id": integration}
+            if "toolguard-current-time" in lower:
+                item["allowed_tools"] = ["get_current_time"]
+            elif "duckduckgo" in lower:
+                item["allowed_tools"] = ["Web Search"]
+            elif "playwright" in lower:
+                item["allowed_tools"] = [
+                    "browser_navigate", "browser_snapshot", "browser_wait_for",
+                ]
+            elif lower.startswith("mcp/") and "fetch" in lower:
+                item["allowed_tools"] = ["fetch"]
+            selected.append(item)
+        return selected
+
+    @staticmethod
+    def _needs_native_research(integrations) -> bool:
+        """Return whether selected integrations include more than clock grounding."""
+        for integration in integrations:
+            value = integration.get("id", "") if isinstance(integration, dict) else str(integration)
+            if "toolguard-current-time" not in value.lower():
+                return True
+        return False
+
+    def _has_time_integration(self, integrations) -> bool:
+        for integration in integrations:
+            value = integration.get("id", "") if isinstance(integration, dict) else str(integration)
+            if "toolguard-current-time" in value.lower():
+                return True
+        return False
+
+    def _responses_input(self, user_message: str):
+        if self._native_response_id:
+            return user_message
+        messages = []
+        for message in self._conversation:
+            messages.append(
+                {
+                    "role": message["role"],
+                    "content": message["content"],
+                }
+            )
+        messages.append({"role": "user", "content": user_message})
+        return messages
+
+    def _build_responses_request(self, input_value, integrations, tools) -> None:
+        """Build a Responses request in fragments to keep peak heap bounded."""
+        storage = self.view_manager.storage
+        if storage.exists(self._file_path) and not storage.remove(self._file_path):
+            raise OSError("could not replace Agent request file")
+        request_file = storage.file_open(self._file_path)
+        if request_file is None:
+            raise OSError("could not create Agent request file")
+        try:
+            self._write_file_fragment(storage, request_file, '{"model":')
+            self._write_json_value(storage, request_file, self.llm.model)
+            self._write_file_fragment(storage, request_file, ',"input":')
+            self._write_json_value(storage, request_file, input_value)
+            self._write_file_fragment(storage, request_file, ',"tools":')
+            self._write_json_value(storage, request_file, tools)
+            self._write_file_fragment(storage, request_file, ',"integrations":')
+            self._write_json_value(storage, request_file, integrations)
+            self._write_file_fragment(
+                storage,
+                request_file,
+                ',"store":true,"stream":false,"temperature":0'
+                ',"max_output_tokens":' + str(MAX_MODEL_OUTPUT_TOKENS)
+                + ',"max_tool_calls":' + str(MAX_TOOL_CALLS_PER_RUN),
+            )
+            if self._native_response_id:
+                self._write_file_fragment(
+                    storage, request_file, ',"previous_response_id":'
+                )
+                self._write_json_value(
+                    storage, request_file, self._native_response_id
+                )
+            # Responses instructions are turn-scoped and are not inherited by
+            # previous_response_id, so include the compact policy every round.
+            self._write_file_fragment(storage, request_file, ',"instructions":"')
+        finally:
+            storage.file_close(request_file)
+        if storage.exists(self._mem_path):
+            self._stream_file_json_escaped(storage, self._mem_path, self._file_path)
+        grounding = _current_time_grounding(self.view_manager)
+        request_file = storage.file_open(self._file_path)
+        if request_file is None:
+            raise OSError("could not reopen Agent request file")
+        try:
+            if not storage.file_seek(request_file, storage.size(self._file_path)):
+                raise OSError("could not append Agent request file")
+            policy = grounding + _tool_loop_policy()
+            offset = 0
+            while offset < len(policy):
+                chunk = policy[offset:offset + 512]
+                self._write_file_fragment(
+                    storage, request_file, json.dumps(chunk)[1:-1]
+                )
+                offset += len(chunk)
+            self._write_file_fragment(storage, request_file, '"}')
+        finally:
+            storage.file_close(request_file)
+
+    def _build_native_research_request(
+        self, user_message: str, integrations,
+    ) -> None:
+        """Build the LM Studio native request that executes installed MCPs."""
+        guarded_input = (
+            "Tool execution rule: Call each available integration tool at "
+            "most once. Never repeat a tool with identical arguments. For "
+            "web search, use one concise plain-language query without Boolean "
+            "OR chains and request no more than 3 results. When visiting a "
+            "page, request at most 8 links, no images, and at most 4000 text "
+            "characters. When both search and browser tools are available, "
+            "search once and open only the single most relevant result. Use "
+            "browser tools only to read; do not submit forms or download files. "
+            "If a result is empty or unhelpful, stop immediately "
+            "and report that limitation.\n\nUser request:\n" + user_message
+        )
+        payload = {
+            "model": self.llm.model,
+            "input": guarded_input,
+            "system_prompt": (
+                "Use the configured integrations to gather current, factual "
+                "evidence for the Picoware Agent. Call only relevant tools, "
+                "respect the tool-call budget, preserve direct URLs, and then "
+                "return a concise evidence summary. Do not perform or claim "
+                "Picoware device actions."
+                + _current_time_grounding(self.view_manager)
+                + _tool_loop_policy()
+            ),
+            "integrations": integrations,
+            "temperature": 0,
+            "store": False,
+            "stream": True,
+            "max_output_tokens": MAX_NATIVE_RESEARCH_TOKENS,
+        }
+        thinking = self.llm.thinking_payload
+        if thinking:
+            payload.update(thinking)
+        self.view_manager.storage.write(
+            self._file_path, json.dumps(payload), mode="w"
+        )
+
+    def _run_native_research(
+        self, user_message: str, integrations,
+        max_tool_calls: int = MAX_NATIVE_MCP_CALLS,
+    ):
+        """Execute installed LM Studio integrations and return bounded evidence."""
+        self._status = "MCP research"
+        # LM Studio's /api/v1/chat rejects max_tool_calls. The streaming sink
+        # below enforces this stage's hard device-side call limit instead.
+        self._build_native_research_request(user_message, integrations)
+        storage = self.view_manager.storage
+        spool_path = "picoware/settings/agent_mcp_stream.tmp"
+        sink = _NativeResearchSink(
+            self.http, storage, spool_path, max_calls=max_tool_calls
+        )
+        response = None
+        try:
+            if not sink.issue:
+                response = self.http.post(
+                    native_mcp_url(self.llm.url),
+                    headers=self.llm.headers,
+                    payload=None,
+                    timeout=90,
+                    storage=storage,
+                    send_file=self._file_path,
+                    stream_sink=sink,
+                )
+        finally:
+            try:
+                if response is not None:
+                    response.close()
+            except Exception:
+                pass
+            sink.close()
+            storage.remove(spool_path)
+            from gc import collect
+            collect()
+        if sink.issue:
+            if sink.evidence:
+                evidence = (
+                    "The device stopped LM Studio's MCP loop: " + sink.issue
+                    + ". Use only the completed tool evidence below and "
+                    "clearly state any limitation.\n\n"
+                    + "\n\n".join(sink.evidence)
+                )
+                self.view_manager.log(
+                    "[Agent] MCP loop stopped after " + str(sink.call_count)
+                    + " calls; preserving completed evidence"
+                )
+                return evidence, sink.call_count, ""
+            return "", sink.call_count, "API error: LM Studio MCP loop stopped: " + sink.issue + "."
+        if sink.error:
+            return "", sink.call_count, "API error: LM Studio MCP: " + sink.error
+        if sink.evidence and sink.call_count:
+            evidence = "\n\n".join(sink.evidence).strip()
+            if evidence:
+                self.view_manager.log(
+                    "[Agent] MCP research complete with "
+                    + str(sink.call_count) + " tool calls"
+                )
+                return evidence, sink.call_count, ""
+        data = sink.result
+        if not isinstance(data, dict):
+            if sink.evidence and sink.call_count:
+                evidence = "\n\n".join(sink.evidence).strip()
+                if evidence:
+                    return evidence, sink.call_count, ""
+            return "", sink.call_count, "API error: LM Studio MCP stream ended without chat.end."
+        error = self._error_message(data, "LM Studio MCP")
+        if error:
+            return "", 0, error
+        output = data.get("output", []) if isinstance(data, dict) else []
+        if not isinstance(output, list):
+            return "", 0, "API error: LM Studio MCP returned invalid output."
+        issue = _native_tool_loop_issue(output)
+        if issue:
+            return "", 0, "API error: LM Studio MCP loop detected: " + issue + "."
+
+        messages = []
+        call_count = sink.call_count
+        output_call_count = 0
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            if item.get("type") in ("tool_call", "mcp_call", "mcp_tool_call"):
+                output_call_count += 1
+            elif item.get("type") == "message":
+                content = self._native_message_content(item).strip()
+                if content:
+                    messages.append(content)
+        if call_count == 0:
+            call_count = output_call_count
+        if call_count == 0:
+            return "", 0, "API error: LM Studio MCP returned no tool calls."
+        evidence = "\n\n".join(messages).strip()
+        if not evidence:
+            return "", call_count, "API error: LM Studio MCP returned no evidence."
+        if len(evidence) > MAX_NATIVE_EVIDENCE_CHARS:
+            evidence = evidence[:MAX_NATIVE_EVIDENCE_CHARS] + "..."
+        self.view_manager.log(
+            "[Agent] MCP research complete with " + str(call_count) + " tool calls"
+        )
+        return evidence, call_count, ""
+
+    def _run_native_research_pipeline(self, user_message: str, integrations):
+        """Run search and browser MCPs in deterministic, bounded stages."""
+        search_integrations = []
+        browser_integrations = []
+        other_integrations = []
+        for item in integrations:
+            value = item.get("id", "") if isinstance(item, dict) else str(item)
+            lower = value.lower()
+            if "duckduckgo" in lower:
+                search_integrations.append(item)
+            elif "playwright" in lower:
+                browser_integrations.append({
+                    "type": "plugin",
+                    "id": value,
+                    "allowed_tools": ["browser_navigate"],
+                })
+            elif "toolguard-current-time" not in lower:
+                other_integrations.append(item)
+
+        # Non-web profiles keep their existing bounded multi-tool behavior.
+        if not search_integrations and not browser_integrations:
+            return self._run_native_research(user_message, integrations)
+
+        parts = []
+        total_calls = 0
+        search_evidence = ""
+        if search_integrations:
+            search_evidence, calls, error = self._run_native_research(
+                user_message, search_integrations, max_tool_calls=1
+            )
+            total_calls += calls
+            if error:
+                return "", total_calls, error
+            if search_evidence:
+                parts.append("# Search evidence\n" + search_evidence)
+
+        if browser_integrations:
+            browser_request = user_message
+            if search_evidence:
+                browser_request = (
+                    "Open and read the single most relevant direct URL from "
+                    "the search evidence below. Call browser_navigate exactly "
+                    "once. Return the page title, final URL, and concise page "
+                    "evidence relevant to the original request.\n\n"
+                    "Original request:\n" + user_message
+                    + "\n\nSearch evidence:\n"
+                    + search_evidence[:MAX_NATIVE_EVIDENCE_CHARS]
+                )
+            browser_evidence, calls, error = self._run_native_research(
+                browser_request, browser_integrations, max_tool_calls=1
+            )
+            total_calls += calls
+            if error:
+                if parts:
+                    parts.append("# Browser limitation\n" + error)
+                else:
+                    return "", total_calls, error
+            elif browser_evidence:
+                parts.append("# Browser page evidence\n" + browser_evidence)
+
+        if other_integrations:
+            other_evidence, calls, error = self._run_native_research(
+                user_message, other_integrations, max_tool_calls=2
+            )
+            total_calls += calls
+            if error:
+                parts.append("# Additional integration limitation\n" + error)
+            elif other_evidence:
+                parts.append("# Additional integration evidence\n" + other_evidence)
+
+        evidence = "\n\n".join(parts).strip()
+        if not evidence:
+            return "", total_calls, "API error: web integrations returned no evidence."
+        return evidence, total_calls, ""
+
+    def _response_data(self, response):
+        """Parse a response saved to SD, falling back to an in-memory test response."""
+        storage = self.view_manager.storage
+        try:
+            if storage.exists(self._response_path):
+                return storage.serialize(self._response_path)
+            if response is not None:
+                return response.json()
+        finally:
+            if response is not None:
+                try:
+                    response.close()
+                except Exception:
+                    pass
+        return {}
+
+    def _post_request_file(self, url: str, timeout: int):
+        storage = self.view_manager.storage
+        storage.remove(self._response_path)
+        response = self.http.post(
+            url,
+            headers=self.llm.headers,
+            payload=None,
+            timeout=timeout,
+            storage=storage,
+            send_file=self._file_path,
+            save_to_file=self._response_path,
+        )
+        if self._cancelled:
+            return {"error": {"message": "request cancelled"}}
+        if (
+            storage.exists(self._response_path)
+            and storage.size(self._response_path) > MAX_PROVIDER_RESPONSE_BYTES
+        ):
+            if response is not None:
+                try:
+                    response.close()
+                except Exception:
+                    pass
+            storage.remove(self._response_path)
+            return {
+                "error": {
+                    "message": "response exceeds the 262144-byte device limit"
+                }
+            }
+        return self._response_data(response)
+
+    @staticmethod
+    def _error_message(data, provider: str) -> str:
+        error_detail = data.get("error") if isinstance(data, dict) else None
+        if not error_detail:
+            return ""
+        if isinstance(error_detail, dict):
+            message = error_detail.get("message", str(error_detail))
+        else:
+            message = str(error_detail)
+        if len(message) > 500:
+            message = message[:500] + "..."
+        return "API error: " + provider + ": " + message
+
+    def _execute_guarded_tool(self, history, cache, name: str, arguments):
+        issue = _tool_loop_issue(history, name, arguments)
+        if issue:
+            raise RuntimeError("Tool loop stopped before execution: " + issue + ".")
+        signature = (name, _argument_signature(arguments))
+        if signature in cache:
+            return cache[signature]
+        if self._cancelled:
+            raise RuntimeError("Agent request cancelled.")
+        self._status = "Tool: " + name
+        self.view_manager.log("[Agent] Executing " + name)
+        try:
+            result = dispatch.execute_tool(self.view_manager, name, arguments)
+        except Exception as exc:
+            result = {"ok": False, "error": "tool_error", "message": str(exc)}
+        if not isinstance(result, dict) or result.get("ok", True):
+            cache[signature] = result
+        self.view_manager.log("[Agent] " + name + " completed")
+        return result
+
+    def _mode_tool_limit(self, name: str) -> int:
+        """Return per-turn tool limits without restricting SD-card access."""
+        if name == "network_get_info":
+            return 1
+        if name == "network_send_request":
+            return 1
+        if self.mode != MODE_APP_CREATOR:
+            return 0
+        if name == "picoware_api_search":
+            return 2
+        if name == "picoware_api_read":
+            return 4
+        if name == "picoware_app_validate":
+            return 4
+        return 0
+
+    def _execute_mode_guarded_tool(
+        self, history, cache, counts, name: str, arguments
+    ):
+        """Execute a tool with loop guards and compact-reference budgets."""
+        limit = self._mode_tool_limit(name)
+        if limit and counts.get(name, 0) >= limit:
+            # A model can emit the same one-shot call more than once in a
+            # single response batch. Reuse its successful result for each
+            # call ID; the next request no longer advertises the tool.
+            signature = (name, _argument_signature(arguments))
+            if signature in cache:
+                return cache[signature]
+            issue = _tool_loop_issue(history, name, arguments)
+            if issue:
+                raise RuntimeError("Tool loop stopped before execution: " + issue + ".")
+            counts[name] = counts.get(name, 0) + 1
+            return {
+                "ok": False,
+                "error": "tool_budget_exhausted",
+                "message": (
+                    name + " reached its per-turn limit; use the results "
+                    "already returned and continue without calling it again"
+                ),
+            }
+        counts[name] = counts.get(name, 0) + 1
+        return self._execute_guarded_tool(history, cache, name, arguments)
+
+    def _response_tools(self, counts, excluded=None):
+        """Return tool schemas, hiding tools exhausted for this turn."""
+        tools = []
+        for tool in dispatch.get_tool_list():
+            if excluded and tool.name in excluded:
+                continue
+            limit = self._mode_tool_limit(tool.name)
+            if limit and counts.get(tool.name, 0) >= limit:
+                continue
+            tools.append(tool.json_responses)
+        return tools
+
+    def _chat_completion_tools(self, counts):
+        """Return Chat Completions schemas with the same reference budgets."""
+        tools = []
+        for tool in dispatch.get_tool_list():
+            limit = self._mode_tool_limit(tool.name)
+            if limit and counts.get(tool.name, 0) >= limit:
+                continue
+            tools.append(tool.json_openai)
+        return tools
+
+    def _run_responses_mcp(self, user_message: str) -> str:
+        """Run LM Studio MCP and Picoware functions through one Responses loop."""
+        integrations = self._selected_integrations(user_message)
+        research = ""
+        mcp_call_count = 0
+        used_native_research = self._needs_native_research(integrations)
+        if used_native_research:
+            research, mcp_call_count, error = self._run_native_research_pipeline(
+                user_message, integrations
+            )
+            if error:
+                return error
+        tool_counts = {}
+        model_input = user_message
+        if research:
+            model_input += (
+                "\n\n# Current integration evidence\n"
+                "The following evidence was retrieved for this turn by LM "
+                "Studio integrations. Use it as tool output; do not claim "
+                "unsupported facts.\n" + research
+            )
+        input_value = self._responses_input(model_input)
+        tool_history = []
+        mcp_history = []
+        cache = {}
+
+        for round_index in range(MAX_TOOL_ITERATIONS):
+            if self._cancelled:
+                return "An error occurred during processing: Agent request cancelled."
+            self._status = "LM Studio"
+            # Installed LM Studio plugins execute on /api/v1/chat. This
+            # Responses call carries their evidence plus Picoware functions.
+            # Do not offer the generic URL fetcher after research: otherwise
+            # a model can ignore the evidence and repeatedly probe alternate
+            # search-engine endpoints with slightly different arguments.
+            excluded = ("network_send_request",) if used_native_research else None
+            self._build_responses_request(
+                input_value, [], self._response_tools(tool_counts, excluded)
+            )
+            data = self._post_request_file(self.llm.url, 180)
+            error = self._error_message(data, "LM Studio")
+            if error:
+                return error
+
+            response_id = _native_response_id(data.get("id", data.get("response_id")))
+            if not response_id:
+                return "API error: LM Studio Responses omitted a usable response ID."
+            output = data.get("output", [])
+            if not isinstance(output, list):
+                return "API error: LM Studio Responses returned invalid output."
+
+            mcp_issue = ""
+            for item in output:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") in ("mcp_call", "mcp_tool_call", "tool_call"):
+                    mcp_call_count += 1
+                    name = item.get("name", item.get("tool", "unknown"))
+                    arguments = item.get("arguments", {})
+                    provider = item.get("server_label", item.get("provider_info", {}))
+                    qualified = str(provider) + ":" + str(name)
+                    mcp_issue = _tool_loop_issue(mcp_history, qualified, arguments)
+                    if mcp_issue:
+                        break
+            if mcp_issue:
+                return "API error: LM Studio MCP loop detected: " + mcp_issue + "."
+
+            calls = []
+            messages = []
+            for item in output:
+                if not isinstance(item, dict):
+                    continue
+                item_type = item.get("type")
+                if item_type in ("function_call", "custom_tool_call"):
+                    calls.append(item)
+                elif item_type == "message":
+                    content = self._native_message_content(item).strip()
+                    if content:
+                        messages.append(content)
+
+            stats = data.get("usage", data.get("stats", {}))
+            self._last_stats = dict(stats) if isinstance(stats, dict) else {}
+            self._last_stats["mcp_calls"] = mcp_call_count
+            self._last_stats["device_tool_calls"] = len(tool_history)
+            self._last_stats["response_rounds"] = round_index + 1
+            self._native_response_id = response_id
+            if calls:
+                outputs = []
+                for call in calls:
+                    name = call.get("name", call.get("tool", ""))
+                    call_id = call.get("call_id", call.get("id", ""))
+                    if not isinstance(call_id, str) or not call_id:
+                        return "API error: LM Studio Responses tool call omitted call_id."
+                    arguments = self._parse_tool_arguments(call.get("arguments", {}))
+                    try:
+                        result = self._execute_mode_guarded_tool(
+                            tool_history, cache, tool_counts, name, arguments
+                        )
+                    except RuntimeError as exc:
+                        return str(exc)
+                    outputs.append(
+                        {
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": json.dumps(result),
+                        }
+                    )
+                input_value = outputs
+                continue
+
+            final = "\n\n".join(messages)
+            if not final:
+                return "API error: LM Studio Responses returned no final message."
+            self._status = "Complete"
+            self.view_manager.log("[Agent] LM Studio response complete")
+            return final
+
+        return "An error occurred during processing: Tool loop exceeded max iterations."
+
+    @staticmethod
+    def _parse_integration_catalog(value) -> list[str]:
+        """Extract stored integration IDs from a catalog tool result."""
+        if isinstance(value, dict):
+            if isinstance(value.get("id"), str):
+                value = [value]
+            elif "content" in value:
+                return Agent._parse_integration_catalog(value.get("content"))
+            else:
+                return []
+
+        if isinstance(value, str):
+            text = value.strip()
+            try:
+                value = json.loads(text)
+            except ValueError:
+                start = text.find("[")
+                end = text.rfind("]")
+                if start == -1 or end <= start:
+                    return []
+                try:
+                    value = json.loads(text[start : end + 1])
+                except ValueError:
+                    return []
+
+        if not isinstance(value, list):
+            return []
+
+        integrations = []
+        for item in value:
+            if isinstance(item, dict) and item.get("type") == "text":
+                for integration_id in Agent._parse_integration_catalog(item.get("text", "")):
+                    if integration_id not in integrations:
+                        integrations.append(integration_id)
+                continue
+            if not isinstance(item, dict):
+                continue
+            integration_id = item.get("id")
+            if not isinstance(integration_id, str):
+                continue
+            if not (integration_id.startswith("mcp/") or integration_id.startswith("plugin:")):
+                continue
+            if integration_id == INTEGRATION_CATALOG_ID or integration_id in integrations:
+                continue
+            integrations.append(integration_id)
+            if len(integrations) >= 64:
+                break
+        return integrations
+
+    def scan_integrations(self) -> tuple[list[str], str]:
+        """Ask the read-only catalog MCP for available LM Studio integrations.
+
+        Returns:
+            tuple: ``(integration IDs, error message)``. The error string is
+            empty when discovery succeeds.
+        """
+        payload = {
+            "model": self.llm.model,
+            "input": "Call list_integrations exactly once. Do not call any other tool.",
+            "integrations": [INTEGRATION_CATALOG_ID],
+            "temperature": 0,
+            "store": False,
+        }
+        thinking = self.llm.thinking_payload
+        if thinking:
+            payload.update(thinking)
+
+        storage = self.view_manager.storage
+        storage.remove(self._response_path)
+        response = None
+        try:
+            response = self.http.post(
+                native_mcp_url(self.llm.url),
+                payload=payload,
+                headers=self.llm.headers,
+                timeout=180,
+                save_to_file=self._response_path,
+                storage=storage,
+            )
+            if not storage.exists(self._response_path):
+                return [], "LM Studio returned no scan data."
+            if storage.size(self._response_path) > MAX_SCAN_RESPONSE_BYTES:
+                return [], "Scan response exceeded the 32768-byte device limit."
+            from gc import collect
+            collect()
+            data = storage.serialize(self._response_path)
+        except (MemoryError, ValueError):
+            return [], "LM Studio scan data exceeded available device memory."
+        finally:
+            if response is not None:
+                try:
+                    response.close()
+                except Exception:
+                    pass
+            storage.remove(self._response_path)
+            from gc import collect
+            collect()
+
+        error_detail = data.get("error") if isinstance(data, dict) else None
+        if error_detail:
+            if isinstance(error_detail, dict):
+                error_detail = error_detail.get("message", str(error_detail))
+            error_text = str(error_detail)
+            if len(error_text) > 180:
+                error_text = error_text[:180] + "..."
+            return [], "Scan failed: " + error_text
+
+        output = data.get("output", []) if isinstance(data, dict) else []
+        for item in output:
+            if not isinstance(item, dict) or item.get("type") != "tool_call":
+                continue
+            integrations = self._parse_integration_catalog(
+                item.get("output", item.get("result", ""))
+            )
+            if integrations:
+                return integrations, ""
+
+        return [], "Catalog MCP returned no integrations."
+
+    def _run_loop(self, user_message: str) -> str:
         """Run the model/tool loop until a final reply is produced.
 
         Returns:
             str: The final assistant text, or an error message.
         """
-        tools = [tool.json_openai for tool in dispatch.get_tool_list()]
-        storage = self.view_manager.storage
+        if self.llm.native_mcp:
+            return self._run_responses_mcp(user_message)
+
+        tool_history = []
+        cache = {}
+        tool_counts = {}
 
         for _ in range(MAX_TOOL_ITERATIONS):
+            if self._cancelled:
+                return "An error occurred during processing: Agent request cancelled."
             # Build request from conversation
-            self._build_request(tools)
-
-            response = self.http.post(
-                self.llm.url,
-                headers=self.llm.headers,
-                payload=None,
-                timeout=120,
-                storage=storage,
-                send_file=self._file_path,
-            )
-
-            try:
-                data = response.json()
-            except ValueError:
-                body = response.text.strip()
-                if len(body) > 500:
-                    body = body[:500] + "..."
-                return f"API error: Invalid JSON response from model API: {body}"
+            self._status = "Local model"
+            self._build_request(self._chat_completion_tools(tool_counts))
+            data = self._post_request_file(self.llm.url, 120)
+            error = self._error_message(data, "model API")
+            if error:
+                return error
 
             if "choices" not in data:
                 error_detail = data.get("error", {})
@@ -272,7 +1477,18 @@ class Agent:
                 self.view_manager.log(f"[Agent] Final response: {content}")
                 return content if isinstance(content, str) else str(content)
 
-            # Store assistant message
+            parsed_calls = []
+            for tool_call in message["tool_calls"]:
+                try:
+                    function = tool_call["function"]
+                    name = function["name"]
+                    raw_args = function.get("arguments", "{}")
+                except (KeyError, TypeError):
+                    return "An error occurred during processing: Invalid tool call."
+                args = self._parse_tool_arguments(raw_args)
+                parsed_calls.append((tool_call, name, args))
+
+            # Store assistant message after the whole tool batch passes guards.
             assistant_message: dict = {
                 "role": "assistant",
                 "tool_calls": message["tool_calls"],
@@ -281,25 +1497,20 @@ class Agent:
                 assistant_message["content"] = message["content"]
             self._conv_append(assistant_message)
 
-            for tool_call in message["tool_calls"]:
-                name = tool_call["function"]["name"]
-                raw_args = tool_call["function"].get("arguments", "{}")
-                args = self._parse_tool_arguments(raw_args)
-
+            for tool_call, name, args in parsed_calls:
                 try:
-                    self.view_manager.log(f"[Agent] Executing {name} with args: {args}")
-                    result = dispatch.execute_tool(self.view_manager, name, args)
-                    self.view_manager.log(f"[Agent] {name} returned: {result}")
-                except (TypeError, ValueError, KeyError) as exc:
-                    result = f"Tool error in {name}: {exc}"
-                    self.view_manager.log(f"[Agent] {result}")
+                    result = self._execute_mode_guarded_tool(
+                        tool_history, cache, tool_counts, name, args
+                    )
+                except RuntimeError as exc:
+                    return str(exc)
 
                 # Store tool result
                 self._conv_append(
                     {
                         "role": "tool",
                         "tool_call_id": tool_call.get("id", "unknown_tool_call"),
-                        "content": str(result),
+                        "content": json.dumps(result),
                     }
                 )
 
@@ -337,12 +1548,55 @@ class Agent:
             text = content.strip()
             if not text:
                 continue
+            if len(text) > MAX_MESSAGE_CHARS:
+                text = text[:MAX_MESSAGE_CHARS] + "..."
 
             sanitized.append({"role": role, "content": text})
 
         if len(sanitized) > max_messages > 0:
-            return sanitized[-max_messages:]
-        return sanitized
+            sanitized = sanitized[-max_messages:]
+
+        bounded = []
+        total = 0
+        for message in reversed(sanitized):
+            size = len(message["content"].encode("utf-8"))
+            if bounded and total + size > MAX_CONVERSATION_BYTES:
+                break
+            bounded.append(message)
+            total += size
+        bounded.reverse()
+        return bounded
+
+    def _write_mode_context(self, context=None) -> None:
+        """Write one compact, provider-neutral system context to SD."""
+        storage = self.view_manager.storage
+        storage.remove(self._mem_path)
+        if context is not None:
+            storage.write(self._mem_path, context.strip() + "\n", mode="w")
+            return
+        file_obj = storage.file_open(self._mem_path)
+        if file_obj is None:
+            raise OSError("could not create Agent context file")
+        try:
+            if self.mode == MODE_CHAT:
+                values = (chat.PROMPT, chat.WORKFLOW, chat.CONTEXT)
+            elif self.mode == MODE_APP_CREATOR:
+                values = (
+                    app_creator.PROMPT,
+                    app_creator.WORKFLOW,
+                    app_creator.COMPACT_CONTEXT,
+                )
+            else:
+                values = (
+                    device_manager.PROMPT,
+                    device_manager.WORKFLOW,
+                    device_manager.CONTEXT,
+                )
+            for value in values:
+                storage.file_write(file_obj, value, mode="b")
+                storage.file_write(file_obj, b"\n", mode="b")
+        finally:
+            storage.file_close(file_obj)
 
 
     def run(self,topic: str, conversation: list[dict] | None = None, context=None) -> str:
@@ -360,46 +1614,22 @@ class Agent:
         if not user_message:
             return "No message provided."
         
-        s = self.view_manager.storage
-        if context is not None:
-            s.write(self._mem_path, f"{context.strip()}\n", mode="a")
-        else:
-            f = s.file_open(self._mem_path)
-            if f is not None:
-                try:
-                    if self.mode == MODE_CHAT:
-                        s.file_write(f, chat.PROMPT, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                        s.file_write(f, chat.WORKFLOW, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                        s.file_write(f, chat.CONTEXT, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                    elif self.mode == MODE_APP_CREATOR:
-                        s.file_write(f, app_creator.PROMPT, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                        s.file_write(f, app_creator.WORKFLOW, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                        s.file_write(f, app_creator.CONTEXT, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                    elif self.mode == MODE_DEVICE_MANAGER:
-                        s.file_write(f, device_manager.PROMPT, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                        s.file_write(f, device_manager.WORKFLOW, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                        s.file_write(f, device_manager.CONTEXT, mode="b")
-                        s.file_write(f, b"\n", mode="b")
-                finally:
-                    s.file_close(f)
+        self._cancelled = False
+        self._status = "Preparing"
+        self._conversation = self._sanitize_conversation(conversation)
+        self._write_mode_context(context)
 
         # Write initial messages to storage
         messages = [{"role": "system", "content": ""}]
-        messages.extend(self._sanitize_conversation(conversation))
+        messages.extend(self._conversation)
         messages.append({"role": "user", "content": user_message})
 
         try:
-            self._conv_write_initial(messages)
-            return self._run_loop()
+            if not self.llm.native_mcp:
+                self._conv_write_initial(messages)
+            return self._run_loop(user_message)
         except Exception as exc:
+            self._status = "Error"
             return f"An error occurred during processing: {exc}"
 
     def run_payload(self, payload: dict) -> dict:
@@ -419,7 +1649,12 @@ class Agent:
             }
 
         topic = payload.get("message") or payload.get("topic")
-        conversation = self._sanitize_conversation(payload.get("conversation"))
+        raw_conversation = payload.get("conversation")
+        conversation = (
+            self._sanitize_conversation(raw_conversation)
+            if raw_conversation is not None
+            else list(self._conversation)
+        )
 
         if not isinstance(topic, str) or not topic.strip():
             return {
@@ -443,14 +1678,32 @@ class Agent:
             if isinstance(message, str) and message.startswith((
             "API error",
             "An error occurred during processing:",
+            "Tool loop stopped before execution:",
         ))
             else "completed"
         )
+
+        self._conversation = updated_conversation
+        if status == "error":
+            # A failed request may not exist in the provider-side chain. The
+            # next turn restarts from the bounded visible conversation.
+            self._native_response_id = ""
+            self._status = "Error"
+        else:
+            self._status = "Complete"
+            total_bytes = sum(
+                len(item["content"].encode("utf-8"))
+                for item in updated_conversation
+            )
+            if (
+                len(updated_conversation) >= MAX_CONVERSATION_MESSAGES
+                or total_bytes >= (MAX_CONVERSATION_BYTES * 3 // 4)
+            ):
+                self._native_response_id = ""
+        self._save_state()
 
         return {
             "status": status,
             "message": message,
             "conversation": updated_conversation,
         }
-
-    

--- a/src/MicroPython/picoware/system/agent/context/app_creator.py
+++ b/src/MicroPython/picoware/system/agent/context/app_creator.py
@@ -2169,9 +2169,45 @@ WORKFLOW = const(b"""
 # App Creator - Workflow
 
 Follow these steps in order for every run:
-1. Determine the user's intent and the type of app they want to create, and review the relevant API sections.
+1. Determine the user's intent and the type of app they want to create. Call `picoware_api_search`, then call `picoware_api_read` for the relevant API sections before writing code.
 2. Write the app code in a single `.py` file using the provided APIs. Regular applications are saved in `picoware/apps/`, screensavers in `picoware/apps/screensavers/`, and games in `picoware/apps/games/`. 
-3. Review the code for correctness, syntax, and adherence to the API specifications. Correct any issues and ensure the code is ready to run.
+3. Call `picoware_app_validate`, then read the saved source back. Correct a concrete error at most once and ensure the code is ready to run.
 4. Return the location of the `.py` file containing the app code, describe how the app works, and list any errors, assumptions, or limitations in the implementation. Always return a response.          
 """
 )
+
+COMPACT_CONTEXT = const(b"""
+# App Creator API access
+
+The full Picoware API reference is available through `picoware_api_search` and
+`picoware_api_read`. Retrieve only the sections needed for the requested app.
+Do not invent classes, methods, constants, imports, or callback signatures.
+
+# Required app-file contract
+
+- An SD app is a plain module that exports exactly the lifecycle callbacks
+  `start(view_manager)`, `run(view_manager)`, and `stop(view_manager)`.
+- Do not instantiate or register `View` or `ViewManager` in the app file.
+- Do not import from top-level `picoware`. Import exact modules documented by
+  the reference, for example `BUTTON_BACK` from
+  `picoware.system.buttons` and `Vector` from `picoware.system.vector`.
+- Read buttons from `view_manager.button`. Exit with
+  `view_manager.back()` when it equals `BUTTON_BACK`.
+- Use `view_manager.draw`; draw with documented methods and call `draw.swap()`
+  after changing the back buffer. Keep `run` non-blocking.
+
+# Efficient tool sequence
+
+Use one combined `picoware_api_search` call, then read no more than four
+relevant sections. Write the complete source once, call
+`picoware_app_validate`, and read the file back once. If validation succeeds
+and read-back is complete, stop using tools and answer. Rewrite at most once,
+and only to correct a concrete validator or read-back error.
+Never call `picoware_app_validate` before `storage_write` succeeds. If the
+validator reports `not_found`, write the file instead of retrying validation.
+
+Use `storage_write` with mode `w` and encoding `utf-8` for Python source.
+Check the structured write result. If it is not successful, correct the path or
+request and retry only once when the correction is meaningful. After writing,
+validate and read the file back to verify that the complete source was saved.
+""")

--- a/src/MicroPython/picoware/system/agent/llm.py
+++ b/src/MicroPython/picoware/system/agent/llm.py
@@ -8,10 +8,81 @@ ANTHROPIC = const(2)
 GEMINI = const(3)
 LOCAL = const(4)
 XAI = const(5)
+LOCAL_MCP = const(6)
+
+
+def native_mcp_url(local_url: str) -> str:
+    """Return LM Studio's native chat endpoint for a configured local URL.
+
+    Args:
+        local_url (str): Local provider URL or server base URL.
+
+    Returns:
+        str: URL ending in /api/v1/chat.
+    """
+    url = (local_url or "").rstrip("/")
+    for suffix in ("/api/v1/chat", "/v1/chat/completions", "/v1/responses"):
+        if url.endswith(suffix):
+            return url[: -len(suffix)] + "/api/v1/chat"
+    if url.endswith("/v1"):
+        url = url[:-3]
+    return url + "/api/v1/chat"
+
+
+def responses_url(local_url: str) -> str:
+    """Return LM Studio's OpenAI-compatible Responses endpoint."""
+    url = (local_url or "").rstrip("/")
+    for suffix in ("/api/v1/chat", "/v1/chat/completions", "/v1/responses"):
+        if url.endswith(suffix):
+            return url[: -len(suffix)] + "/v1/responses"
+    if url.endswith("/v1"):
+        return url + "/responses"
+    return url + "/v1/responses"
+
+
+def parse_mcp_integrations(value: str, limit: int = 16) -> list[str]:
+    """Normalize comma-separated LM Studio integration IDs.
+
+    Args:
+        value (str): Comma- or newline-separated server IDs.
+        limit (int): Maximum number of integrations to expose. Defaults to 16.
+
+    Returns:
+        list[str]: Unique LM Studio integration IDs.
+
+    Notes:
+        Plain values remain backward-compatible MCP labels and receive the
+        ``mcp/`` prefix. Hub plugins use an explicit ``plugin:owner/name``
+        spelling because MCP labels may also contain slashes.
+    """
+    if not isinstance(value, str):
+        return []
+
+    integrations = []
+    for raw in value.replace("\n", ",").split(","):
+        server_id = raw.strip()
+        if not server_id:
+            continue
+        if server_id.startswith("plugin:"):
+            server_id = server_id[7:].strip()
+            if not server_id:
+                continue
+        else:
+            if not server_id.startswith("mcp/"):
+                server_id = "mcp/" + server_id
+            # LM Studio canonicalizes MCP labels containing slashes when it
+            # generates the mcpBridge artifact (for example,
+            # microsoft/markitdown -> mcp/microsoftmarkitdown).
+            server_id = "mcp/" + server_id[4:].replace("/", "")
+        if server_id not in integrations:
+            integrations.append(server_id)
+        if len(integrations) >= limit:
+            break
+    return integrations
 
 class LLM:
     """LLM config"""
-    __slots__ = ["_api_key", "_current_model", "_id", "_name", "_url", "_models", "_headers", "_thinking"]
+    __slots__ = ["_api_key", "_current_model", "_id", "_name", "_url", "_models", "_headers", "_thinking", "_mcp_integrations"]
     def __init__(self, storage, llm_id: int, model: str = None, thinking: str = "none"):
         """Initialize the LLM config for the given provider ID.
 
@@ -32,6 +103,7 @@ class LLM:
         self._url = ""
         self._models = []
         self._headers = {}
+        self._mcp_integrations = []
         self.__set(storage)
     
     @property
@@ -60,6 +132,16 @@ class LLM:
         return self._models
 
     @property
+    def mcp_integrations(self) -> list[str]:
+        """Return configured LM Studio MCP integration IDs."""
+        return self._mcp_integrations
+
+    @property
+    def native_mcp(self) -> bool:
+        """Return whether this provider uses LM Studio's native MCP API."""
+        return self._id == LOCAL_MCP
+
+    @property
     def payload(self) -> dict:
         """Return a payload for the chat agent based on the provider."""
         _payload = {
@@ -85,6 +167,8 @@ class LLM:
                 _payload["reasoning_effort"] = self._thinking
             elif self._id == LOCAL:
                 _payload["think"] = True
+            elif self._id == LOCAL_MCP:
+                _payload["reasoning"] = "on"
             elif self._id in (OPENAI, GEMINI):
                 _payload["reasoning_effort"] = self._thinking
             elif self._id == ANTHROPIC:
@@ -100,6 +184,8 @@ class LLM:
                 _payload["thinking"] = {"type": "disabled"}
             elif self._id == LOCAL:
                 _payload["think"] = False
+            elif self._id == LOCAL_MCP:
+                _payload["reasoning"] = "off"
             elif self._id in (OPENAI, GEMINI):
                 _payload["reasoning_effort"] = self._thinking
             elif self._id == ANTHROPIC:
@@ -121,7 +207,7 @@ class LLM:
     @staticmethod
     def providers() -> list:
         """Return a list of available LLM providers."""
-        return [OPENAI, DEEPSEEK, ANTHROPIC, GEMINI, LOCAL, XAI]
+        return [OPENAI, DEEPSEEK, ANTHROPIC, GEMINI, LOCAL, LOCAL_MCP, XAI]
 
     @staticmethod
     def provider_name(provider_id: int) -> str:
@@ -143,6 +229,8 @@ class LLM:
             return "Gemini"
         if provider_id == LOCAL:
             return "Local"
+        if provider_id == LOCAL_MCP:
+            return "LM Studio MCP"
         if provider_id == XAI:
             return "xAI"
         return "Unknown"
@@ -182,13 +270,20 @@ class LLM:
             self._name = "Local"
             self._url = settings.local_url
             self._models = ["qwen3.5:9b", "qwen3.5:4b", "qwen3.5:0.8b", "qwen3.5:2b", "llama3.2:3b", "llama3.2:1b"]
+            self._api_key = settings.local_api_key
+        elif self._id == LOCAL_MCP:
+            self._name = "LM Studio MCP"
+            self._url = responses_url(settings.local_url)
+            self._models = ["qwen/qwen3.5-9b", "qwen/qwen3.5-4b", "qwen/qwen3.5-2b", "qwen/qwen3.5-0.8b"]
+            self._api_key = settings.local_api_key
+            self._mcp_integrations = parse_mcp_integrations(settings.local_mcp_servers)
         elif self._id == XAI:
             self._name = "xAI"
             self._url = "https://api.x.ai/v1"
             self._models = ["grok-4.5", "grok-4.3", "grok-build-0.1", "grok-4.20", "grok-4.20-non-reasoning"]
             self._api_key = settings.xai_api_key
         
-        if self._id != LOCAL:
+        if self._id not in (LOCAL, LOCAL_MCP) or self._api_key:
             self._headers["Authorization"] = f"Bearer {self._api_key}"
         
         if self._current_model is None:
@@ -196,4 +291,3 @@ class LLM:
         else:
             if self._current_model not in self._models:
                 self._models.append(self._current_model)
-        

--- a/src/MicroPython/picoware/system/agent/tools/api_reference.py
+++ b/src/MicroPython/picoware/system/agent/tools/api_reference.py
@@ -1,0 +1,188 @@
+"""On-demand access to the large App Creator API reference."""
+from picoware.system.agent.tools.tool import Tool, Parameters, Property
+
+MAX_REFERENCE_RESULT_BYTES = 12000
+
+
+def _sections():
+    from picoware.system.agent.context import app_creator
+
+    raw = app_creator.CONTEXT
+    marker = b"\n#### "
+    start = raw.find(marker)
+    while start >= 0:
+        title_start = start + len(marker)
+        title_end = raw.find(b"\n", title_start)
+        if title_end < 0:
+            break
+        next_start = raw.find(marker, title_end)
+        end = len(raw) if next_start < 0 else next_start
+        yield raw[title_start:title_end].decode("utf-8"), title_end + 1, end, raw
+        start = next_start
+
+
+def _query_tokens(query: str):
+    tokens = []
+    for token in query.lower().replace("_", " ").replace("-", " ").split():
+        if len(token) >= 3 and token not in tokens:
+            tokens.append(token)
+    return tokens[:8]
+
+
+def picoware_api_search(_view_manager, query, limit: int = 6):
+    """Return the best matching App Creator API section names."""
+    if not isinstance(query, str) or not query.strip():
+        return {"ok": False, "error": "invalid_query", "message": "query is empty"}
+    if not isinstance(limit, int):
+        limit = 6
+    limit = max(1, min(limit, 10))
+    tokens = _query_tokens(query)
+    matches = []
+    for title, start, end, raw in _sections():
+        title_lower = title.lower()
+        body = raw[start:end].lower()
+        score = 0
+        for token in tokens:
+            encoded = token.encode("utf-8")
+            if token in title_lower:
+                score += 10
+            if body.find(encoded) >= 0:
+                score += 1
+        if score:
+            matches.append((score, title))
+    matches.sort(key=lambda item: (-item[0], item[1]))
+    return {
+        "ok": True,
+        "query": query,
+        "sections": [title for _score, title in matches[:limit]],
+    }
+
+
+def picoware_api_read(_view_manager, section, max_bytes: int = MAX_REFERENCE_RESULT_BYTES):
+    """Return one named App Creator API section with a strict size bound."""
+    if not isinstance(section, str) or not section.strip():
+        return {"ok": False, "error": "invalid_section", "message": "section is empty"}
+    if not isinstance(max_bytes, int):
+        max_bytes = MAX_REFERENCE_RESULT_BYTES
+    max_bytes = max(512, min(max_bytes, MAX_REFERENCE_RESULT_BYTES))
+    requested = section.strip().lower()
+    fallback = None
+    for title, start, end, raw in _sections():
+        title_lower = title.lower()
+        if title_lower == requested:
+            fallback = (title, start, end, raw)
+            break
+        if requested in title_lower and fallback is None:
+            fallback = (title, start, end, raw)
+    if fallback is None:
+        return {
+            "ok": False,
+            "error": "section_not_found",
+            "message": "call picoware_api_search to find a section name",
+        }
+    title, start, end, raw = fallback
+    truncated = end - start > max_bytes
+    content = raw[start : min(end, start + max_bytes)].decode("utf-8")
+    return {
+        "ok": True,
+        "section": title,
+        "content": content,
+        "truncated": truncated,
+    }
+
+
+def picoware_app_validate(view_manager, file_path):
+    """Validate syntax and the required Picoware SD-app module contract."""
+    from picoware.system.agent.tools.storage import _normalize_path
+
+    try:
+        path = _normalize_path(file_path)
+        storage = view_manager.storage
+        if not storage.exists(path) or storage.is_directory(path):
+            return {
+                "ok": False,
+                "path": path,
+                "error": "not_found",
+                "message": "app source does not exist",
+            }
+        size = storage.size(path)
+        if size > 65536:
+            return {
+                "ok": False,
+                "path": path,
+                "error": "too_large",
+                "message": "app source exceeds 65536 bytes",
+                "size": size,
+            }
+        source = storage.read(path, "r")
+        if not isinstance(source, str) or not source:
+            return {
+                "ok": False,
+                "path": path,
+                "error": "read_failed",
+                "message": "could not read app source as UTF-8",
+            }
+        issues = []
+        for callback in ("def start(view_manager", "def run(view_manager", "def stop(view_manager"):
+            if callback not in source:
+                issues.append("missing " + callback.split("(", 1)[0])
+        if "return True" not in source:
+            issues.append("start must return True")
+        if "view_manager.back()" not in source:
+            issues.append("run must provide view_manager.back() exit")
+        forbidden = (
+            "from picoware import",
+            "ViewManager.add",
+            "view_manager.add(",
+            "view = View(",
+        )
+        for pattern in forbidden:
+            if pattern in source:
+                issues.append("app module must not register views: " + pattern)
+        syntax_error = ""
+        try:
+            compile(source, path, "exec")
+        except Exception as exc:
+            syntax_error = str(exc)
+            issues.append("syntax error: " + syntax_error)
+        return {
+            "ok": not issues,
+            "path": path,
+            "size": size,
+            "syntax_ok": not syntax_error,
+            "contract_ok": not issues,
+            "issues": issues,
+        }
+    except Exception as exc:
+        return {
+            "ok": False,
+            "error": "validation_failed",
+            "message": str(exc),
+        }
+
+
+TOOL_PICOWARE_API_SEARCH = Tool(
+    "picoware_api_search",
+    "Search Picoware's App Creator API reference for relevant section names.",
+    Parameters([
+        Property("query", "string", "API, module, widget, or feature to find.", True),
+        Property("limit", "integer", "Maximum section names to return, from 1 to 10."),
+    ]),
+)
+
+TOOL_PICOWARE_API_READ = Tool(
+    "picoware_api_read",
+    "Read one exact section returned by picoware_api_search.",
+    Parameters([
+        Property("section", "string", "Section name returned by picoware_api_search.", True),
+        Property("max_bytes", "integer", "Maximum bytes to return, up to 12000."),
+    ]),
+)
+
+TOOL_PICOWARE_APP_VALIDATE = Tool(
+    "picoware_app_validate",
+    "Compile-check a saved Picoware app and validate its lifecycle module contract.",
+    Parameters([
+        Property("file_path", "string", "Saved Picoware .py app path on the SD card.", True),
+    ]),
+)

--- a/src/MicroPython/picoware/system/agent/tools/dispatch.py
+++ b/src/MicroPython/picoware/system/agent/tools/dispatch.py
@@ -1,10 +1,12 @@
 """Tool registry and execution dispatcher."""
 from picoware.system.agent.tools.storage import (
+    storage_get_info,
     storage_listdir,
     storage_mkdir,
     storage_read,
     storage_remove,
     storage_write,
+    TOOL_STORAGE_GET_INFO,
     TOOL_STORAGE_LISTDIR,
     TOOL_STORAGE_MKDIR,
     TOOL_STORAGE_READ,
@@ -22,6 +24,31 @@ from picoware.system.agent.tools.network import (
     TOOL_NETWORK_SCAN_BLE,
     TOOL_NETWORK_SEND_REQUEST,
 )
+from picoware.system.agent.tools.api_reference import (
+    picoware_api_search,
+    picoware_api_read,
+    picoware_app_validate,
+    TOOL_PICOWARE_API_SEARCH,
+    TOOL_PICOWARE_API_READ,
+    TOOL_PICOWARE_APP_VALIDATE,
+)
+
+
+_TOOL_MAP = {
+    "storage_get_info": storage_get_info,
+    "storage_listdir": storage_listdir,
+    "storage_mkdir": storage_mkdir,
+    "storage_read": storage_read,
+    "storage_remove": storage_remove,
+    "storage_write": storage_write,
+    "network_get_info": network_get_info,
+    "network_scan_wifi": network_scan_wifi,
+    "network_scan_ble": network_scan_ble,
+    "network_send_request": network_send_request,
+    "picoware_api_search": picoware_api_search,
+    "picoware_api_read": picoware_api_read,
+    "picoware_app_validate": picoware_app_validate,
+}
 
 def execute_tool(view_manager, name, args=None, **kwargs):
     """Execute a named tool with the given arguments.
@@ -39,27 +66,20 @@ def execute_tool(view_manager, name, args=None, **kwargs):
     if args and isinstance(args, dict):
         payload.update(args)
     payload.update(kwargs)
-    result = get_tool_map()[name](view_manager, **payload)
+    function = _TOOL_MAP.get(name)
+    if function is None:
+        raise ValueError("unknown tool: " + str(name))
+    result = function(view_manager, **payload)
     return result
 
 def get_tool_map():
     """Return the mapping of tool names to their execution functions."""
-    return {
-        "storage_listdir": storage_listdir,
-        "storage_mkdir": storage_mkdir,
-        "storage_read": storage_read,
-        "storage_remove": storage_remove,
-        "storage_write": storage_write,
-        #
-        "network_get_info": network_get_info,
-        "network_scan_wifi": network_scan_wifi,
-        "network_scan_ble": network_scan_ble,
-        "network_send_request": network_send_request,
-    }
+    return _TOOL_MAP
 
 def get_tool_list():
     """Return the list of available tools."""
     return [
+        TOOL_STORAGE_GET_INFO,
         TOOL_STORAGE_LISTDIR,
         TOOL_STORAGE_MKDIR,
         TOOL_STORAGE_READ,
@@ -70,4 +90,7 @@ def get_tool_list():
         TOOL_NETWORK_SCAN_WIFI,
         TOOL_NETWORK_SCAN_BLE,
         TOOL_NETWORK_SEND_REQUEST,
+        TOOL_PICOWARE_API_SEARCH,
+        TOOL_PICOWARE_API_READ,
+        TOOL_PICOWARE_APP_VALIDATE,
     ]

--- a/src/MicroPython/picoware/system/agent/tools/network.py
+++ b/src/MicroPython/picoware/system/agent/tools/network.py
@@ -2,8 +2,53 @@
 
 from picoware.system.agent.tools.tool import Tool, Parameters, Property
 
+
+def network_get_time_info(view_manager) -> dict:
+    """Return the Picoware clock state in a model-friendly format.
+
+    The RTC value is only authoritative when ``clock_is_set`` is true. The
+    Time service sets that flag after either an NTP update or a manual date
+    and time update.
+    """
+    offset = int(getattr(view_manager, "gmt_offset", 0))
+    sign = "+" if offset >= 0 else "-"
+    info = {
+        "clock_is_set": False,
+        "clock_is_fetching": False,
+        "current_local_datetime": "",
+        "gmt_offset_hours": offset,
+        "utc_offset": "{}{:02d}:00".format(sign, abs(offset)),
+    }
+
+    clock = getattr(view_manager, "time", None)
+    if clock is None:
+        return info
+
+    info["clock_is_set"] = bool(clock.is_set)
+    info["clock_is_fetching"] = bool(clock.is_fetching)
+    rtc = clock.rtc
+    if rtc is None:
+        return info
+
+    try:
+        value = rtc.datetime()
+        info["current_local_datetime"] = (
+            "{:04d}-{:02d}-{:02d}T{:02d}:{:02d}:{:02d}".format(
+                value[0],
+                value[1],
+                value[2],
+                value[4],
+                value[5],
+                value[6],
+            )
+        )
+    except (IndexError, OSError, TypeError, ValueError):
+        pass
+    return info
+
+
 def network_get_info(view_manager) -> dict:
-    """Get network information about the device.
+    """Get device, network, and current clock information.
 
     Args:
         view_manager (ViewManager): The view manager for system access.
@@ -32,6 +77,7 @@ def network_get_info(view_manager) -> dict:
         "used_psram": syst.used_psram,
         "version": syst.version,
     }
+    _info.update(network_get_time_info(view_manager))
     if not view_manager.has_wifi:
         return _info
     _wifi = view_manager.wifi
@@ -101,7 +147,7 @@ def network_scan_ble(view_manager, timeout_ms: int = 3000) -> list:
     
 
 def network_send_request(view_manager, url, method="GET", headers=None, data=None):
-    """Send an HTTP request and return the response text.
+    """Fetch one URL through an SD spool and return a bounded text excerpt.
 
     Args:
         view_manager (ViewManager): The view manager for thread access.
@@ -111,16 +157,67 @@ def network_send_request(view_manager, url, method="GET", headers=None, data=Non
         data (str or None): Optional request body data. Defaults to None.
 
     Returns:
-        str: The response text.
+        dict: Structured status and at most 8192 bytes of response text.
     """
     from picoware.system.http import HTTP
+    if not isinstance(url, str) or not url.startswith(("http://", "https://")):
+        return {"ok": False, "error": "invalid_url", "message": "URL must use HTTP or HTTPS"}
+    if len(url) > 2048:
+        return {"ok": False, "error": "invalid_url", "message": "URL is longer than 2048 characters"}
+    method = str(method or "GET").upper()
+    if method not in ("GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"):
+        return {"ok": False, "error": "invalid_method", "message": "unsupported HTTP method"}
+
+    storage = view_manager.storage
+    spool_path = "picoware/settings/agent_network_response.tmp"
+    response = None
     http = HTTP(thread_manager=view_manager.thread_manager)
-    response = http.request(method, url, headers=headers, data=data)
-    return response.text
+    storage.remove(spool_path)
+    try:
+        response = http.request(
+            method,
+            url,
+            headers=headers,
+            data=data,
+            timeout=30,
+            save_to_file=spool_path,
+            storage=storage,
+        )
+        if response is None:
+            return {"ok": False, "error": "request_failed", "message": "request returned no response"}
+        status = int(getattr(response, "status_code", 0))
+        size = storage.size(spool_path) if storage.exists(spool_path) else 0
+        count = min(size, 8192)
+        content = ""
+        if count:
+            try:
+                content = storage.read(spool_path, "r", 0, count)
+            except Exception:
+                content = "[binary response omitted]"
+        return {
+            "ok": 200 <= status <= 299,
+            "status_code": status,
+            "url": url,
+            "content": content,
+            "response_bytes": size,
+            "truncated": size > count,
+        }
+    except Exception as exc:
+        return {"ok": False, "error": "request_failed", "message": str(exc)[:240]}
+    finally:
+        if response is not None:
+            try:
+                response.close()
+            except Exception:
+                pass
+        storage.remove(spool_path)
 
 TOOL_NETWORK_GET_INFO = Tool(
     name="network_get_info",
-    description="Get network information",
+    description=(
+        "Get device, network, and current clock information. Call this at "
+        "most once per user request and use the returned result."
+    ),
     parameters=Parameters(properties=[]),
 )
 
@@ -145,7 +242,7 @@ TOOL_NETWORK_SCAN_BLE = Tool(
 
 TOOL_NETWORK_SEND_REQUEST = Tool(
     name="network_send_request",
-    description="Send an HTTP request and return the response.",
+    description="Fetch one known HTTP URL and return a bounded response excerpt. Do not use it as a search engine.",
     parameters=Parameters(
         properties=[
             Property(

--- a/src/MicroPython/picoware/system/agent/tools/storage.py
+++ b/src/MicroPython/picoware/system/agent/tools/storage.py
@@ -1,175 +1,357 @@
-"""Storage tools for the agent."""
-
+"""Validated, recoverable SD-card tools for the Picoware Agent."""
 from picoware.system.agent.tools.tool import Tool, Parameters, Property
 
-def storage_listdir(view_manager, dir_path) ->list[str]:
-    """List the contents of a directory on the SD card.
+MAX_PATH_BYTES = 259
+MAX_TOOL_DATA_BYTES = 65536
+IO_CHUNK_BYTES = 2048
+_INVALID_NAME_CHARS = '<>:"|?*'
 
-    Args:
-        view_manager (ViewManager): The view manager for storage access.
-        dir_path (str): The directory path.
 
-    Returns:
-        list[str]: A list of filenames.
-    """
-    storage = view_manager.storage
-    return storage.listdir(dir_path)
+def _result(ok: bool, path: str = "", error: str = "", message: str = "", **values):
+    value = {"ok": bool(ok)}
+    if path:
+        value["path"] = path
+    if error:
+        value["error"] = error
+    if message:
+        value["message"] = message
+    value.update(values)
+    return value
 
-def storage_mkdir(view_manager, dir_path) -> bool:
-    """Create a directory on the SD card.
 
-    Args:
-        view_manager (ViewManager): The view manager for storage access.
-        dir_path (str): The directory path to create.
+def _normalize_path(path: str) -> str:
+    """Return one FAT-relative path without limiting usable SD folders."""
+    if not isinstance(path, str):
+        raise ValueError("path must be a string")
+    path = path.strip().replace("\\", "/")
+    for prefix in ("/sdcard/", "/sd/", "sdcard/", "sd/"):
+        if path.startswith(prefix):
+            path = path[len(prefix):]
+            break
+    path = path.lstrip("/")
+    if not path:
+        raise ValueError("path is empty")
 
-    Returns:
-        bool: True on success.
-    """
-    storage = view_manager.storage
-    return storage.mkdir(dir_path)
+    parts = []
+    for part in path.split("/"):
+        if not part or part == ".":
+            continue
+        if part == "..":
+            if not parts:
+                raise ValueError("path escapes the SD root")
+            parts.pop()
+            continue
+        if any(ord(char) < 32 or char in _INVALID_NAME_CHARS for char in part):
+            raise ValueError("path contains FAT-incompatible characters")
+        if len(part.encode("utf-8")) > 255:
+            raise ValueError("path component is longer than 255 bytes")
+        parts.append(part)
+
+    normalized = "/".join(parts)
+    if not normalized or len(normalized.encode("utf-8")) > MAX_PATH_BYTES:
+        raise ValueError("path is empty or longer than the FAT32 limit")
+    return normalized
+
+
+def _normalize_directory_path(path: str) -> str:
+    """Normalize a directory path while allowing the SD-card root."""
+    if not isinstance(path, str):
+        raise ValueError("path must be a string")
+    value = path.strip().replace("\\", "/")
+    if value in ("", "/", ".", "/sd", "/sd/", "/sdcard", "/sdcard/"):
+        return ""
+    return _normalize_path(value)
+
+
+def _ensure_parents(storage, path: str):
+    parts = path.split("/")[:-1]
+    current = ""
+    for part in parts:
+        current = part if not current else current + "/" + part
+        if storage.exists(current):
+            if not storage.is_directory(current):
+                raise OSError("parent path is not a directory: " + current)
+            continue
+        if not storage.mkdir(current):
+            raise OSError("could not create parent directory: " + current)
+
+
+def _decode_data(data, mode: str, encoding: str):
+    if not isinstance(data, str):
+        raise ValueError("data must be a string")
+    if mode not in ("w", "a", "wb", "ab"):
+        raise ValueError("mode must be w, a, wb, or ab")
+    if encoding not in ("utf-8", "base64"):
+        raise ValueError("encoding must be utf-8 or base64")
+    if encoding == "base64":
+        try:
+            from ubinascii import a2b_base64
+            value = a2b_base64(data)
+        except Exception as exc:
+            raise ValueError("data is not valid base64") from exc
+    else:
+        value = data.encode("utf-8")
+    if len(value) > MAX_TOOL_DATA_BYTES:
+        raise ValueError("data exceeds the 65536-byte tool limit")
+    return value
+
+
+def _checksum_file(storage, path: str) -> tuple[int, int]:
+    offset = 0
+    checksum = 2166136261
+    while True:
+        chunk = storage.read_chunked(path, offset, IO_CHUNK_BYTES)
+        if not chunk:
+            break
+        for value in chunk:
+            checksum ^= value
+            checksum = (checksum * 16777619) & 0xFFFFFFFF
+        offset += len(chunk)
+    return offset, checksum
+
+
+def _write_chunks(storage, path: str, data, append: bool = False):
+    file_obj = storage.file_open(path)
+    if file_obj is None:
+        raise OSError("could not open temporary file")
+    try:
+        if append and not storage.file_seek(file_obj, storage.size(path)):
+            raise OSError("could not seek to append position")
+        offset = 0
+        while offset < len(data):
+            chunk = data[offset : offset + IO_CHUNK_BYTES]
+            if not storage.file_write(file_obj, chunk, "wb"):
+                raise OSError("could not write file data")
+            offset += len(chunk)
+    finally:
+        storage.file_close(file_obj)
+
+
+def _install_temp_file(storage, path: str, temp_path: str):
+    """Install a verified temporary file and retain the old file as backup."""
+    backup_path = path + ".agent-bak"
+    had_original = storage.exists(path)
+    if storage.exists(backup_path) and not storage.remove(backup_path):
+        raise OSError("could not remove stale backup")
+    if had_original and not storage.rename(path, backup_path):
+        raise OSError("could not preserve existing file")
+    if not storage.rename(temp_path, path):
+        if had_original:
+            storage.rename(backup_path, path)
+        raise OSError("could not install temporary file")
+    return had_original, backup_path
+
+
+def _restore_backup(storage, path: str, backup_path: str, had_original: bool):
+    """Remove a failed replacement and restore the previous file if present."""
+    storage.remove(path)
+    if had_original and not storage.rename(backup_path, path):
+        raise OSError("read-back failed and the original file could not be restored")
+
+
+def storage_listdir(view_manager, dir_path):
+    try:
+        path = _normalize_directory_path(dir_path)
+        storage = view_manager.storage
+        if path and not storage.exists(path):
+            return _result(False, path, "not_found", "directory does not exist")
+        if path and not storage.is_directory(path):
+            return _result(False, path, "not_directory", "path is not a directory")
+        return _result(True, path or "/", entries=storage.listdir(path))
+    except Exception as exc:
+        return _result(False, error="invalid_path", message=str(exc))
+
+
+def _human_bytes(value: int) -> str:
+    units = ("B", "KiB", "MiB", "GiB", "TiB")
+    unit = 0
+    remainder = 0
+    while value >= 1024 and unit < len(units) - 1:
+        remainder = value % 1024
+        value //= 1024
+        unit += 1
+    if unit and value < 10:
+        return "%d.%d %s" % (value, (remainder * 10) // 1024, units[unit])
+    return "%d %s" % (value, units[unit])
+
+
+def storage_get_info(view_manager):
+    """Return authoritative SD-card capacity counters from the storage driver."""
+    try:
+        storage = view_manager.storage
+        free = max(0, int(storage.free_space))
+        total = max(0, int(storage.total_space))
+        used = max(0, total - free)
+        if total <= 0:
+            return _result(
+                False, "/", "capacity_unavailable", "SD capacity is unavailable"
+            )
+        return _result(
+            True,
+            "/",
+            free_bytes=free,
+            used_bytes=used,
+            total_bytes=total,
+            free=_human_bytes(free),
+            used=_human_bytes(used),
+            total=_human_bytes(total),
+        )
+    except Exception as exc:
+        return _result(False, "/", "capacity_failed", str(exc))
+
+
+def storage_mkdir(view_manager, dir_path):
+    try:
+        path = _normalize_path(dir_path)
+        storage = view_manager.storage
+        _ensure_parents(storage, path)
+        if storage.exists(path):
+            if storage.is_directory(path):
+                return _result(True, path, created=False)
+            return _result(False, path, "path_exists", "path exists as a file")
+        if not storage.mkdir(path):
+            return _result(False, path, "mkdir_failed", "could not create directory")
+        return _result(True, path, created=True)
+    except ValueError as exc:
+        return _result(False, error="invalid_path", message=str(exc))
+    except Exception as exc:
+        return _result(False, error="mkdir_failed", message=str(exc))
+
 
 def storage_read(view_manager, file_path, mode: str = "r", index: int = 0, count: int = 0):
-    """Read the contents of a file from the SD card.
+    try:
+        path = _normalize_path(file_path)
+        if mode not in ("r", "rb"):
+            raise ValueError("mode must be r or rb")
+        if not isinstance(index, int) or not isinstance(count, int) or index < 0 or count < 0:
+            raise ValueError("index and count must be non-negative integers")
+        storage = view_manager.storage
+        if not storage.exists(path) or storage.is_directory(path):
+            return _result(False, path, "not_found", "file does not exist")
+        size = storage.size(path)
+        requested = count if count else size - index
+        if requested > MAX_TOOL_DATA_BYTES:
+            return _result(
+                False,
+                path,
+                "read_too_large",
+                "request a partial read of at most 65536 bytes",
+                size=size,
+            )
+        data = storage.read(path, mode, index, count)
+        if mode == "rb":
+            from ubinascii import b2a_base64
+            encoded = b2a_base64(data).decode("ascii").strip()
+            return _result(True, path, data=encoded, encoding="base64", size=len(data))
+        return _result(True, path, data=data, encoding="utf-8", size=len(data.encode("utf-8")))
+    except ValueError as exc:
+        return _result(False, error="invalid_request", message=str(exc))
+    except Exception as exc:
+        return _result(False, error="read_failed", message=str(exc))
 
-    Args:
-        view_manager (ViewManager): The view manager for storage access.
-        file_path (str): The file path.
-        mode (str): The read mode. Defaults to "r".
-        index (int): The byte index to start from. Defaults to 0.
-        count (int): The number of bytes to read. Defaults to 0.
 
-    Returns:
-        str or bytes: The file contents.
-    """
-    storage = view_manager.storage
-    return storage.read(file_path, mode, index, count)
+def storage_remove(view_manager, file_path):
+    try:
+        path = _normalize_path(file_path)
+        storage = view_manager.storage
+        if not storage.exists(path):
+            return _result(True, path, removed=False)
+        if not storage.remove(path):
+            return _result(False, path, "remove_failed", "could not remove path")
+        return _result(True, path, removed=True)
+    except ValueError as exc:
+        return _result(False, error="invalid_path", message=str(exc))
+    except Exception as exc:
+        return _result(False, error="remove_failed", message=str(exc))
 
-def storage_remove(view_manager, file_path) -> bool:
-    """Remove a file or directory from the SD card.
 
-    Args:
-        view_manager (ViewManager): The view manager for storage access.
-        file_path (str): The path to remove.
+def storage_write(view_manager, file_path, data, mode: str = "w", encoding: str = "utf-8"):
+    temp_path = ""
+    try:
+        path = _normalize_path(file_path)
+        if len((path + ".agent-bak").encode("utf-8")) > MAX_PATH_BYTES:
+            raise ValueError("path is too long for recoverable writes")
+        value = _decode_data(data, mode, encoding)
+        storage = view_manager.storage
+        _ensure_parents(storage, path)
+        temp_path = path + ".agent-tmp"
+        if storage.exists(temp_path) and not storage.remove(temp_path):
+            raise OSError("could not remove stale temporary file")
 
-    Returns:
-        bool: True on success.
-    """
-    storage = view_manager.storage
-    return storage.remove(file_path)
+        append = mode in ("a", "ab")
+        if append and storage.exists(path):
+            if not storage.copy(path, temp_path, IO_CHUNK_BYTES):
+                raise OSError("could not copy existing file for append")
+            _write_chunks(storage, temp_path, value, append=True)
+        else:
+            _write_chunks(storage, temp_path, value)
 
-def storage_write(view_manager, file_path, data, mode: str = "w") -> bool:
-    """Write data to a file on the SD card.
+        expected_size, expected_checksum = _checksum_file(storage, temp_path)
+        had_original, backup_path = _install_temp_file(storage, path, temp_path)
+        actual_size, actual_checksum = _checksum_file(storage, path)
+        if actual_size != expected_size or actual_checksum != expected_checksum:
+            _restore_backup(storage, path, backup_path, had_original)
+            raise OSError("read-back verification failed")
+        backup_removed = True
+        if had_original:
+            backup_removed = storage.remove(backup_path)
+        return _result(
+            True,
+            path,
+            bytes_written=len(value),
+            size=actual_size,
+            checksum="%08x" % actual_checksum,
+            mode=mode,
+            backup_removed=backup_removed,
+        )
+    except ValueError as exc:
+        return _result(False, error="invalid_request", message=str(exc))
+    except Exception as exc:
+        if temp_path:
+            try:
+                view_manager.storage.remove(temp_path)
+            except Exception:
+                pass
+        return _result(False, error="write_failed", message=str(exc))
 
-    Args:
-        view_manager (ViewManager): The view manager for storage access.
-        file_path (str): The file path.
-        data (str or bytes): The data to write.
-        mode (str): The write mode. Defaults to "w".
-
-    Returns:
-        bool: True on success.
-    """
-    storage = view_manager.storage
-    return storage.write(file_path, data, mode)
 
 TOOL_STORAGE_LISTDIR = Tool(
-    name="storage_listdir",
-    description="List the contents of a directory on the SD card.",
-    parameters=Parameters(
-        properties=[
-            Property(
-                name="dir_path",
-                type="string",
-                description="The path to the directory on the SD card.",
-                required=True,
-            ),
-        ]
-    ),
+    "storage_listdir",
+    "List an SD-card directory and return a structured result.",
+    Parameters([Property("dir_path", "string", "Directory path on the SD card.", True)]),
 )
-
+TOOL_STORAGE_GET_INFO = Tool(
+    "storage_get_info",
+    "Return authoritative free, used, and total SD-card space in bytes and human-readable units.",
+    Parameters([]),
+)
 TOOL_STORAGE_MKDIR = Tool(
-    name="storage_mkdir",
-    description="Create a directory on the SD card.",
-    parameters=Parameters(
-        properties=[
-            Property(
-                name="dir_path",
-                type="string",
-                description="The path to the directory on the SD card.",
-                required=True,
-            ),
-        ]
-    ),
+    "storage_mkdir",
+    "Recursively create an SD-card directory and return a structured result.",
+    Parameters([Property("dir_path", "string", "Directory path on the SD card.", True)]),
 )
-
 TOOL_STORAGE_READ = Tool(
-    name="storage_read",
-    description="Read the contents of a file from the SD card.",
-    parameters=Parameters(
-        properties=[
-            Property(
-                name="file_path",
-                type="string",
-                description="The path to the file on the SD card.",
-                required=True,
-            ),
-            Property(
-                name="mode",
-                type="string",
-                description="The file mode (e.g. 'r' for read, 'rb' for read binary).",
-            ),
-            Property(
-                name="index",
-                type="integer",
-                description="The byte index to start reading from (for partial reads).",
-            ),
-            Property(
-                name="count",
-                type="integer",
-                description="The number of bytes to read (0 for full file).",
-            ),
-        ]
-    ),
+    "storage_read",
+    "Read an SD-card file. Binary data is returned as base64.",
+    Parameters([
+        Property("file_path", "string", "File path on the SD card.", True),
+        Property("mode", "string", "Read mode.", enum=["r", "rb"]),
+        Property("index", "integer", "Starting byte offset."),
+        Property("count", "integer", "Bytes to read; zero means the remaining file."),
+    ]),
 )
-
 TOOL_STORAGE_REMOVE = Tool(
-    name="storage_remove",
-    description="Remove a file or directory from the SD card.",
-    parameters=Parameters(
-        properties=[
-            Property(
-                name="file_path",
-                type="string",
-                description="The path to the file or directory on the SD card.",
-                required=True,
-            ),
-        ]
-    ),
+    "storage_remove",
+    "Remove any requested SD-card file or directory and return a structured result.",
+    Parameters([Property("file_path", "string", "File or directory path on the SD card.", True)]),
 )
-
-
 TOOL_STORAGE_WRITE = Tool(
-    name="storage_write",
-    description="Write data to a file on the SD card.",
-    parameters=Parameters(
-        properties=[
-            Property(
-                name="file_path",
-                type="string",
-                description="The path to the file on the SD card.",
-                required=True,
-            ),
-            Property(
-                name="data",
-                type="string",
-                description="The data to write to the file.",
-                required=True,
-            ),
-            Property(
-                name="mode",
-                type="string",
-                description="The file mode (e.g. 'w' for write, 'wb' for write binary).",
-            ),
-        ]
-    ),
+    "storage_write",
+    "Reliably write or append an SD-card file, creating parents and verifying the result.",
+    Parameters([
+        Property("file_path", "string", "File path on the SD card.", True),
+        Property("data", "string", "UTF-8 text or base64-encoded binary data.", True),
+        Property("mode", "string", "Write or append mode.", enum=["w", "a", "wb", "ab"]),
+        Property("encoding", "string", "Encoding of data.", enum=["utf-8", "base64"]),
+    ]),
 )

--- a/src/MicroPython/picoware/system/agent/tools/tool.py
+++ b/src/MicroPython/picoware/system/agent/tools/tool.py
@@ -3,9 +3,16 @@
 class Property:
     """Represents a property of a tool's parameters."""
 
-    __slots__ = ["name", "type", "description", "required"]
+    __slots__ = ["name", "type", "description", "required", "enum"]
 
-    def __init__(self, name: str, type: str, description: str, required: bool = False):
+    def __init__(
+        self,
+        name: str,
+        type: str,
+        description: str,
+        required: bool = False,
+        enum: list | None = None,
+    ):
         """Create a tool parameter property.
 
         Args:
@@ -18,14 +25,18 @@ class Property:
         self.type = type
         self.description = description
         self.required = required
+        self.enum = enum
 
     @property
     def json(self):
         """Returns the JSON representation of the property."""
-        return {
+        value = {
             "type": self.type,
             "description": self.description,
         }
+        if self.enum:
+            value["enum"] = self.enum
+        return value
 
 
 class Parameters:
@@ -48,6 +59,7 @@ class Parameters:
             "type": "object",
             "properties": {prop.name: prop.json for prop in self.properties},
             "required": [prop.name for prop in self.properties if prop.required],
+            "additionalProperties": False,
         }
 
 
@@ -95,4 +107,23 @@ class Tool:
                     else {"type": "object", "properties": {}}
                 ),
             },
+        }
+
+    @property
+    def json_responses(self):
+        """Schema for OpenAI-compatible Responses endpoints."""
+        return {
+            "type": "function",
+            "name": self.name,
+            "description": self.description,
+            "parameters": (
+                self.parameters.json
+                if self.parameters
+                else {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                }
+            ),
+            "strict": False,
         }

--- a/src/MicroPython/picoware/system/http.py
+++ b/src/MicroPython/picoware/system/http.py
@@ -517,6 +517,7 @@ class HTTP:
         save_to_file=None,
         storage=None,
         send_file=None,
+        stream_sink=None,
     ) -> Response:
         """Send a POST request and return a Response object.
 
@@ -528,6 +529,7 @@ class HTTP:
             save_to_file (str): File path to save response data to (requires storage). Defaults to None.
             storage (Storage): Storage object for file operations. Defaults to None.
             send_file (str): File path to send as request body (requires storage). Defaults to None.
+            stream_sink: Optional write/flush sink for a streaming response body.
 
         Returns:
             Response: The HTTP response.
@@ -547,6 +549,7 @@ class HTTP:
                     dumps(payload) if not is_instance and has_payload else None,
                     headers,
                     timeout=timeout,
+                    uart=stream_sink,
                     save_to_file=save_to_file,
                     storage=storage,
                     send_file=send_file,
@@ -722,26 +725,35 @@ class HTTP:
                         ):
                             break
                     break
-                # Read the chunk data
-                chunk = s.read(chunk_size)
-                self._update_speed(len(chunk))
-                if uart:
-                    uart.write(chunk)
-                    uart.flush()
-                elif file:
-                    # Write directly to file with retry
-                    retries = 10
-                    while retries > 0:
-                        try:
-                            storage.file_write(file, chunk, "wb")
-                            break
-                        except OSError as e:
-                            retries -= 1
-                            if retries == 0:
-                                raise e
-                            sleep_ms(10)
-                else:
-                    body += chunk
+                # A server-controlled HTTP chunk may be much larger than the
+                # Pico heap. Consume it through the configured bounded buffer.
+                remaining = chunk_size
+                while remaining > 0:
+                    read_size = min(self._chunk_size, remaining)
+                    chunk = s.read(read_size)
+                    if not chunk:
+                        remaining = 0
+                        break
+                    actual_len = len(chunk)
+                    self._update_speed(actual_len)
+                    if uart:
+                        uart.write(chunk)
+                        uart.flush()
+                    elif file:
+                        # Write directly to file with retry
+                        retries = 10
+                        while retries > 0:
+                            try:
+                                storage.file_write(file, chunk, "wb")
+                                break
+                            except OSError as e:
+                                retries -= 1
+                                if retries == 0:
+                                    raise e
+                                sleep_ms(10)
+                    else:
+                        body += chunk
+                    remaining -= actual_len
                 # Read the trailing CRLF after the chunk
                 s.read(2)
             if uart:
@@ -967,6 +979,11 @@ class HTTP:
             if not self._should_continue():
                 s.close()
                 return
+
+            # Streaming sinks consume the body without retaining it in RAM.
+            # Keep the Response contract valid for content-length and
+            # connection-close responses as well as chunked responses.
+            body = b""
 
             # Read body
             self._download_start_ticks = ticks_ms()

--- a/src/MicroPython/picoware/system/settings.py
+++ b/src/MicroPython/picoware/system/settings.py
@@ -27,6 +27,8 @@ class Settings:
             "exit_button": BUTTON_BACK,
             "gemini_api_key": "",
             "gmt_offset": 0,
+            "local_api_key": "",
+            "local_mcp_servers": "",
             "local_url": "http://127.0.0.1:8080/v1/chat/completions",
             "lvgl_mode": False,
             "onscreen_keyboard": BOARD_HAS_TOUCH == 1 or BOARD_ID == BOARD_FLIPPER_ZERO,
@@ -49,6 +51,8 @@ class Settings:
                 "exit_button": int(self.__fetch_setting("picoware/settings/exit_button.json", "exit_button", BUTTON_BACK)),
                 "gemini_api_key": "",
                 "gmt_offset": int(self.__fetch_setting("picoware/settings/gmt_offset.json", "gmt_offset", 0)),
+                "local_api_key": "",
+                "local_mcp_servers": "",
                 "local_url": "http://127.0.0.1:8080/v1/chat/completions",
                 "lvgl_mode": bool(self.__fetch_setting("picoware/settings/lvgl_mode.json", "lvgl_mode", False)),
                 "onscreen_keyboard": bool(self.__fetch_setting("picoware/settings/onscreen_keyboard.json", "onscreen_keyboard", BOARD_HAS_TOUCH == 1)),
@@ -181,6 +185,36 @@ class Settings:
     def local_url(self) -> str:
         """Return the current local URL."""
         return self._settings.get("local_url", "")
+
+    @property
+    def local_api_key(self) -> str:
+        """Return the API key for the local LLM provider."""
+        return self._settings.get("local_api_key", "")
+
+    @local_api_key.setter
+    def local_api_key(self, value: str):
+        """Set the API key for the local LLM provider.
+
+        Args:
+            value (str): The local provider API key to set.
+        """
+        self._settings["local_api_key"] = value
+        self.__save_settings()
+
+    @property
+    def local_mcp_servers(self) -> str:
+        """Return the comma-separated LM Studio MCP and plugin IDs."""
+        return self._settings.get("local_mcp_servers", "")
+
+    @local_mcp_servers.setter
+    def local_mcp_servers(self, value: str):
+        """Set the comma-separated LM Studio MCP and plugin IDs.
+
+        Args:
+            value (str): IDs such as mcp/weather or plugin:owner/name.
+        """
+        self._settings["local_mcp_servers"] = value
+        self.__save_settings()
 
     @local_url.setter
     def local_url(self, value: str):

--- a/src/MicroPython/picoware/system/storage.py
+++ b/src/MicroPython/picoware/system/storage.py
@@ -79,6 +79,28 @@ class Storage:
         return sd_mp.is_initialized()
 
     @property
+    def free_space(self) -> int:
+        """Return currently available SD-card bytes."""
+        if not self._has_storage:
+            return 0
+        try:
+            return int(sd_mp.get_free_space())
+        except Exception as e:
+            print(f"Error reading SD free space: {e}")
+            return 0
+
+    @property
+    def total_space(self) -> int:
+        """Return total SD-card capacity in bytes."""
+        if not self._has_storage:
+            return 0
+        try:
+            return int(sd_mp.get_total_space())
+        except Exception as e:
+            print(f"Error reading SD total space: {e}")
+            return 0
+
+    @property
     def vfs_mounted(self) -> bool:
         """Returns True if the VFS is mounted (allows use of open(), __import__, etc.)."""
         return self._vfs_mounted

--- a/tools/lmstudio_picoware_catalog_mcp.py
+++ b/tools/lmstudio_picoware_catalog_mcp.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Read-only LM Studio integration catalog for the Picoware Agent.
+
+The server intentionally returns names and integration types only. It never
+returns MCP commands, arguments, environment variables, paths, or secrets.
+It uses MCP over stdio and depends only on the Python standard library.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+SERVER_NAME = "picoware-integration-catalog"
+TOOL_NAME = "list_integrations"
+
+
+def _plugin_has_tools_provider(plugin_dir: Path) -> bool:
+    """Return whether a plugin's own source registers a tools provider.
+
+    Bundled dependencies are intentionally ignored because the LM Studio SDK
+    itself contains ``setToolsProvider`` even when the plugin never uses it.
+    """
+    source_root = plugin_dir / "src"
+    if not source_root.is_dir():
+        return False
+
+    for suffix in ("*.ts", "*.js", "*.mjs", "*.cjs"):
+        for source_path in source_root.rglob(suffix):
+            try:
+                if source_path.stat().st_size > 512 * 1024:
+                    continue
+                source = source_path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if "withToolsProvider(" in source or "setToolsProvider(" in source:
+                return True
+    return False
+
+
+def discover_integrations(home: Path | None = None) -> list[dict[str, str]]:
+    """Return stable, non-secret IDs for configured MCPs and installed plugins."""
+    base = home if home is not None else Path.home()
+    found: dict[str, dict[str, str]] = {}
+
+    mcp_path = base / ".lmstudio" / "mcp.json"
+    try:
+        config = json.loads(mcp_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        config = {}
+
+    servers = config.get("mcpServers", {}) if isinstance(config, dict) else {}
+    if isinstance(servers, dict):
+        for label in servers:
+            if not isinstance(label, str) or not label.strip():
+                continue
+            if "/" in label:
+                # LM Studio removes separators when it creates the runtime
+                # mcpBridge artifact. Its manifest below is authoritative.
+                continue
+            integration_id = "mcp/" + label.strip()
+            if integration_id == "mcp/" + SERVER_NAME:
+                continue
+            found[integration_id] = {
+                "id": integration_id,
+                "type": "mcp",
+                "label": label.strip(),
+            }
+
+    plugin_root = base / ".lmstudio" / "extensions" / "plugins"
+    for manifest_path in sorted(plugin_root.glob("*/*/manifest.json")):
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(manifest, dict):
+            continue
+        if manifest.get("runner") == "mcpBridge":
+            owner = manifest.get("owner")
+            name = manifest.get("name")
+            if not isinstance(owner, str) or not isinstance(name, str):
+                continue
+            if not owner.strip() or not name.strip():
+                continue
+            integration_id = owner.strip() + "/" + name.strip()
+            if integration_id == "mcp/" + SERVER_NAME:
+                continue
+            found[integration_id] = {
+                "id": integration_id,
+                "type": "mcp",
+                "label": name.strip(),
+            }
+            continue
+        if not _plugin_has_tools_provider(manifest_path.parent):
+            continue
+        owner = manifest.get("owner")
+        name = manifest.get("name")
+        if not isinstance(owner, str) or not isinstance(name, str):
+            continue
+        if not owner.strip() or not name.strip():
+            continue
+        runtime_id = owner.strip() + "/" + name.strip()
+        stored_id = "plugin:" + runtime_id
+        found[stored_id] = {
+            "id": stored_id,
+            "type": "plugin",
+            "label": runtime_id,
+        }
+
+    return [found[key] for key in sorted(found)]
+
+
+def _result(request_id, result: dict) -> None:
+    print(
+        json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}, separators=(",", ":")),
+        flush=True,
+    )
+
+
+def _error(request_id, code: int, message: str) -> None:
+    print(
+        json.dumps(
+            {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message}},
+            separators=(",", ":"),
+        ),
+        flush=True,
+    )
+
+
+def handle(message: dict) -> None:
+    """Handle one JSON-RPC message from LM Studio."""
+    method = message.get("method")
+    request_id = message.get("id")
+
+    if method == "initialize":
+        requested = message.get("params", {}).get("protocolVersion", "2024-11-05")
+        _result(
+            request_id,
+            {
+                "protocolVersion": requested,
+                "capabilities": {"tools": {}},
+                "serverInfo": {"name": SERVER_NAME, "version": "1.0.0"},
+            },
+        )
+    elif method == "ping":
+        _result(request_id, {})
+    elif method == "tools/list":
+        _result(
+            request_id,
+            {
+                "tools": [
+                    {
+                        "name": TOOL_NAME,
+                        "description": "List configured LM Studio MCP and plugin IDs without secrets.",
+                        "inputSchema": {"type": "object", "properties": {}, "additionalProperties": False},
+                    }
+                ]
+            },
+        )
+    elif method == "tools/call":
+        params = message.get("params", {})
+        if params.get("name") != TOOL_NAME:
+            _error(request_id, -32602, "Unknown tool")
+            return
+        payload = json.dumps(discover_integrations(), separators=(",", ":"))
+        _result(request_id, {"content": [{"type": "text", "text": payload}]})
+    elif request_id is not None:
+        _error(request_id, -32601, "Method not found")
+
+
+def main() -> int:
+    """Run the line-delimited MCP stdio loop."""
+    for line in sys.stdin:
+        try:
+            message = json.loads(line)
+        except ValueError:
+            _error(None, -32700, "Parse error")
+            continue
+        if isinstance(message, dict):
+            handle(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- add Picoware-side LM Studio MCP discovery, selection, and persistent activation state
- include the read-only, standard-library LM Studio catalog MCP used by `Scan Integrations`
- make Agent request, response, conversation, and tool handling safer for constrained SD-backed operation
- prevent repeated identical tool loops, including one-shot `network_get_info` handling
- show an animated phase and elapsed-time indicator while the Agent is working, with a visible cancel affordance
- expand validated Picoware API, network, and storage tools
- add focused simulator coverage for Agent tool loops, follow-ups, activity feedback, sessions, typing, time grounding, and SD capacity

## Why

Long-running requests previously looked frozen, and a model could repeat an identical tool call until the tool-loop guard stopped the request. This gives users visible progress and makes Agent and MCP execution bounded and recoverable.

The catalog MCP is included because it directly completes Picoware's optional `Scan Integrations` workflow. It returns integration names and types without exposing commands, arguments, environment variables, paths, or secrets. The unrelated Toolguard plugin sources remain intentionally excluded.

## Validation

- `micropython simulator/run.py --agent-check` — all 7 focused Agent checks passed
- direct catalog discovery smoke test with an empty LM Studio home — passed
- `git diff --check` — passed
