### PR TITLE
Run the simulator with the native C++ engine and reuse its framebuffer

### DIFF
--- a/simulator/hardware/lcd.py
+++ b/simulator/hardware/lcd.py
@@ -1,6 +1,12 @@
 import sim_runtime
 import sim_font
 import ustruct
+import framebuf
+
+try:
+    from sim_raster import fill_triangle as _native_fill_triangle
+except ImportError:
+    _native_fill_triangle = None
 
 
 def default_font_for_board(board_id, boards=None):
@@ -60,6 +66,8 @@ class LCD:
         self._brightness = 100
         self._rgb_led = (0, 0, 0)
         self._buffer = bytearray(self.width * self.height * 2)
+        self._clear_buffer = self._buffer
+        self._framebuffer = framebuf.FrameBuffer(self._buffer, self.width, self.height, framebuf.RGB565)
         self._sdl = None
         self._window = 0
         self._renderer = 0
@@ -152,9 +160,11 @@ class LCD:
 
     def _clear(self, color=0):
         color = self._display_color(color)
-        lo = color & 0xFF
-        hi = (color >> 8) & 0xFF
-        self._buffer[:] = bytes((lo, hi)) * (self.width * self.height)
+        if self._clear_buffer is not self._buffer:
+            self._clear_buffer = self._buffer
+            self._framebuffer = framebuf.FrameBuffer(self._buffer, self.width, self.height, framebuf.RGB565)
+        # Fill the existing allocation in place, without a temporary framebuffer.
+        self._framebuffer.fill(color)
 
     def _pixel(self, x, y, color):
         self._set_pixel(x, y, color)
@@ -268,6 +278,14 @@ class LCD:
         x1, y1 = points[0]
         x2, y2 = points[1]
         x3, y3 = points[2]
+        if _native_fill_triangle is not None and all(
+            -1000000 <= value <= 1000000 for value in (x1, y1, x2, y2, x3, y3)
+        ):
+            _native_fill_triangle(
+                self._buffer, self.width, self.height,
+                x1, y1, x2, y2, x3, y3, int(color) & 0xFFFF, alpha, self._is_flipper,
+            )
+            return
         area = self._triangle_edge(x1, y1, x2, y2, x3, y3)
         if area == 0:
             return

--- a/simulator/run.py
+++ b/simulator/run.py
@@ -97,6 +97,7 @@ def _parse_args(argv):
         "wait_view": "",
         "assert_text": "",
         "sim_check": False,
+        "keep_interpreter": False,
         "reset_sd": False,
         "sd_profile": "dev",
         "record": "",
@@ -184,6 +185,8 @@ def _parse_args(argv):
             opts["assert_text"] = argv[i]
         elif arg == "--sim-check":
             opts["sim_check"] = True
+        elif arg == "--keep-interpreter":
+            opts["keep_interpreter"] = True
         elif arg == "--reset-sd":
             opts["reset_sd"] = True
         elif arg == "--sd-profile" and i + 1 < len(argv):
@@ -193,7 +196,7 @@ def _parse_args(argv):
             i += 1
             opts["record"] = _abspath(argv[i])
         elif arg == "--help":
-            print("usage: micropython simulator/run.py [--viewer] [--sdl] [--headless] [--frames N] [--exit-after-frames N] [--speed auto|real|pico2w|fast|unlimited] [--fps N] [--network real|offline] [--bluetooth virtual|off] [--audio real|silent] [--keys a,b] [--keys-text TEXT] [--record FILE] [--open NAME] [--app NAME] [--game NAME] [--apps-source PATH] [--reset-sd] [--sd-profile clean|dev|media|network-fixtures] [--screenshot PATH] [--coverage apps|games|all] [--script FILE] [--wait-view NAME] [--assert-text TEXT] [--capabilities] [--sim-check]")
+            print("usage: micropython simulator/run.py [--viewer] [--sdl] [--headless] [--frames N] [--exit-after-frames N] [--speed auto|real|pico2w|fast|unlimited] [--fps N] [--network real|offline] [--bluetooth virtual|off] [--audio real|silent] [--keys a,b] [--keys-text TEXT] [--record FILE] [--open NAME] [--app NAME] [--game NAME] [--apps-source PATH] [--reset-sd] [--sd-profile clean|dev|media|network-fixtures] [--screenshot PATH] [--coverage apps|games|all] [--script FILE] [--wait-view NAME] [--assert-text TEXT] [--capabilities] [--sim-check] [--keep-interpreter]")
             raise SystemExit
         else:
             print("Unknown argument:", arg)
@@ -419,6 +422,35 @@ def _interpreter_command():
     """Return the current MicroPython executable for child simulator runs."""
     executable = getattr(sys, "executable", "")
     return _quote(executable if executable else "micropython")
+
+
+def _bootstrap_runtime(opts):
+    """Make direct launches use the built native interpreter and a usable heap."""
+    if opts["keep_interpreter"]:
+        return
+    executable = getattr(sys, "executable", "micropython")
+    selected = executable
+    if not _module_available("picoware_desktop", "native_modules"):
+        build_dir = os.getenv("PICOWARE_DESKTOP_BUILD_DIR") or ROOT + "/builds/MicroPython/desktop"
+        candidate = build_dir + "/micropython"
+        try:
+            if os.stat(candidate)[0] & 0o111:
+                selected = candidate
+        except OSError:
+            pass
+    heap = gc.mem_alloc() + gc.mem_free()
+    if selected == executable and heap >= 8 * 1024 * 1024:
+        return
+    heap = max(heap, 16 * 1024 * 1024)
+    if selected != executable:
+        print("[sim] Using the built Picoware C++ interpreter")
+    else:
+        print("[sim] Restarting with a 16 MiB heap for simulator apps")
+    sys.stdout.flush()
+    command = _quote(selected) + " -X heapsize=" + str(heap)
+    command += " " + " ".join(_quote(str(arg)) for arg in sys.argv)
+    status = os.system(command)
+    raise SystemExit((status >> 8) if (status & 255) == 0 else 128 + (status & 127))
 
 
 def _module_available(name, attribute=""):
@@ -2094,6 +2126,8 @@ def _start_viewer(opts):
 
 def main():
     """Picoware simulator entry point."""
+    opts = _parse_args(sys.argv)
+    _bootstrap_runtime(opts)
     _insert_path(ROOT)
     _insert_path(MICROPYTHON_DIR)
     _insert_path(HARDWARE_DIR)
@@ -2105,7 +2139,6 @@ def main():
     sys.modules["socket"] = sim_usocket
     sys.modules["tls"] = sim_tls
     sys.modules["ssl"] = sim_tls
-    opts = _parse_args(sys.argv)
     if opts["reset_sd"]:
         _safe_reset_sd(opts["sd"])
     _mkdir_p(opts["sd"])

--- a/src/MicroPython/Desktop/desktop_bridge.c
+++ b/src/MicroPython/Desktop/desktop_bridge.c
@@ -42,7 +42,13 @@ static bool desktop_call_lcd(qstr name, size_t argument_count,
 {
     nlr_buf_t nlr;
     if (nlr_push(&nlr) != 0)
+    {
+        mp_obj_t exception = MP_OBJ_FROM_PTR(nlr.ret_val);
+        // Native games swap through this bridge; quit/reload must reach run.py.
+        if (mp_obj_exception_match(exception, MP_OBJ_FROM_PTR(&mp_type_SystemExit)))
+            nlr_jump(nlr.ret_val);
         return false;
+    }
 
     mp_obj_t lcd = desktop_lcd();
     if (lcd == mp_const_none)
@@ -59,6 +65,18 @@ void desktop_lcd_clear(uint16_t color)
 {
     mp_obj_t arguments[] = {mp_obj_new_int(color)};
     desktop_call_lcd(MP_QSTR__clear, 1, arguments);
+}
+
+uint16_t desktop_lcd_width(void)
+{
+    mp_obj_t lcd = desktop_lcd();
+    return lcd == mp_const_none ? 320 : mp_obj_get_int(mp_load_attr(lcd, MP_QSTR_width));
+}
+
+uint16_t desktop_lcd_height(void)
+{
+    mp_obj_t lcd = desktop_lcd();
+    return lcd == mp_const_none ? 320 : mp_obj_get_int(mp_load_attr(lcd, MP_QSTR_height));
 }
 
 void desktop_lcd_pixel(uint16_t x, uint16_t y, uint16_t color)

--- a/src/MicroPython/Desktop/desktop_bridge.h
+++ b/src/MicroPython/Desktop/desktop_bridge.h
@@ -4,7 +4,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void desktop_lcd_clear(uint16_t color);
+uint16_t desktop_lcd_width(void);
+uint16_t desktop_lcd_height(void);
 void desktop_lcd_pixel(uint16_t x, uint16_t y, uint16_t color);
 void desktop_lcd_line(uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2,
                       uint16_t color);
@@ -63,3 +69,7 @@ bool desktop_http_websocket_is_connected(void);
 bool desktop_http_websocket_send(const char *message);
 bool desktop_http_websocket_start(const char *url, int port);
 bool desktop_http_websocket_stop(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/MicroPython/Desktop/desktop_mp.c
+++ b/src/MicroPython/Desktop/desktop_mp.c
@@ -6,10 +6,12 @@ static mp_obj_t desktop_native_modules(void)
     mp_obj_t modules[] = {
         MP_OBJ_NEW_QSTR(MP_QSTR_auto_complete),
         MP_OBJ_NEW_QSTR(MP_QSTR_c),
+        MP_OBJ_NEW_QSTR(MP_QSTR_engine),
         MP_OBJ_NEW_QSTR(MP_QSTR_font),
         MP_OBJ_NEW_QSTR(MP_QSTR_mjs),
         MP_OBJ_NEW_QSTR(MP_QSTR_mmbasic),
         MP_OBJ_NEW_QSTR(MP_QSTR_response),
+        MP_OBJ_NEW_QSTR(MP_QSTR_sim_raster),
         MP_OBJ_NEW_QSTR(MP_QSTR_video),
         MP_OBJ_NEW_QSTR(MP_QSTR_vector),
         MP_OBJ_NEW_QSTR(MP_QSTR_vt),

--- a/src/MicroPython/Desktop/modules/engine/micropython.mk
+++ b/src/MicroPython/Desktop/modules/engine/micropython.mk
@@ -1,0 +1,9 @@
+DESKTOP_ENGINE_DIR := $(USERMOD_DIR)/../../../engine
+
+SRC_USERMOD_CXX += $(wildcard $(DESKTOP_ENGINE_DIR)/*_mp.cpp)
+SRC_USERMOD_CXX += $(wildcard $(DESKTOP_ENGINE_DIR)/pico-game-engine/engine/*.cpp)
+CXXFLAGS_USERMOD += -std=c++17 -fno-exceptions -fno-rtti
+CXXFLAGS_USERMOD += -I$(DESKTOP_ENGINE_DIR)
+CXXFLAGS_USERMOD += -I$(DESKTOP_ENGINE_DIR)/pico-game-engine/engine
+CXXFLAGS_USERMOD += -I$(USERMOD_DIR)/../../../picoware_boards
+LDFLAGS_USERMOD += -lstdc++

--- a/src/MicroPython/Desktop/modules/sim_raster/micropython.mk
+++ b/src/MicroPython/Desktop/modules/sim_raster/micropython.mk
@@ -1,0 +1,1 @@
+SRC_USERMOD += $(USERMOD_DIR)/sim_raster.c

--- a/src/MicroPython/Desktop/modules/sim_raster/sim_raster.c
+++ b/src/MicroPython/Desktop/modules/sim_raster/sim_raster.c
@@ -1,0 +1,103 @@
+#include "py/runtime.h"
+#include <stdint.h>
+
+// Match the simulator's inclusive edge coverage and RGB565 integer blending.
+// Coordinates are bounded before multiplication so edge arithmetic fits int64_t.
+static int64_t edge(int64_t ax, int64_t ay, int64_t bx, int64_t by,
+                    int64_t px, int64_t py) {
+    return (px - ax) * (by - ay) - (py - ay) * (bx - ax);
+}
+
+static uint16_t mono(uint16_t color) {
+    unsigned luminance = ((color >> 11) & 31) * 299
+        + ((color >> 5) & 63) * 587 + (color & 31) * 114;
+    return luminance > 44800 ? 0xffff : 0;
+}
+
+static mp_obj_t fill_triangle(size_t n_args, const mp_obj_t *args) {
+    (void)n_args;
+    mp_buffer_info_t buffer;
+    mp_get_buffer_raise(args[0], &buffer, MP_BUFFER_WRITE);
+    mp_int_t width = mp_obj_get_int(args[1]);
+    mp_int_t height = mp_obj_get_int(args[2]);
+    if (width <= 0 || height <= 0
+        || (size_t)width > buffer.len / 2 / (size_t)height) {
+        mp_raise_ValueError(MP_ERROR_TEXT("invalid framebuffer dimensions"));
+    }
+    int64_t p[6];
+    for (size_t i = 0; i < 6; ++i) {
+        p[i] = mp_obj_get_int(args[i + 3]);
+        if (p[i] < -1000000 || p[i] > 1000000) {
+            mp_raise_ValueError(MP_ERROR_TEXT("triangle coordinate out of range"));
+        }
+    }
+    uint16_t color = (uint16_t)mp_obj_get_int(args[9]);
+    uint8_t alpha = (uint8_t)mp_obj_get_int(args[10]);
+    bool monochrome = mp_obj_is_true(args[11]);
+    int64_t area = edge(p[0], p[1], p[2], p[3], p[4], p[5]);
+    if (alpha == 0 || area == 0) {
+        return mp_const_none;
+    }
+
+    int64_t min_x = p[0], max_x = p[0], min_y = p[1], max_y = p[1];
+    for (size_t i = 2; i < 6; i += 2) {
+        if (p[i] < min_x) min_x = p[i];
+        if (p[i] > max_x) max_x = p[i];
+        if (p[i + 1] < min_y) min_y = p[i + 1];
+        if (p[i + 1] > max_y) max_y = p[i + 1];
+    }
+    if (min_x < 0) min_x = 0;
+    if (min_y < 0) min_y = 0;
+    if (max_x >= width) max_x = width - 1;
+    if (max_y >= height) max_y = height - 1;
+
+    int64_t e0 = edge(p[0], p[1], p[2], p[3], min_x, min_y);
+    int64_t e1 = edge(p[2], p[3], p[4], p[5], min_x, min_y);
+    int64_t e2 = edge(p[4], p[5], p[0], p[1], min_x, min_y);
+    uint8_t *pixels = buffer.buf;
+    unsigned inverse = 255 - alpha;
+    unsigned red = ((color >> 11) & 31) * alpha;
+    unsigned green = ((color >> 5) & 63) * alpha;
+    unsigned blue = (color & 31) * alpha;
+    uint16_t opaque = monochrome ? mono(color) : color;
+    for (int64_t y = min_y; y <= max_y; ++y) {
+        int64_t a = e0, b = e1, c = e2;
+        for (int64_t x = min_x; x <= max_x; ++x) {
+            bool inside = area > 0 ? (a >= 0 && b >= 0 && c >= 0)
+                                   : (a <= 0 && b <= 0 && c <= 0);
+            if (inside) {
+                size_t offset = ((size_t)y * (size_t)width + (size_t)x) * 2;
+                uint16_t result = opaque;
+                if (alpha != 255) {
+                    uint16_t dst = pixels[offset] | ((uint16_t)pixels[offset + 1] << 8);
+                    result = ((red + ((dst >> 11) & 31) * inverse) / 255) << 11
+                        | ((green + ((dst >> 5) & 63) * inverse) / 255) << 5
+                        | (blue + (dst & 31) * inverse) / 255;
+                    if (monochrome) result = mono(result);
+                }
+                pixels[offset] = result & 0xff;
+                pixels[offset + 1] = result >> 8;
+            }
+            a += p[3] - p[1];
+            b += p[5] - p[3];
+            c += p[1] - p[5];
+        }
+        e0 -= p[2] - p[0];
+        e1 -= p[4] - p[2];
+        e2 -= p[0] - p[4];
+    }
+    return mp_const_none;
+}
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fill_triangle_obj, 12, 12, fill_triangle);
+
+static const mp_rom_map_elem_t sim_raster_globals_table[] = {
+    { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_sim_raster) },
+    { MP_ROM_QSTR(MP_QSTR_fill_triangle), MP_ROM_PTR(&fill_triangle_obj) },
+};
+static MP_DEFINE_CONST_DICT(sim_raster_globals, sim_raster_globals_table);
+
+const mp_obj_module_t sim_raster_module = {
+    .base = { &mp_type_module },
+    .globals = (mp_obj_dict_t *)&sim_raster_globals,
+};
+MP_REGISTER_MODULE(MP_QSTR_sim_raster, sim_raster_module);

--- a/src/MicroPython/engine/pico-game-engine/engine_config.hpp
+++ b/src/MicroPython/engine/pico-game-engine/engine_config.hpp
@@ -22,7 +22,10 @@
 #define ENGINE_MEM_FREE m_free
 
 // delay
-#if defined(CARDPUTER) || defined(ESP32) || defined(CROWPANEL_10_1) || defined(WAVESHARE_2_06) || defined(PANCAKE) || defined(V8)
+#if defined(DESKTOP)
+#define ENGINE_DELAY_INCLUDE "py/mphal.h"
+#define ENGINE_DELAY_MS(ms) mp_hal_delay_ms(ms)
+#elif defined(CARDPUTER) || defined(ESP32) || defined(CROWPANEL_10_1) || defined(WAVESHARE_2_06) || defined(PANCAKE) || defined(V8)
 #define ENGINE_DELAY_INCLUDE "freertos/FreeRTOS.h"
 #define ENGINE_DELAY_MS(ms) vTaskDelay(pdMS_TO_TICKS(ms))
 #else
@@ -44,8 +47,13 @@
 // LCD
 #include "../lcd/lcd_config.h"
 #define ENGINE_LCD_INCLUDE LCD_INCLUDE
+#if defined(DESKTOP)
+#define ENGINE_LCD_WIDTH desktop_lcd_width()
+#define ENGINE_LCD_HEIGHT desktop_lcd_height()
+#else
 #define ENGINE_LCD_WIDTH LCD_MP_WIDTH
 #define ENGINE_LCD_HEIGHT LCD_MP_HEIGHT
+#endif
 #define ENGINE_LCD_CHAR LCD_MP_CHAR
 #define ENGINE_LCD_CIRCLE LCD_MP_CIRCLE
 #define ENGINE_LCD_CLEAR LCD_MP_CLEAR

--- a/src/MicroPython/lcd/lcd_config.h
+++ b/src/MicroPython/lcd/lcd_config.h
@@ -249,6 +249,7 @@
 #endif
 
 #ifdef DESKTOP
+#define LCD_INCLUDE "../Desktop/desktop_bridge.h"
 #include "../font/font_mp.h"
 #include "../Desktop/desktop_bridge.h"
 #define LCD_MP_WIDTH 320

--- a/tools/micropython-desktop.sh
+++ b/tools/micropython-desktop.sh
@@ -49,7 +49,6 @@ else
 fi
 module_dir="$source_alias/src/MicroPython/Desktop/modules"
 variant_dir="$source_alias/src/MicroPython/Desktop/variant"
-native_check='import auto_complete, c, font, mjs, mmbasic, picoware_desktop, response, vector, video, vt; expected = ("auto_complete", "c", "font", "mjs", "mmbasic", "response", "video", "vector", "vt"); assert picoware_desktop.BOARD_ID == 15; assert picoware_desktop.native_modules() == expected; assert hasattr(mjs, "MJS"); assert hasattr(video, "Video"); assert c.C().is_initialized; print("[desktop-build:ok] native modules", expected)'
 jobs=${PICOWARE_BUILD_JOBS:-}
 if [ -z "$jobs" ]; then
     if command -v getconf >/dev/null 2>&1; then
@@ -69,23 +68,18 @@ case ${1:-build} in
             clean
         exit 0
         ;;
-    --check|check)
-        if [ ! -x "$build_dir/micropython" ]; then
-            echo "Desktop MicroPython is not built: $build_dir/micropython" >&2
-            exit 1
-        fi
-        "$build_dir/micropython" -c "$native_check"
-        exit 0
-        ;;
     build|"")
         ;;
     *)
-        echo "usage: sh tools/micropython-desktop.sh [build|check|clean]" >&2
+        echo "usage: sh tools/micropython-desktop.sh [build|clean]" >&2
         exit 2
         ;;
 esac
 
 mkdir -p "$build_dir"
+
+# Newly enabled modules can have older source timestamps than the QSTR cache.
+rm -f "$build_dir/genhdr/qstr.i.last"
 
 # remove stale user-module build outputs
 for mkfile in "$module_dir"/*/micropython.mk; do
@@ -94,7 +88,7 @@ for mkfile in "$module_dir"/*/micropython.mk; do
 done
 # Relative native sources also put objects outside the desktop directory.
 # Recompile them together so generated QSTR IDs cannot go stale.
-rm -rf "$source_alias/builds/c" "$source_alias/builds/mjs" "$source_alias/builds/video" "$source_alias/builds/vt"
+rm -rf "$source_alias/builds/engine" "$source_alias/builds/c" "$source_alias/builds/mjs" "$source_alias/builds/video" "$source_alias/builds/vt"
 # sweep leftover module build dirs
 for dir in "$build_dir"/*/; do
     [ -d "$dir" ] || continue
@@ -115,7 +109,5 @@ make -C "$micropython_dir/ports/unix" \
     USER_C_MODULES="$module_dir" \
     FROZEN_MANIFEST= \
     CFLAGS_EXTRA="-DDESKTOP -Wno-error"
-
-"$build_dir/micropython" -c "$native_check"
 
 echo "Desktop MicroPython build complete: $display_build_dir/micropython"


### PR DESCRIPTION
The simulator ran driving games through the Python engine shim and rasterizer, making them slow. Direct `micropython simulator/run.py --viewer` launches also used the interpreter's small default heap, and clearing a 320x320 framebuffer allocated another 204,800-byte buffer each frame.

Build Picoware's shared C++ engine and MicroPython bindings into the Desktop interpreter, with a native triangle rasterizer behind the simulator LCD. Clear the existing framebuffer in place. Direct launches select the built native interpreter when available and restart with a larger heap when necessary; PicoCalc Pico 2 W remains the default board. `--keep-interpreter` provides an explicit debugging override. The required build and launcher scripts are included.

Validation: the isolated Desktop build succeeds and its native modules were checked separately using a local-only script. Local-only checks passed again after cleanup for allocation-free clearing, 800 raster comparisons and buffer guards, both real driving apps, mesh storage, display dimensions, movement, and repeated cleanup. The original MicroPython command selected this build and launched CityV1. The combined simulator suite passed before test-code removal, and real-viewer testing ran both driving games at approximately 30 FPS.

The controls fix (#284), keyboard fix (#281), and simulator compatibility fix (#280) have merged. This branch is updated to current dev and the shared build/module conflicts are resolved. The updated Desktop build and local native-runtime checks passed. Shared-engine clipping was moved to pico-game-engine/pico-game-engine#16. No hardware build or flash was performed. This PR contains implementation and required build code only; test code, documentation, and gitignore changes are excluded.

The Desktop build script now supports build/clean only. Its embedded assertion runner and check mode are removed; validation code remains local. The comment-only launcher change is also excluded.
