### PR TITLE
Apply held simulator controls without keyboard-repeat delay

### DIFF
--- a/simulator/hardware/sim_runtime.py
+++ b/simulator/hardware/sim_runtime.py
@@ -53,6 +53,7 @@ open_target = ""
 _keys = []
 _delayed_keys = []
 _held_keys = {}
+_held_key_order = []
 _lcd = None
 _wait_view = ""
 _assert_text = ""
@@ -153,7 +154,7 @@ def configure(_root, _sd_root, _apps_source, _scale, _board, _max_frames, _headl
     global viewer, viewer_frame_path, viewer_keys_path, status_path, error_path, control_path, log_path, record_path
     global sd_profile, network_mode, bluetooth_mode, audio_mode
     global speed_mode, target_fps, _frame_interval_ms, _last_frame_ms, _viewer_key_offset, _last_status_ms, _control_offset, audio_muted
-    global frame_count, loop_count, open_target, _keys, _delayed_keys, _held_keys, _lcd
+    global frame_count, loop_count, open_target, _keys, _delayed_keys, _held_keys, _held_key_order, _lcd
     global _wait_view, _assert_text, _seen_wait_view, _seen_assert_text, _current_view_name, _recent_text
     global _recent_input, _record_text, _ir_waveform
     global _key_callback, _background_key_poll, _notifying_key
@@ -194,6 +195,7 @@ def configure(_root, _sd_root, _apps_source, _scale, _board, _max_frames, _headl
     _keys = []
     _delayed_keys = []
     _held_keys = {}
+    _held_key_order = []
     _lcd = None
     _wait_view = ""
     _assert_text = ""
@@ -833,6 +835,12 @@ def is_key_held(code):
         return False
 
 
+def held_key():
+    """Return the most recently pressed key still down, independent of repeats."""
+    poll_events()
+    return _held_key_order[-1] if _held_key_order else -1
+
+
 def enqueue_key_names(text):
     parts = text.split(",")
     for raw in parts:
@@ -1181,20 +1189,27 @@ def poll_viewer_keys():
         if line:
             parts = line.split()
             try:
+                if parts[0] == "release_all":
+                    _held_keys.clear()
+                    _held_key_order.clear()
+                    continue
                 if parts[0] == "touch" and len(parts) >= 3:
                     gesture = int(parts[3]) if len(parts) > 3 else 6
                     set_touch_point(int(parts[1]), int(parts[2]), gesture)
                     continue
                 if len(parts) >= 2 and parts[0] in ("down", "up"):
                     code = int(parts[1])
-                    repeat = len(parts) >= 3 and int(parts[2]) != 0
                     if parts[0] == "down":
+                        if code not in _held_keys:
+                            _held_key_order.append(code)
                         _held_keys[code] = True
-                        if not repeat:
-                            push_key(code)
-                            _record_key(code)
+                        # SDL repeat events drive held-key input in firmware apps.
+                        push_key(code)
+                        _record_key(code)
                     else:
                         _held_keys.pop(code, None)
+                        if code in _held_key_order:
+                            _held_key_order.remove(code)
                 else:
                     code = int(line)
                     push_key(code)

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -308,6 +308,7 @@ def _install_view_tracking():
         import sim_runtime
         from picoware.system.input import Input
         from picoware.system.view_manager import ViewManager
+        from picoware.engine.game import Game
     except Exception:
         return
 
@@ -337,6 +338,14 @@ def _install_view_tracking():
     original_switch_to = ViewManager.switch_to
     original_back = ViewManager.back
     original_remove = ViewManager.remove
+    original_game_update = Game._update
+
+    def tracked_game_update(self):
+        original_game_update(self)
+        if self.is_active and self.input == -1:
+            code = sim_runtime.held_key()
+            if code != -1:
+                self.set_input(self.input_manager._key_to_button(code))
 
     def tracked_set(self, *args, **kwargs):
         if args:
@@ -397,6 +406,7 @@ def _install_view_tracking():
     ViewManager.back = tracked_back
     ViewManager.remove = tracked_remove
     Input.button = property(tracked_input_button)
+    Game._update = tracked_game_update
     ViewManager._sim_view_tracking_installed = True
 
 

--- a/simulator/viewer/sdl_fb_viewer.c
+++ b/simulator/viewer/sdl_fb_viewer.c
@@ -468,6 +468,9 @@ int main(int argc, char **argv)
     char status_text[2048];
     char error_text[4096];
     char log_text[4096];
+    int down_codes[SDL_NUM_SCANCODES];
+    for (int i = 0; i < SDL_NUM_SCANCODES; ++i)
+        down_codes[i] = -1;
     while (running)
     {
         FILE *stop = fopen(stop_path, "rb");
@@ -485,20 +488,23 @@ int main(int argc, char **argv)
                 write_signal(quit_path, "quit");
                 running = 0;
             }
+            else if (event.type == SDL_WINDOWEVENT && event.window.event == SDL_WINDOWEVENT_FOCUS_LOST)
+            {
+                append_key_event(input_path, "release_all", 0, 0);
+                for (int i = 0; i < SDL_NUM_SCANCODES; ++i)
+                    down_codes[i] = -1;
+            }
             else if (event.type == SDL_KEYDOWN || event.type == SDL_KEYUP)
             {
                 int is_keydown = event.type == SDL_KEYDOWN;
+                SDL_Scancode scancode = event.key.keysym.scancode;
                 if (!is_keydown)
                 {
-                    int code = map_key(event.key.keysym.sym);
-                    if ((event.key.keysym.mod & KMOD_CTRL) && event.key.keysym.sym == SDLK_UP)
-                        code = 0xC2;
-                    else if ((event.key.keysym.mod & KMOD_CTRL) && event.key.keysym.sym == SDLK_DOWN)
-                        code = 0xC3;
+                    // Release the original code even if Shift/Ctrl changed first.
+                    int code = down_codes[scancode];
+                    down_codes[scancode] = -1;
                     if (code >= 0)
                     {
-                        if (event.key.keysym.mod & KMOD_SHIFT)
-                            code = apply_shift(code);
                         append_key_event(input_path, "up", code, 0);
                     }
                     continue;
@@ -562,6 +568,9 @@ int main(int argc, char **argv)
                 {
                     if (event.key.keysym.mod & KMOD_SHIFT)
                         code = apply_shift(code);
+                    if (down_codes[scancode] >= 0)
+                        code = down_codes[scancode];
+                    down_codes[scancode] = code;
                     append_key_event(input_path, "down", code, event.key.repeat ? 1 : 0);
                 }
             }


### PR DESCRIPTION
Holding a driving-game control produced one press, then paused until desktop keyboard repeat started. Read held keys on every game update so movement begins immediately and continues until release. This applies to all mapped keys.

Preserve normal repeat for text entry. Track the newest held key, resume the previous key when it is released, and clear held controls on focus loss. Record each physical key's original mapping so modifier changes do not leave keys stuck. The engine still accepts one button per update.

Validation: local-only checks passed for Up, Left, letters, Backspace, immediate updates without repeat events, release, key priority, focus loss, and legacy input. The SDL viewer builds successfully. Real-viewer tests on the combined version passed for both driving games with OS repeat disabled, modifier release, and focus loss. This PR contains implementation code only; test and documentation changes are excluded.
