### PR TITLE
Fix Desktop C compiler allocation and repeated compilation crashes

### DIFF
--- a/simulator/run.py
+++ b/simulator/run.py
@@ -863,6 +863,12 @@ def _run_c_parity_check(opts):
             raise RuntimeError("native C engine failed to initialize")
         if engine.run("int main(){ return 0; }") != 0:
             raise RuntimeError("native C engine rejected a valid source")
+        if engine.run("int main(){ return 0; }") != 0:
+            raise RuntimeError("native C engine failed on repeated compilation")
+        if engine.run("int main(){ return ; broken syntax }") == 0:
+            raise RuntimeError("native C engine accepted invalid source")
+        if engine.run("int main(){ return 0; }") != 0:
+            raise RuntimeError("native C engine failed after invalid source")
         try:
             os.stat(sim_runtime.host_path("picoware/c/hello.c"))
         except OSError:

--- a/src/MicroPython/c/pshell/cc/cc.c
+++ b/src/MicroPython/c/pshell/cc/cc.c
@@ -48,7 +48,9 @@
 #define EXE_DBG 0
 
 // Uninitialized global data section
-#if defined(DESKTOP)
+#if defined(DESKTOP) && defined(__linux__)
+#define UDATA __attribute__((section("desktop_ccudata")))
+#elif defined(DESKTOP)
 #define UDATA
 #elif defined(PSHELL_MICROPYTHON)
 #define UDATA __attribute__((section("ccudata")))
@@ -4948,7 +4950,13 @@ int cc(int mode, int argc, char **argv)
 {
 
     // clear uninitialized global variables
-#if !defined(DESKTOP) && defined(PSHELL_MICROPYTHON)
+#if defined(DESKTOP) && defined(__linux__)
+    // Match the embedded reset: previous AST and symbol pointers were freed
+    // after compilation and must not be reused on the next invocation.
+    extern char __start_desktop_ccudata, __stop_desktop_ccudata;
+    memset(&__start_desktop_ccudata, 0,
+           &__stop_desktop_ccudata - &__start_desktop_ccudata);
+#elif !defined(DESKTOP) && defined(PSHELL_MICROPYTHON)
     extern char __start_ccudata, __stop_ccudata;
     memset(&__start_ccudata, 0, &__stop_ccudata - &__start_ccudata);
 #elif !defined(DESKTOP)

--- a/src/MicroPython/c/pshell/cc/cc_malloc.c
+++ b/src/MicroPython/c/pshell/cc/cc_malloc.c
@@ -1,6 +1,14 @@
 #include <stdarg.h>
+#include <limits.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+
+#ifdef DESKTOP
+#if defined(__linux__) && defined(__x86_64__)
+#include <sys/mman.h>
+#endif
+#endif
 
 #include "py/runtime.h"
 
@@ -10,6 +18,9 @@
 typedef struct qentry_s
 {
     struct qentry_s *next;
+#ifdef DESKTOP
+    size_t allocation_size;
+#endif
     char data[0];
 } qentry_t;
 
@@ -25,10 +36,43 @@ typedef struct qentry_s
 
 static qentry_t malloc_list UDATA; // list of allocated memory blocks
 
+#ifdef DESKTOP
+// The compiler stores AST links in signed 32-bit integers. Keep Desktop
+// allocations representable until those internal pointer fields are widened.
+static qentry_t *desktop_alloc(size_t allocation_size)
+{
+#if defined(__linux__) && defined(__x86_64__) && defined(MAP_32BIT)
+    void *memory = mmap(NULL, allocation_size, PROT_READ | PROT_WRITE,
+                        MAP_PRIVATE | MAP_ANONYMOUS | MAP_32BIT, -1, 0);
+    if (memory == MAP_FAILED)
+        return NULL;
+    if ((uintptr_t)memory > INT_MAX)
+    {
+        munmap(memory, allocation_size);
+        return NULL;
+    }
+    return memory;
+#else
+    qentry_t *memory = m_malloc(allocation_size);
+    if (memory && (uintptr_t)memory > INT_MAX)
+    {
+        m_free(memory);
+        memory = NULL;
+    }
+    return memory;
+#endif
+}
+#endif
+
 // local memory management functions
 void *cc_malloc(int l, int cc, int zero)
 {
-    qentry_t *p = m_malloc(l + sizeof(qentry_t));
+    size_t allocation_size = l + sizeof(qentry_t);
+#ifdef DESKTOP
+    qentry_t *p = desktop_alloc(allocation_size);
+#else
+    qentry_t *p = m_malloc(allocation_size);
+#endif
     if (!p)
     {
         if (cc)
@@ -36,6 +80,9 @@ void *cc_malloc(int l, int cc, int zero)
         else
             return 0;
     }
+#ifdef DESKTOP
+    p->allocation_size = allocation_size;
+#endif
     if (zero)
         memset(p->data, 0, l);
     p->next = malloc_list.next;
@@ -60,7 +107,15 @@ void cc_free(void *p, int user)
         if (p2 == p3)
         {
             last->next = p2->next;
+#ifdef DESKTOP
+#if defined(__linux__) && defined(__x86_64__) && defined(MAP_32BIT)
+            munmap(p2, p2->allocation_size);
+#else
             m_free(p2);
+#endif
+#else
+            m_free(p2);
+#endif
             return;
         }
         last = p3;
@@ -78,6 +133,14 @@ void cc_free_all(void)
     {
         qentry_t *p = malloc_list.next;
         malloc_list.next = p->next;
+#ifdef DESKTOP
+#if defined(__linux__) && defined(__x86_64__) && defined(MAP_32BIT)
+        munmap(p, p->allocation_size);
+#else
         m_free(p);
+#endif
+#else
+        m_free(p);
+#endif
     }
 }


### PR DESCRIPTION
On Linux x86-64 Desktop, compiling `int main(){ return 0; }` crashes after compiler pointers are truncated into signed 32-bit fields. Restore the earlier low-address allocator workaround, with matching unmapping, and reset Linux Desktop compiler globals between invocations so a second compilation does not reuse freed AST/symbol state. Embedded allocation and reset branches remain unchanged.

Add regression checks for repeated compilation, invalid input rejection, and successful compilation after an error. This restores compilation on the tested host; it does not add execution of generated ARM code on Desktop or make the compiler generally pointer-safe.

Validation on dev `69b30de6`, combined with the companion simulator compatibility change:
- Fresh Desktop build and full fresh-SD `--sim-check`: passed without exclusions.
- Twenty repeated compilations, invalid input, then a valid compilation: passed.
- `git diff --check`: passed.

The companion PR #278 supplies the upstream keyboard/MJS compatibility and build fixes needed for the full suite. This PR contains only the allocator, compiler reset, and C regression checks; no firmware binaries or device deployment.
