### PR TITLE
Fit keyboard dialogs to device displays and rotate Waveshare 3.49

### DIFF
--- a/src/MicroPython/font/font_mp.c
+++ b/src/MicroPython/font/font_mp.c
@@ -168,7 +168,7 @@ mp_obj_t font_mp_get_character(mp_obj_t self_in, mp_obj_t size, mp_obj_t char_ob
     return mp_const_none; // Character not found or invalid font size
   }
   FontTable table = font_get_table(font_size);
-  return mp_obj_new_bytes(char_data, (table.width * table.height + 7) / 8); // Return the character bitmap as bytes
+  return mp_obj_new_bytes(char_data, ((table.width + 7) / 8) * table.height); // Return the character bitmap as bytes
 }
 static MP_DEFINE_CONST_FUN_OBJ_3(font_mp_get_character_obj, font_mp_get_character);
 
@@ -181,7 +181,7 @@ mp_obj_t font_mp_get_data(mp_obj_t self_in, mp_obj_t size)
   }
   FontSize font_size = mp_obj_get_int(size);
   FontTable table = font_get_table(font_size);
-  return mp_obj_new_bytes(table.table, (table.width * table.height + 7) / 8 * (126 - 32 + 1)); // Return the entire font data as bytes
+  return mp_obj_new_bytes(table.table, ((table.width + 7) / 8) * table.height * (126 - 32 + 1)); // Return the entire font data as bytes
 }
 static MP_DEFINE_CONST_FUN_OBJ_2(font_mp_get_data_obj, font_mp_get_data);
 

--- a/src/MicroPython/picoware/gui/keyboard.py
+++ b/src/MicroPython/picoware/gui/keyboard.py
@@ -542,7 +542,7 @@ class Keyboard:
                 self._draw_keyboard()
 
             if not self._is_flipper:
-                self._draw_text(
+                self.draw._text(
                     self.title_vec.x, self.title_vec.y,
                     self._display_title,
                     self.text_color,
@@ -604,30 +604,11 @@ class Keyboard:
             "Picoware",
         ]
 
-    def _draw_rectangle(self, x, y, width, height, color):
-        """Keep all four borders inside the cell on every LCD driver."""
-        right, bottom = x + width - 1, y + height - 1
-        self.draw._line(x, y, right, y, color)
-        self.draw._line(x, bottom, right, bottom, color)
-        self.draw._line(x, y, x, bottom, color)
-        self.draw._line(right, y, right, bottom, color)
-
-    def _draw_text(self, x, y, text, color, font_size=None):
-        """Use the measured font advance even on drivers that omit spacing."""
-        size = self.draw.font if font_size is None else font_size
-        if self._rotated:
-            self.draw._text(x, y, text, color, size)
-            return
-        font = self.draw.get_font(size)
-        for char in text:
-            self.draw._char(x, y, char, color, size)
-            x += font.width + font.spacing
-
     def _fit_text(self, text: str, width: int) -> str:
         """Keep a single line within the available pixel width."""
         text = text.replace("\n", " ").replace("\r", " ")
-        count = max(0, width // self.draw.font_size.x)
-        if len(text) <= count:
+        count = max(0, width // self.draw.len(" "))
+        if self.draw.len(text) <= width:
             return text
         return text[:max(0, count - 3)] + "." * min(3, count)
 
@@ -639,7 +620,7 @@ class Keyboard:
                 label_width = 5 * max(1, font.height // 8)
             else:
                 label_width = self.draw.len(self._key_label(row, col), self._key_font) - font.spacing
-            widths.append(max(key.width * unit, label_width + 2))
+            widths.append(max(key.width * unit, label_width + (2 if self._is_flipper else 3)))
         return widths
 
     def _build_key_rects(self) -> list:
@@ -739,12 +720,12 @@ class Keyboard:
                 x_pos, y_pos, self.size_vec.x, self.size_vec.y, bg_color
             )
 
-            # Draw key border
-            self._draw_rectangle(
+            # Leave room for drivers whose rectangle endpoints are inclusive.
+            self.draw._rectangle(
                 x_pos,
                 y_pos,
-                self.size_vec.x,
-                self.size_vec.y,
+                self.size_vec.x - 1,
+                self.size_vec.y - 1,
                 self.text_color,
             )
 
@@ -762,7 +743,7 @@ class Keyboard:
                         self.draw._fill_rectangle(x + dx * scale, y + dy * scale, scale, scale, color)
             active = self.is_caps_lock_on if caps else self.is_shift_pressed
             if active:
-                inset = 0 if self._is_flipper else 1
+                inset = 0 if self._is_flipper else 2
                 self.draw._line(
                     x_pos + inset, y_pos + height - 1 - inset,
                     x_pos + width - 1 - inset, y_pos + height - 1 - inset, color,
@@ -775,7 +756,7 @@ class Keyboard:
         key_x = x_pos + (width - label_width) // 2
         key_y = y_pos + (height - font.height) // 2
         color = self.background_color if self._is_flipper and is_selected else self.text_color
-        self._draw_text(key_x, key_y, key_label, color, self._key_font)
+        self.draw._text(key_x, key_y, key_label, color, self._key_font)
 
     def _key_label(self, row: int, col: int) -> str:
         """Return the current key label, using compact modifier icons."""
@@ -837,11 +818,11 @@ class Keyboard:
         """Draws the text box that displays the current saved response"""
         # Draw textbox border (highlight if in textbox mode)
         border_color = self.selected_color if self.is_in_textbox else self.text_color
-        self._draw_rectangle(
+        self.draw._rectangle(
             self.text_border_pos.x,
             self.text_border_pos.y,
-            self.text_border_size.x,
-            self.text_border_size.y,
+            self.text_border_size.x - (0 if self._is_flipper else 1),
+            self.text_border_size.y - (0 if self._is_flipper else 1),
             border_color,
         )
 
@@ -875,7 +856,7 @@ class Keyboard:
         _distance = self.draw.font_size.y + 1
         for i in range(start_line, len(lines)):
             self.text_vec.y = _start_y + (i - start_line) * _distance
-            self._draw_text(self.text_vec.x, self.text_vec.y, lines[i], self.text_color)
+            self.draw._text(self.text_vec.x, self.text_vec.y, lines[i], self.text_color)
 
         # Draw cursor at the current position
         # Find which line and column the cursor is on
@@ -894,7 +875,7 @@ class Keyboard:
             display_line = cursor_line - start_line
             self.cursor.x = self.text_vec.x + cursor_col * self.draw.font_size.x
             self.cursor.y = _start_y + display_line * _distance
-            self._draw_text(self.cursor.x, self.cursor.y, "_", self.text_color)
+            self.draw._text(self.cursor.x, self.cursor.y, "_", self.text_color)
 
     def _draw_suggestions(self):
         """Draws auto-complete suggestions based on keyboard visibility"""
@@ -906,7 +887,7 @@ class Keyboard:
             suggestion = suggestions[0]
             text = self._fit_text("Suggestion: " + suggestion, self._layout_width - 2 * self.KEY_MARGIN)
             x_pos = self._layout_x + (self._layout_width - self.draw.len(text)) // 2
-            self._draw_text(x_pos, self._suggestion_y, text, self.text_color)
+            self.draw._text(x_pos, self._suggestion_y, text, self.text_color)
         else:
             # Scroll the two-column list so the selected suggestion stays visible.
             line_height = self.draw.font_size.y + 4
@@ -921,7 +902,7 @@ class Keyboard:
                     self.draw._fill_rectangle(
                         x_pos - 2, y_pos - 2, column_width, line_height, self.selected_color,
                     )
-                self._draw_text(x_pos, y_pos, text, self.text_color)
+                self.draw._text(x_pos, y_pos, text, self.text_color)
 
     def _apply_suggestion(self, suggestion_text: str) -> None:
         """Apply an auto-complete suggestion to the current response.

--- a/src/MicroPython/picoware/gui/keyboard.py
+++ b/src/MicroPython/picoware/gui/keyboard.py
@@ -195,9 +195,20 @@ class Keyboard:
         """
         from picoware.system.vector import Vector
         from picoware.system.auto_complete import AutoComplete
-        from picoware.system.boards import BOARD_ID, BOARD_FLIPPER_ZERO
+        from picoware.system.boards import (
+            BOARD_ID,
+            BOARD_FLIPPER_ZERO,
+            BOARD_WAVESHARE_1_28_RP2350,
+            BOARD_WAVESHARE_1_43_RP2350,
+            BOARD_WAVESHARE_3_49_RP2350,
+        )
+
         self._is_flipper = BOARD_ID == BOARD_FLIPPER_ZERO
 
+        self._rotated = BOARD_ID == BOARD_WAVESHARE_3_49_RP2350
+        if self._rotated:
+            from picoware.gui.keyboard_rotation import KeyboardRotation
+            draw = KeyboardRotation(draw)
         self.draw = draw
         self.input_manager = input_manager
         self.text_color = text_color
@@ -225,41 +236,47 @@ class Keyboard:
         self.text_cursor_position = 0
         self.selected_suggestion_index = -1  # -1 means no suggestion selected
 
-        self.KEY_WIDTH, self.KEY_HEIGHT = draw.scale(22, 48)
-        self.KEY_MARGIN, self.TEXTBOX_HEIGHT = draw.scale(4, 45)
+        # A square inscribed in the round panel keeps every control visible.
+        self._layout_width = draw.size.x
+        self._layout_height = draw.size.y
+        if BOARD_ID in (BOARD_WAVESHARE_1_28_RP2350, BOARD_WAVESHARE_1_43_RP2350):
+            side = int(min(draw.size.x, draw.size.y) * 0.707)
+            self._layout_width = self._layout_height = side
+        self._layout_x = (draw.size.x - self._layout_width) // 2
+        self._layout_y = (draw.size.y - self._layout_height) // 2
+        self.KEY_MARGIN = 0 if self._is_flipper else 2
         self.KEY_SPACING = 1
-
         self._touch_enabled = input_manager.has_touch_support
 
-        _ten_x, _ten_y = draw.scale(10, 10)
-
-        self.max_chars_per_line = (self.draw.size.x - _ten_x) // self.draw.font_size.x
-        self.max_lines = (self.TEXTBOX_HEIGHT - _ten_y) // self.draw.font_size.y
-
-        self.max_lines = max(1, self.max_lines)
-        _min_textbox_height = (
-            _ten_y
-            + self.max_lines * self.draw.font_size.y
-            + (self.max_lines - 1) * self.KEY_SPACING
+        font_height = draw.font_size.y
+        padding = 1 if self._is_flipper else 3
+        self.max_chars_per_line = max(
+            1, (self._layout_width - 2 * (self.KEY_MARGIN + padding + 1))
+            // draw.font_size.x - 1,
         )
-        self.TEXTBOX_HEIGHT = max(self.TEXTBOX_HEIGHT, _min_textbox_height)
-
-        self.keyboard_height = self.NUM_ROWS * (self.KEY_HEIGHT + self.KEY_SPACING) + (_ten_y * 2)
+        preferred_height = self._layout_height * 45 // 320
+        self.max_lines = max(1, (preferred_height - 2 * (padding + 1)) // (font_height + 1))
+        self.TEXTBOX_HEIGHT = 2 * (padding + 1) + self.max_lines * font_height + self.max_lines - 1
+        self._text_y = self._layout_y + padding + 1
         self.size_vec = Vector(0, 0)
-        self.text_vec = Vector(draw.scale_x(5), draw.scale_y(8))
+        self.text_vec = Vector(self._layout_x + self.KEY_MARGIN + padding + 1, self._text_y)
         self.cursor = Vector(0, 0)
-
-        self.text_box_pos_vec = Vector(0, self.TEXTBOX_HEIGHT)
-        self.text_box_pos_size = Vector(self.draw.size.x, self.keyboard_height + _ten_y)
-
-        self.text_border_pos = Vector(draw.scale_x(2), draw.scale_y(2))
-        self.text_border_size = Vector(self.draw.size.x - draw.scale_x(4), self.TEXTBOX_HEIGHT - draw.scale_y(4))
-
-        self.title_vec = Vector(
-            self.draw.size.x // 2 - draw.len(self.current_title) // 2, self.TEXTBOX_HEIGHT + draw.scale_y(2)
+        self.text_border_pos = Vector(self._layout_x + self.KEY_MARGIN, self._layout_y)
+        self.text_border_size = Vector(
+            self._layout_width - 2 * self.KEY_MARGIN, self.TEXTBOX_HEIGHT,
         )
-
+        title_y = self._layout_y + self.TEXTBOX_HEIGHT + 1
+        self.title_vec = Vector(0, title_y)
+        self._keys_y = title_y + font_height + 1 if not self._is_flipper else title_y - 1
+        self._suggestion_y = self._layout_y + self._layout_height - font_height
+        self.KEY_HEIGHT = (self._suggestion_y - self._keys_y - (self.NUM_ROWS - 1)) // self.NUM_ROWS
+        self.keyboard_height = self.NUM_ROWS * self.KEY_HEIGHT + self.NUM_ROWS - 1
+        self.text_box_pos_vec = Vector(self._layout_x, self._keys_y)
+        self.text_box_pos_size = Vector(self._layout_width, self.keyboard_height)
+        self.KEY_WIDTH = max(1, self._layout_width * 22 // 320)
+        self._key_font = draw.font
         self._key_rects = self._build_key_rects()
+        self.title = self.current_title
 
         self.manual_keys = {
             BUTTON_PERIOD: ".",
@@ -416,12 +433,9 @@ class Keyboard:
         Args:
             value (str): The new title.
         """
-        from picoware.system.vector import Vector
-
         self.current_title = value
-        self.title_vec = Vector(
-            self.draw.size.x // 2 - self.draw.len(value) // 2, self.TEXTBOX_HEIGHT + self.draw.scale_y(5)
-        )
+        self._display_title = self._fit_text(value, self._layout_width - 2 * self.KEY_MARGIN)
+        self.title_vec.x = self._layout_x + (self._layout_width - self.draw.len(self._display_title)) // 2
 
     @property
     def response(self) -> str:
@@ -495,6 +509,11 @@ class Keyboard:
             return False
 
         self.dpad_input = self.input_manager.button
+        if self._rotated:
+            self.dpad_input = {
+                BUTTON_UP: BUTTON_RIGHT, BUTTON_RIGHT: BUTTON_DOWN,
+                BUTTON_DOWN: BUTTON_LEFT, BUTTON_LEFT: BUTTON_UP,
+            }.get(self.dpad_input, self.dpad_input)
         has_touch_point = (
             self._touch_enabled
             and self.input_manager.point
@@ -523,9 +542,9 @@ class Keyboard:
                 self._draw_keyboard()
 
             if not self._is_flipper:
-                self.draw._text(
+                self._draw_text(
                     self.title_vec.x, self.title_vec.y,
-                    self.current_title,
+                    self._display_title,
                     self.text_color,
                 )
 
@@ -585,48 +604,64 @@ class Keyboard:
             "Picoware",
         ]
 
+    def _draw_rectangle(self, x, y, width, height, color):
+        """Keep all four borders inside the cell on every LCD driver."""
+        right, bottom = x + width - 1, y + height - 1
+        self.draw._line(x, y, right, y, color)
+        self.draw._line(x, bottom, right, bottom, color)
+        self.draw._line(x, y, x, bottom, color)
+        self.draw._line(right, y, right, bottom, color)
+
+    def _draw_text(self, x, y, text, color, font_size=None):
+        """Use the measured font advance even on drivers that omit spacing."""
+        size = self.draw.font if font_size is None else font_size
+        if self._rotated:
+            self.draw._text(x, y, text, color, size)
+            return
+        font = self.draw.get_font(size)
+        for char in text:
+            self.draw._char(x, y, char, color, size)
+            x += font.width + font.spacing
+
+    def _fit_text(self, text: str, width: int) -> str:
+        """Keep a single line within the available pixel width."""
+        text = text.replace("\n", " ").replace("\r", " ")
+        count = max(0, width // self.draw.font_size.x)
+        if len(text) <= count:
+            return text
+        return text[:max(0, count - 3)] + "." * min(3, count)
+
+    def _key_widths(self, row: int, unit: int) -> list:
+        font = self.draw.get_font(self._key_font)
+        widths = []
+        for col, key in enumerate(self.ROWS[row]):
+            if key.normal in ("\x01", "\x02"):
+                label_width = 5 * max(1, font.height // 8)
+            else:
+                label_width = self.draw.len(self._key_label(row, col), self._key_font) - font.spacing
+            widths.append(max(key.width * unit, label_width + 2))
+        return widths
+
     def _build_key_rects(self) -> list:
-        """Set each key's (x, y, width, height) rectangle."""
-        if self._is_flipper:
-            return self._build_flipper_key_rects()
+        """Fit labels and borders inside disjoint drawing and touch rectangles."""
+        available = self._layout_width - 2 * self.KEY_MARGIN
+        while self._key_font > 0:
+            minimum = max(sum(self._key_widths(row, 1)) + self.ROW_SIZES[row] - 1 for row in range(self.NUM_ROWS))
+            if minimum <= available and self.draw.get_font(self._key_font).height + 2 <= self.KEY_HEIGHT:
+                break
+            self._key_font -= 1
+        while self.KEY_WIDTH > 1:
+            widest = max(sum(self._key_widths(row, self.KEY_WIDTH)) + self.ROW_SIZES[row] - 1 for row in range(self.NUM_ROWS))
+            if widest <= available:
+                break
+            self.KEY_WIDTH -= 1
+
         rects = []
         for row in range(self.NUM_ROWS):
-            total_row_width = 0
-            for i in range(self.ROW_SIZES[row]):
-                total_row_width += self.ROWS[row][i].width * self.KEY_WIDTH + (
-                    self.KEY_SPACING if i > 0 else 0
-                )
-            start_x = (self.draw.size.x - total_row_width) // 2
-            y = self.TEXTBOX_HEIGHT + self.draw.scale_y(13.33) + row * (
-                self.KEY_HEIGHT + self.KEY_SPACING
-            )
-
-            row_rects = []
-            x_pos = start_x
-            for col in range(self.ROW_SIZES[row]):
-                key = self.ROWS[row][col]
-                width = key.width * self.KEY_WIDTH + (key.width - 2) * self.KEY_SPACING
-                row_rects.append((x_pos - 2, y, width + 4, self.KEY_HEIGHT))
-                x_pos += key.width * self.KEY_WIDTH + self.KEY_SPACING
-            rects.append(row_rects)
-        return rects
-
-    def _build_flipper_key_rects(self) -> list:
-        """Fit action labels and center rows without overlapping key cells."""
-        rects = []
-        font_spacing = self.draw.get_font().spacing
-        for row in range(self.NUM_ROWS):
-            widths = []
-            for col in range(self.ROW_SIZES[row]):
-                key = self.ROWS[row][col]
-                label = self._key_label(row, col)
-                label_width = self.draw.len(label) - font_spacing
-                widths.append(max(key.width * self.KEY_WIDTH, label_width + 2))
+            widths = self._key_widths(row, self.KEY_WIDTH)
             row_width = sum(widths) + (len(widths) - 1) * self.KEY_SPACING
-            x = (self.draw.size.x - row_width) // 2
-            y = int(self.TEXTBOX_HEIGHT + self.draw.scale_y(13.33)) + row * (
-                self.KEY_HEIGHT + self.KEY_SPACING
-            )
+            x = self._layout_x + (self._layout_width - row_width) // 2
+            y = self._keys_y + row * (self.KEY_HEIGHT + self.KEY_SPACING)
             row_rects = []
             for width in widths:
                 row_rects.append((x, y, width, self.KEY_HEIGHT))
@@ -645,8 +680,7 @@ class Keyboard:
             tuple or None: The (row, col) of the key, or None if not on a key.
         """
         for row in range(self.NUM_ROWS):
-            # reversed: a multi-unit key is drawn over the key after it
-            for col in range(self.ROW_SIZES[row] - 1, -1, -1):
+            for col in range(self.ROW_SIZES[row]):
                 rx, ry, rw, rh = self._key_rects[row][col]
                 if rx <= x < rx + rw and ry <= y < ry + rh:
                     return row, col
@@ -658,6 +692,8 @@ class Keyboard:
         if not point or point == (0, 0):
             return False
 
+        if self._rotated:
+            point = self.draw.touch_point(point[0], point[1])
         hit = self._key_at_point(point[0], point[1])
         if hit is None:
             return False
@@ -704,7 +740,7 @@ class Keyboard:
             )
 
             # Draw key border
-            self.draw._rectangle(
+            self._draw_rectangle(
                 x_pos,
                 y_pos,
                 self.size_vec.x,
@@ -712,46 +748,39 @@ class Keyboard:
                 self.text_color,
             )
 
-        if self._is_flipper and key.normal in ("\x01", "\x02"):
-            # Printable fonts have no Shift/Caps Lock glyphs. Draw 5x7 arrows
-            # so these controls fit a single cell on the 128-pixel display.
+        if key.normal in ("\x01", "\x02"):
+            # Printable fonts have no Shift/Caps Lock glyphs.
             caps = key.normal == "\x01"
             rows = (4, 14, 31, 4, 4, 0, 31) if caps else (4, 14, 31, 4, 4, 4, 4)
-            color = self.background_color if is_selected else self.text_color
-            x = x_pos + (width - 5) // 2
-            y = y_pos + (height - 7) // 2
+            color = self.background_color if self._is_flipper and is_selected else self.text_color
+            scale = max(1, self.draw.get_font(self._key_font).height // 8)
+            x = x_pos + (width - 5 * scale) // 2
+            y = y_pos + (height - 7 * scale) // 2
             for dy, bits in enumerate(rows):
                 for dx in range(5):
                     if bits & (16 >> dx):
-                        self.draw._pixel(x + dx, y + dy, color)
+                        self.draw._fill_rectangle(x + dx * scale, y + dy * scale, scale, scale, color)
             active = self.is_caps_lock_on if caps else self.is_shift_pressed
             if active:
+                inset = 0 if self._is_flipper else 1
                 self.draw._line(
-                    x_pos, y_pos + height - 1,
-                    x_pos + width - 1, y_pos + height - 1, color,
+                    x_pos + inset, y_pos + height - 1 - inset,
+                    x_pos + width - 1 - inset, y_pos + height - 1 - inset, color,
                 )
             return
 
         key_label = self._key_label(row, col)
-        label_width = self.draw.len(key_label)
-        if self._is_flipper:
-            # Text rendering adds spacing after every glyph, including the last.
-            # Center the visible glyphs, excluding that trailing blank column.
-            label_width -= self.draw.get_font().spacing
-            _key_x = x_pos + (width - label_width) // 2
-        else:
-            _key_x = x_pos + width // 2 - label_width // 2
-        _key_y = y_pos + self.KEY_HEIGHT // 2 - self.draw.font_size.y // 2
-        if self._is_flipper:
-            text_color = self.background_color if is_selected else self.text_color
-            self.draw._text(_key_x, _key_y, key_label, text_color)
-        else:
-            self.draw._text(_key_x, _key_y, key_label, self.text_color)
+        font = self.draw.get_font(self._key_font)
+        label_width = self.draw.len(key_label, self._key_font) - font.spacing
+        key_x = x_pos + (width - label_width) // 2
+        key_y = y_pos + (height - font.height) // 2
+        color = self.background_color if self._is_flipper and is_selected else self.text_color
+        self._draw_text(key_x, key_y, key_label, color, self._key_font)
 
     def _key_label(self, row: int, col: int) -> str:
-        """Return the current key label, using one-cell modifier icons on Flipper."""
+        """Return the current key label, using compact modifier icons."""
         key = self.ROWS[row][col]
-        if self._is_flipper and key.normal in ("\x01", "\x02"):
+        if key.normal in ("\x01", "\x02"):
             return "^"  # Width placeholder for the 5-pixel modifier icon.
 
         # Determine what character to display
@@ -808,7 +837,7 @@ class Keyboard:
         """Draws the text box that displays the current saved response"""
         # Draw textbox border (highlight if in textbox mode)
         border_color = self.selected_color if self.is_in_textbox else self.text_color
-        self.draw._rectangle(
+        self._draw_rectangle(
             self.text_border_pos.x,
             self.text_border_pos.y,
             self.text_border_size.x,
@@ -835,18 +864,18 @@ class Keyboard:
                 current_line += char
             char_pos += 1
 
-        if current_line or not lines:
+        if current_line or not lines or self._response.endswith("\n"):
             lines.append(current_line)
             line_positions.append(char_pos - len(current_line))
 
         # Show only the last few lines that fit
         start_line = max(0, len(lines) - self.max_lines)
 
-        _start_y = self.draw.scale_y(8)
+        _start_y = self._text_y
         _distance = self.draw.font_size.y + 1
         for i in range(start_line, len(lines)):
             self.text_vec.y = _start_y + (i - start_line) * _distance
-            self.draw._text(self.text_vec.x, self.text_vec.y, lines[i], self.text_color)
+            self._draw_text(self.text_vec.x, self.text_vec.y, lines[i], self.text_color)
 
         # Draw cursor at the current position
         # Find which line and column the cursor is on
@@ -865,7 +894,7 @@ class Keyboard:
             display_line = cursor_line - start_line
             self.cursor.x = self.text_vec.x + cursor_col * self.draw.font_size.x
             self.cursor.y = _start_y + display_line * _distance
-            self.draw._text(self.cursor.x, self.cursor.y, "_", self.text_color)
+            self._draw_text(self.cursor.x, self.cursor.y, "_", self.text_color)
 
     def _draw_suggestions(self):
         """Draws auto-complete suggestions based on keyboard visibility"""
@@ -875,35 +904,24 @@ class Keyboard:
         if self._show_keyboard:
             # Show only one suggestion below the keyboard area
             suggestion = suggestions[0]
-            y_pos = self.TEXTBOX_HEIGHT + self.draw.scale_y(20) + self.keyboard_height + self.draw.scale_y(5)
-            text = f"Suggestion: {suggestion}"
-            x_pos = (self.draw.size.x - self.draw.len(text)) // 2
-            self.draw._text(x_pos, y_pos, text, self.text_color)
+            text = self._fit_text("Suggestion: " + suggestion, self._layout_width - 2 * self.KEY_MARGIN)
+            x_pos = self._layout_x + (self._layout_width - self.draw.len(text)) // 2
+            self._draw_text(x_pos, self._suggestion_y, text, self.text_color)
         else:
-            # Show all suggestions in 2-column list below the title
-            y_start = self.TEXTBOX_HEIGHT + self.draw.scale_y(20)
-            x_col1 = self.draw.scale_x(5)
-            x_col2 = self.draw.size.x // 2 + self.draw.scale_x(5)
-            line_height = self.draw.font_size.y * 2
-
-            for i, suggestion in enumerate(suggestions):
-                row = i // 2
-                col = i % 2
-                x_pos = x_col1 if col == 0 else x_col2
-                y_pos = y_start + row * line_height
-
-                # Highlight selected suggestion
+            # Scroll the two-column list so the selected suggestion stays visible.
+            line_height = self.draw.font_size.y + 4
+            visible_rows = max(1, (self._layout_y + self._layout_height - self._keys_y) // line_height)
+            first_row = max(0, self.selected_suggestion_index // 2 - visible_rows + 1)
+            column_width = (self._layout_width - 2 * self.KEY_MARGIN) // 2
+            for i in range(first_row * 2, min(len(suggestions), (first_row + visible_rows) * 2)):
+                x_pos = self._layout_x + self.KEY_MARGIN + (i % 2) * column_width + 2
+                y_pos = self._keys_y + (i // 2 - first_row) * line_height + 2
+                text = self._fit_text(suggestions[i], column_width - 4)
                 if i == self.selected_suggestion_index:
-                    # Draw background highlight
                     self.draw._fill_rectangle(
-                        x_pos - 2,
-                        y_pos - 2,
-                        self.draw.len(suggestion) + self.draw.scale_x(4),
-                        line_height - 2,
-                        self.selected_color,
+                        x_pos - 2, y_pos - 2, column_width, line_height, self.selected_color,
                     )
-
-                self.draw._text(x_pos, y_pos, suggestion, self.text_color)
+                self._draw_text(x_pos, y_pos, text, self.text_color)
 
     def _apply_suggestion(self, suggestion_text: str) -> None:
         """Apply an auto-complete suggestion to the current response.

--- a/src/MicroPython/picoware/gui/keyboard.py
+++ b/src/MicroPython/picoware/gui/keyboard.py
@@ -244,22 +244,23 @@ class Keyboard:
             self._layout_width = self._layout_height = side
         self._layout_x = (draw.size.x - self._layout_width) // 2
         self._layout_y = (draw.size.y - self._layout_height) // 2
-        self.KEY_MARGIN = 0 if self._is_flipper else 2
+        self.KEY_MARGIN = 0 if self._is_flipper else max(1, draw.scale_x(2))
         self.KEY_SPACING = 1
         self._touch_enabled = input_manager.has_touch_support
 
         font_height = draw.font_size.y
-        padding = 1 if self._is_flipper else 3
+        padding_x = 1 if self._is_flipper else max(1, draw.scale_x(3))
+        padding_y = 1 if self._is_flipper else max(1, draw.scale_y(3))
         self.max_chars_per_line = max(
-            1, (self._layout_width - 2 * (self.KEY_MARGIN + padding + 1))
+            1, (self._layout_width - 2 * (self.KEY_MARGIN + padding_x + 1))
             // draw.font_size.x - 1,
         )
         preferred_height = self._layout_height * 45 // 320
-        self.max_lines = max(1, (preferred_height - 2 * (padding + 1)) // (font_height + 1))
-        self.TEXTBOX_HEIGHT = 2 * (padding + 1) + self.max_lines * font_height + self.max_lines - 1
-        self._text_y = self._layout_y + padding + 1
+        self.max_lines = max(1, (preferred_height - 2 * (padding_y + 1)) // (font_height + 1))
+        self.TEXTBOX_HEIGHT = 2 * (padding_y + 1) + self.max_lines * font_height + self.max_lines - 1
+        self._text_y = self._layout_y + padding_y + 1
         self.size_vec = Vector(0, 0)
-        self.text_vec = Vector(self._layout_x + self.KEY_MARGIN + padding + 1, self._text_y)
+        self.text_vec = Vector(self._layout_x + self.KEY_MARGIN + padding_x + 1, self._text_y)
         self.cursor = Vector(0, 0)
         self.text_border_pos = Vector(self._layout_x + self.KEY_MARGIN, self._layout_y)
         self.text_border_size = Vector(
@@ -616,10 +617,7 @@ class Keyboard:
         font = self.draw.get_font(self._key_font)
         widths = []
         for col, key in enumerate(self.ROWS[row]):
-            if key.normal in ("\x01", "\x02"):
-                label_width = 5 * max(1, font.height // 8)
-            else:
-                label_width = self.draw.len(self._key_label(row, col), self._key_font) - font.spacing
+            label_width = self.draw.len(self._key_label(row, col), self._key_font) - font.spacing
             widths.append(max(key.width * unit, label_width + (2 if self._is_flipper else 3)))
         return widths
 
@@ -734,13 +732,20 @@ class Keyboard:
             caps = key.normal == "\x01"
             rows = (4, 14, 31, 4, 4, 0, 31) if caps else (4, 14, 31, 4, 4, 4, 4)
             color = self.background_color if self._is_flipper and is_selected else self.text_color
-            scale = max(1, self.draw.get_font(self._key_font).height // 8)
-            x = x_pos + (width - 5 * scale) // 2
-            y = y_pos + (height - 7 * scale) // 2
+            # Fit the 5x7 bitmap to the same glyph box as the other key labels.
+            font = self.draw.get_font(self._key_font)
+            icon_width = self.draw.len(self._key_label(row, col), self._key_font) - font.spacing
+            icon_height = font.height - 1
+            x = x_pos + (width - icon_width) // 2
+            y = y_pos + (height - icon_height) // 2
             for dy, bits in enumerate(rows):
+                top = dy * icon_height // 7
+                bottom = (dy + 1) * icon_height // 7
                 for dx in range(5):
                     if bits & (16 >> dx):
-                        self.draw._fill_rectangle(x + dx * scale, y + dy * scale, scale, scale, color)
+                        left = dx * icon_width // 5
+                        right = (dx + 1) * icon_width // 5
+                        self.draw._fill_rectangle(x + left, y + top, right - left, bottom - top, color)
             active = self.is_caps_lock_on if caps else self.is_shift_pressed
             if active:
                 inset = 0 if self._is_flipper else 2
@@ -762,7 +767,7 @@ class Keyboard:
         """Return the current key label, using compact modifier icons."""
         key = self.ROWS[row][col]
         if key.normal in ("\x01", "\x02"):
-            return "^"  # Width placeholder for the 5-pixel modifier icon.
+            return "^"  # Use one printable glyph width for the modifier icon.
 
         # Determine what character to display
         display_char = key.normal
@@ -890,17 +895,19 @@ class Keyboard:
             self.draw._text(x_pos, self._suggestion_y, text, self.text_color)
         else:
             # Scroll the two-column list so the selected suggestion stays visible.
-            line_height = self.draw.font_size.y + 4
+            padding_x = max(1, self.draw.scale_x(2))
+            padding_y = max(1, self.draw.scale_y(2))
+            line_height = self.draw.font_size.y + 2 * padding_y
             visible_rows = max(1, (self._layout_y + self._layout_height - self._keys_y) // line_height)
             first_row = max(0, self.selected_suggestion_index // 2 - visible_rows + 1)
             column_width = (self._layout_width - 2 * self.KEY_MARGIN) // 2
             for i in range(first_row * 2, min(len(suggestions), (first_row + visible_rows) * 2)):
-                x_pos = self._layout_x + self.KEY_MARGIN + (i % 2) * column_width + 2
-                y_pos = self._keys_y + (i // 2 - first_row) * line_height + 2
-                text = self._fit_text(suggestions[i], column_width - 4)
+                x_pos = self._layout_x + self.KEY_MARGIN + (i % 2) * column_width + padding_x
+                y_pos = self._keys_y + (i // 2 - first_row) * line_height + padding_y
+                text = self._fit_text(suggestions[i], column_width - 2 * padding_x)
                 if i == self.selected_suggestion_index:
                     self.draw._fill_rectangle(
-                        x_pos - 2, y_pos - 2, column_width, line_height, self.selected_color,
+                        x_pos - padding_x, y_pos - padding_y, column_width, line_height, self.selected_color,
                     )
                 self.draw._text(x_pos, y_pos, text, self.text_color)
 

--- a/src/MicroPython/picoware/gui/keyboard_rotation.py
+++ b/src/MicroPython/picoware/gui/keyboard_rotation.py
@@ -16,6 +16,14 @@ class KeyboardRotation:
     def __getattr__(self, name):
         return getattr(self._draw, name)
 
+    def scale_x(self, value, screen_width=320):
+        """Scale horizontal spacing along the rotated display width."""
+        return self._draw.scale_y(value, screen_width)
+
+    def scale_y(self, value, screen_height=320):
+        """Scale vertical spacing along the rotated display height."""
+        return self._draw.scale_x(value, screen_height)
+
     def touch_point(self, x, y):
         """Map a physical touch back into the landscape dialog."""
         return self.size.x - 1 - y, x

--- a/src/MicroPython/picoware/gui/keyboard_rotation.py
+++ b/src/MicroPython/picoware/gui/keyboard_rotation.py
@@ -1,0 +1,56 @@
+"""Drawing coordinates for a keyboard dialog rotated counterclockwise."""
+
+
+class KeyboardRotation:
+    """Rotate dialog primitives without changing the display's global state."""
+
+    def __init__(self, draw):
+        from picoware.system.vector import Vector
+        from picoware.system.font import Font
+
+        self._draw = draw
+        self.size = Vector(draw.size.y, draw.size.x)
+        self._font = Font()
+        self._tables = {}
+
+    def __getattr__(self, name):
+        return getattr(self._draw, name)
+
+    def touch_point(self, x, y):
+        """Map a physical touch back into the landscape dialog."""
+        return self.size.x - 1 - y, x
+
+    def _fill_rectangle(self, x, y, width, height, color):
+        self._draw._fill_rectangle(y, self.size.x - x - width, height, width, color)
+
+    def _line(self, x1, y1, x2, y2, color):
+        self._draw._line(y1, self.size.x - 1 - x1, y2, self.size.x - 1 - x2, color)
+
+    def _text(self, x, y, text, color, font_size=None):
+        size = self._draw.font if font_size is None else font_size
+        font = self._draw.get_font(size)
+        if size not in self._tables:
+            self._tables[size] = self._font.get_data(size)
+        data = self._tables[size]
+        row_bytes = (font.width + 7) // 8
+        start_x = x
+        for char in text:
+            if char == "\n":
+                x = start_x
+                y += font.height
+                continue
+            code = ord(char)
+            if not 32 <= code <= 126:
+                code = ord("?")
+            offset = (code - 32) * font.height * row_bytes
+            for row in range(font.height):
+                # Draw runs of set bits as vertical spans on the physical LCD.
+                run = -1
+                for col in range(font.width + 1):
+                    on = col < font.width and data[offset + row * row_bytes + col // 8] & (0x80 >> (col % 8))
+                    if on and run < 0:
+                        run = col
+                    elif not on and run >= 0:
+                        self._fill_rectangle(x + run, y + row, col - run, 1, color)
+                        run = -1
+            x += font.width + font.spacing

--- a/src/MicroPython/picoware/gui/keyboard_rotation.py
+++ b/src/MicroPython/picoware/gui/keyboard_rotation.py
@@ -23,6 +23,11 @@ class KeyboardRotation:
     def _fill_rectangle(self, x, y, width, height, color):
         self._draw._fill_rectangle(y, self.size.x - x - width, height, width, color)
 
+    def _rectangle(self, x, y, width, height, color):
+        self._draw._rectangle(
+            y, self.size.x - 1 - x - width, height, width, color,
+        )
+
     def _line(self, x1, y1, x2, y2, color):
         self._draw._line(y1, self.size.x - 1 - x1, y2, self.size.x - 1 - x2, color)
 


### PR DESCRIPTION
Keyboard labels and key borders overlapped on smaller displays, suggestions were drawn below the screen, and round displays clipped controls. Fit the text field, title, five key rows and suggestions into the available area, with measured labels and consistent drawing/touch bounds. Keep the Waveshare 1.28 and 1.43 dialogs inside their circular panels.

Rotate the Waveshare 3.49 text-entry dialog 90° counterclockwise into a 640 × 172 logical layout, including touch and directional input mapping. The rotation is local to the dialog. Correct the native font bitmap lengths to include row padding so rotated larger fonts render completely.

Validation: native simulator build passed. Combined source/simulator checks passed for all 16 profiles in stock and native MicroPython, including key bounds, label fit, round-panel key corners, title/suggestion placement and touch selection. All 475 printable glyphs matched firmware data, and rotated text pixels matched the expected transform at all five font sizes. No physical-device testing is claimed.

Automated --app keyboard-simple startup navigation has a timing failure reproduced on the unchanged baseline; dialog validation used direct rendering and input checks. The separate simulator display/font PR provides the accurate previews used for these measurements.

The diff contains keyboard.py, keyboard_rotation.py and font_mp.c only. Main menus and SimpleRPN are unchanged. Tests, screenshots, generated files and .gitignore changes are excluded.
