### PR TITLE
Match Flipper display geometry and text in simulator

### DIFF
--- a/guides/Simulator.md
+++ b/guides/Simulator.md
@@ -63,6 +63,25 @@ Useful board names include `picocalc-pico2w`, `waveshare-1.28-rp2350`,
 `waveshare-1.43-rp2350`, `waveshare-1.69-rp2350`, `waveshare-3.49-rp2350`,
 `crowpanel-10.1`, and `cardputer`.
 
+### Flipper keyboard preview
+
+From the repository root, launch the bundled keyboard example at the Flipper's
+128x64 resolution, enlarged for desktop viewing:
+
+```sh
+sh tools/run-micropython-desktop.sh --viewer --board flipper-zero \
+  --app keyboard-simple --scale 6 --sd /tmp/picoware-flipper-preview
+```
+
+A fresh Flipper SD directory enables the on-screen keyboard by default. Existing
+settings are preserved; if it is hidden, enable **Onscreen Keyboard** in Settings.
+Arrow keys select keys and Enter presses the selected key.
+
+Edit `src/MicroPython/picoware/gui/keyboard.py`, then press **Ctrl+R** in the viewer
+to reload the Python code. No firmware build or flashing is needed. The preview
+uses the shared keyboard layout, the default 5x8 font, and Flipper text clipping
+and monochrome colors, so spacing and clipped labels can be inspected directly.
+
 ### Game Boy controls
 
 The simulator runs Game Boy ROMs through the native Walnut-CGB helper when it

--- a/simulator/hardware/lcd.py
+++ b/simulator/hardware/lcd.py
@@ -40,6 +40,7 @@ class LCD:
     MODE_PSRAM = 1
 
     def __init__(self, scale_x=1.0, scale_y=1.0, scale_position=False):
+        self._is_flipper = False
         try:
             import picoware_boards
 
@@ -47,6 +48,7 @@ class LCD:
             self.FONT_DEFAULT = default_font_for_board(
                 picoware_boards.BOARD_ID, picoware_boards
             )
+            self._is_flipper = picoware_boards.BOARD_ID == picoware_boards.BOARD_FLIPPER_ZERO
             if self.width * self.height > 320 * 480:
                 self.width, self.height = 320, 320
         except Exception:
@@ -109,12 +111,20 @@ class LCD:
     def _offset(self, x, y):
         return (int(y) * self.width + int(x)) * 2
 
+    def _display_color(self, color):
+        color = int(color) & 0xFFFF
+        if self._is_flipper:
+            # Match color_to_mono() in Flipper/lcd/lcd.c.
+            luminance = ((color >> 11) & 31) * 299 + ((color >> 5) & 63) * 587 + (color & 31) * 114
+            return 0xFFFF if luminance > 44800 else 0
+        return color
+
     def _set_pixel(self, x, y, color):
         x = int(x)
         y = int(y)
         if 0 <= x < self.width and 0 <= y < self.height:
             off = self._offset(x, y)
-            color = int(color) & 0xFFFF
+            color = self._display_color(color) if self._is_flipper else int(color) & 0xFFFF
             self._buffer[off] = color & 0xFF
             self._buffer[off + 1] = (color >> 8) & 0xFF
 
@@ -141,7 +151,7 @@ class LCD:
         return bytes(row)
 
     def _clear(self, color=0):
-        color = int(color) & 0xFFFF
+        color = self._display_color(color)
         lo = color & 0xFF
         hi = (color >> 8) & 0xFF
         self._buffer[:] = bytes((lo, hi)) * (self.width * self.height)
@@ -174,6 +184,10 @@ class LCD:
                 y += sy
 
     def _rectangle(self, x, y, w, h, color):
+        if self._is_flipper:
+            # Flipper lcd_draw_rect() includes the border in width and height.
+            w -= 1
+            h -= 1
         self._line(x, y, x + w, y, color)
         self._line(x, y, x, y + h, color)
         self._line(x + w, y, x + w, y + h, color)
@@ -192,7 +206,7 @@ class LCD:
         y1 = min(self.height, y + h)
         if x0 >= x1 or y0 >= y1:
             return
-        color = int(color) & 0xFFFF
+        color = self._display_color(color)
         lo = color & 0xFF
         hi = (color >> 8) & 0xFF
         row = bytes((lo, hi)) * (x1 - x0)
@@ -244,8 +258,8 @@ class LCD:
         )
         if self.scale_position:
             for point in points:
-                point[0] = self.scale_x(point[0])
-                point[1] = self.scale_y(point[1])
+                point[0] = int(point[0] * self._scale_x_factor)
+                point[1] = int(point[1] * self._scale_y_factor)
 
         alpha = int(alpha) & 0xFF
         if alpha == 0:
@@ -328,6 +342,22 @@ class LCD:
         except Exception:
             pass
         w, h, spacing = self._font_metrics(font_size)
+        if self._is_flipper:
+            # Firmware uses uint16_t text coordinates and skips whole glyphs
+            # outside the display. This matters for overwide keyboard labels.
+            start_x = int(x) & 0xFFFF
+            xx, yy = start_x, int(y) & 0xFFFF
+            for code in str(text).encode():
+                if code == 0:
+                    break
+                if code == 10:
+                    xx = start_x
+                    yy = (yy + h + 2) & 0xFFFF
+                    continue
+                if 32 <= code <= 126 and xx + w <= self.width and yy + h <= self.height:
+                    self._draw_glyph(xx, yy, chr(code), color, w, h)
+                xx = (xx + w + 1) & 0xFFFF
+            return
         xx = int(x)
         yy = int(y)
         for ch in str(text):
@@ -352,10 +382,10 @@ class LCD:
 
         is_16bit = data_len >= pixel_count * 2
         scaled = self._scale_x_factor != 1.0 or self._scale_y_factor != 1.0
-        dst_x = self.scale_x(x) if scaled and self.scale_position else int(x)
-        dst_y = self.scale_y(y) if scaled and self.scale_position else int(y)
-        dst_w = self.scale_x(width) if scaled else width
-        dst_h = self.scale_y(height) if scaled else height
+        dst_x = int(x * self._scale_x_factor) if scaled and self.scale_position else int(x)
+        dst_y = int(y * self._scale_y_factor) if scaled and self.scale_position else int(y)
+        dst_w = int(width * self._scale_x_factor) if scaled else width
+        dst_h = int(height * self._scale_y_factor) if scaled else height
         if dst_w <= 0 or dst_h <= 0:
             return
 
@@ -545,19 +575,24 @@ class LCD:
         self._scale_y_factor = scale_y
         self.scale_position = scale_position
 
-    def scale_x(self, value):
-        return int(value * self._scale_x_factor)
+    def scale_x(self, value, screen_width=320):
+        """Convert a layout coordinate from the reference display width."""
+        scaled = 0.0 if value == 0 else value * self.width / float(screen_width)
+        return int(scaled) if isinstance(value, int) else scaled
 
-    def scale_y(self, value):
-        return int(value * self._scale_y_factor)
+    def scale_y(self, value, screen_height=320):
+        """Convert a layout coordinate from the reference display height."""
+        scaled = 0.0 if value == 0 else value * self.height / float(screen_height)
+        return int(scaled) if isinstance(value, int) else scaled
 
-    def scale(self, x, y):
-        return self.scale_x(x), self.scale_y(y)
+    def scale(self, x, y, screen_width=320, screen_height=320):
+        return int(self.scale_x(x, screen_width)), int(self.scale_y(y, screen_height))
 
-    def scale_vector(self, position):
-        from picoware.system.vector import Vector
-
-        return Vector(self.scale_x(position.x), self.scale_y(position.y), self.scale_y(position.z))
+    def scale_vector(self, position, screen_width=320, screen_height=320):
+        x = self.scale_x(float(position.x), screen_width)
+        y = self.scale_y(float(position.y), screen_height)
+        # The native Vector exposes its integer mode through coordinate types.
+        return (int(x), int(y)) if isinstance(position.x, int) else (x, y)
 
     def swap(self):
         self.poll_events()

--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -395,6 +395,8 @@ def seed_sd(profile="dev"):
         _write_if_missing(sd_root + "/picoware/vibesmp/library/state.json", '{}')
         if profile in ("media", "network-fixtures"):
             _write_binary_if_missing(sd_root + "/picoware/vibesmp/library/sim-tone.wav", _wav_fixture())
+    from picoware_boards import BOARD_HAS_KEYBOARD
+
     _merge_json_defaults(
         sd_root + "/picoware/settings/picoware.json",
         {
@@ -407,7 +409,7 @@ def seed_sd(profile="dev"):
             "gemini_api_key": "",
             "jblanked_api_key": "",
             "lvgl_mode": False,
-            "onscreen_keyboard": False,
+            "onscreen_keyboard": BOARD_HAS_KEYBOARD == 0,
             "openai_api_key": "",
             "local_url": "http://127.0.0.1:8080/v1/chat/completions",
             "screen_brightness": 100,

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -724,6 +724,7 @@ def _run_sim_check(opts):
             raise SystemExit(1)
     _run_keyboard_background_check()
     _run_lcd_parity_check()
+    _run_flipper_keyboard_preview_check()
     _run_uart_parity_check()
     _run_engine_parity_check()
     _run_board_parity_check()
@@ -1147,6 +1148,102 @@ def _run_lcd_parity_check():
     if blended in (0x001F, 0xF800):
         raise RuntimeError("simulator LCD alpha triangle mismatch")
     print("[sim-check:ok] lcd brightness RGB LED bytearray inversion alpha triangle")
+
+
+def _run_flipper_keyboard_preview_check():
+    """Check firmware layout scaling and the shared Flipper keyboard preview."""
+    import picoware_boards
+    import sim_runtime
+    from picoware.system import boards
+    from picoware.system.vector import Vector
+    from picoware.gui.draw import Draw
+    from picoware.gui.keyboard import Keyboard
+
+    class InputProbe:
+        has_touch_support = False
+
+    original_id = picoware_boards.BOARD_ID
+    original_shared_id = boards.BOARD_ID
+    original_headless = sim_runtime.headless
+    original_lcd = sim_runtime.get_lcd()
+    try:
+        sim_runtime.headless = True
+        for board_id, dimensions in (
+            (picoware_boards.BOARD_FLIPPER_ZERO, (128, 64)),
+            (picoware_boards.BOARD_PICOCALC_PICO_2W, (320, 320)),
+            (picoware_boards.BOARD_PANCAKE, (320, 480)),
+        ):
+            picoware_boards.BOARD_ID = boards.BOARD_ID = board_id
+            draw = Draw(scale_x=2, scale_y=3, scale_position=True)
+            width, height = dimensions
+            assert draw.scale(320, 320) == dimensions
+            assert draw.scale(22, 48) == (int(22 * width / 320), int(48 * height / 320))
+            assert draw.scale(-22, -48) == (int(-22 * width / 320), int(-48 * height / 320))
+            assert draw.scale(0, 0, 0, 0) == (0, 0)
+            assert draw.scale(64, 32, 128, 64) == (width // 2, height // 2)
+            assert isinstance(draw.scale_x(22), int)
+            assert isinstance(draw.scale_y(48.0), float)
+            assert abs(draw.scale_x(22.0) - 22 * width / 320) < 0.001
+            result = draw.scale_vector(Vector(320, 320))
+            assert result == dimensions and isinstance(result[0], int)
+            result = draw.scale_vector(Vector(64.0, 32.0), 128, 64)
+            assert isinstance(result, tuple) and isinstance(result[0], float)
+            assert result == (width / 2, height / 2)
+            # Drawing scale remains independent of layout-reference scaling.
+            draw._clear(0)
+            draw._bytearray(2, 2, 1, 1, b"\xff\xff")
+            assert draw._get_pixel(4, 6) == 0xFFFF
+            assert draw._get_pixel(5, 8) == 0xFFFF
+            assert draw._get_pixel(6, 8) == 0
+            draw._clear(0)
+            draw._fill_triangle_alpha(2, 2, 6, 2, 2, 6, 0xFFFF, 255)
+            assert draw._get_pixel(5, 7) == 0xFFFF
+            assert draw._get_pixel(2, 2) == 0
+
+        picoware_boards.BOARD_ID = boards.BOARD_ID = picoware_boards.BOARD_FLIPPER_ZERO
+        draw = Draw()
+        keyboard = Keyboard(draw, InputProbe())
+        assert keyboard._is_flipper
+        keyboard._draw_textbox()
+        keyboard._draw_keyboard()
+        # The keyboard clears from TEXTBOX_HEIGHT downwards after the textbox.
+        # Firmware rectangle borders stay inside their width/height extents.
+        left, top = int(keyboard.text_border_pos.x), int(keyboard.text_border_pos.y)
+        right = left + int(keyboard.text_border_size.x) - 1
+        bottom = top + int(keyboard.text_border_size.y) - 1
+        assert all(draw._get_pixel(x, bottom) == 0xFFFF for x in range(left, right + 1))
+        assert all(draw._get_pixel(right, y) == 0xFFFF for y in range(top, bottom + 1))
+        assert draw._get_pixel(left + 1, bottom - 1) == 0
+        # Check real pixels, not just submitted text: unscaled keys were offscreen.
+        assert any(draw._buffer[32 * draw.width * 2:])
+        for x, y in ((124, 0), (0, 57), (-1, 0)):
+            draw._clear(0)
+            draw._text(x, y, "A", 0xFFFF)
+            assert not any(draw._buffer), "Flipper must reject a clipped glyph"
+        draw._text(-3, 0, "AB", 0xFFFF)
+        wrapped = bytes(draw._buffer)
+        draw._clear(0)
+        draw._text(3, 0, "B", 0xFFFF)
+        assert bytes(draw._buffer) == wrapped and any(wrapped)
+        draw._clear(0)
+        draw._text(0, 0, "A\nB", 0xFFFF)
+        multiline = bytes(draw._buffer)
+        draw._clear(0)
+        draw._text(0, 0, "A", 0xFFFF)
+        draw._text(0, 10, "B", 0xFFFF)
+        assert bytes(draw._buffer) == multiline
+        draw._clear(0x001F)
+        assert not any(draw._buffer)
+        draw._pixel(0, 0, 0xFFFF)
+        draw._fill_rectangle(1, 0, 1, 1, 0x07E0)
+        assert draw._get_pixel(0, 0) == 0xFFFF and draw._get_pixel(1, 0) == 0
+    finally:
+        picoware_boards.BOARD_ID = original_id
+        boards.BOARD_ID = original_shared_id
+        sim_runtime.headless = original_headless
+        sim_runtime.set_lcd(original_lcd)
+        gc.collect()
+    print("[sim-check:ok] layout scaling and Flipper keyboard pixels text clipping monochrome")
 
 
 def _run_uart_parity_check():


### PR DESCRIPTION
The Flipper simulator used PicoCalc layout dimensions, placing keyboard keys outside the 128x64 display. Match firmware reference-coordinate scaling, tuple/number return types, monochrome colors, and text clipping. Keep rectangle borders inside their width/height so clearing the keyboard area does not erase the input field's bottom line.

Fresh simulator SD directories now use the firmware keyboard default for boards without a physical keyboard. Existing saved preferences are preserved. The simulator guide includes a direct Flipper keyboard preview command and Ctrl+R reload instructions.

Validation: the isolated Flipper display checks passed for layout scaling, drawing-scale independence, actual keyboard pixels, text clipping, monochrome colors, and continuous textbox borders. The current firmware font bitmap matches the simulator's default font. All four separate fixes merge cleanly and pass the combined simulator suite. No keyboard spacing or firmware source changes are included in this PR.
